### PR TITLE
MTDSA-13300: Add taxYear param to hateoas links

### DIFF
--- a/app/v3/controllers/ListBsasController.scala
+++ b/app/v3/controllers/ListBsasController.scala
@@ -63,7 +63,7 @@ class ListBsasController @Inject()(val authService: EnrolmentsAuthService,
           parsedRequest <- EitherT.fromEither[Future](requestParser.parseRequest(rawData))
           response      <- EitherT(service.listBsas(parsedRequest))
         } yield {
-          val hateoasData     = ListBsasHateoasData(nino, response.responseData, None)
+          val hateoasData     = ListBsasHateoasData(nino, response.responseData, Some(parsedRequest.taxYear))
           val hateoasResponse = hateoasFactory.wrapList(response.responseData, hateoasData)
 
           logger.info(

--- a/app/v3/controllers/RetrieveForeignPropertyBsasController.scala
+++ b/app/v3/controllers/RetrieveForeignPropertyBsasController.scala
@@ -66,7 +66,8 @@ class RetrieveForeignPropertyBsasController @Inject()(
           parsedRequest <- EitherT.fromEither[Future](requestParser.parseRequest(rawData))
           response      <- EitherT(service.retrieveForeignPropertyBsas(parsedRequest))
         } yield {
-          val hateoasResponse = hateoasFactory.wrap(response.responseData, RetrieveForeignPropertyHateoasData(nino, calculationId, None))
+          val hateoasResponse =
+            hateoasFactory.wrap(response.responseData, RetrieveForeignPropertyHateoasData(nino, calculationId, parsedRequest.taxYear))
 
           logger.info(
             s"[${endpointLogContext.controllerName}][${endpointLogContext.endpointName}] - " +

--- a/app/v3/controllers/RetrieveSelfEmploymentBsasController.scala
+++ b/app/v3/controllers/RetrieveSelfEmploymentBsasController.scala
@@ -64,7 +64,7 @@ class RetrieveSelfEmploymentBsasController @Inject()(
           parsedRequest <- EitherT.fromEither[Future](requestParser.parseRequest(rawData))
           response      <- EitherT(service.retrieveSelfEmploymentBsas(parsedRequest))
         } yield {
-          val hateoasData     = RetrieveSelfAssessmentBsasHateoasData(nino, response.responseData.metadata.calculationId, None)
+          val hateoasData     = RetrieveSelfAssessmentBsasHateoasData(nino, response.responseData.metadata.calculationId, parsedRequest.taxYear)
           val hateoasResponse = hateoasFactory.wrap(response.responseData, hateoasData)
 
           logger.info(

--- a/app/v3/controllers/RetrieveUkPropertyBsasController.scala
+++ b/app/v3/controllers/RetrieveUkPropertyBsasController.scala
@@ -64,7 +64,7 @@ class RetrieveUkPropertyBsasController @Inject()(
           parsedRequest <- EitherT.fromEither[Future](requestParser.parseRequest(rawData))
           response      <- EitherT(service.retrieve(parsedRequest))
         } yield {
-          val hateoasData     = RetrieveUkPropertyHateoasData(nino, response.responseData.metadata.calculationId, None)
+          val hateoasData     = RetrieveUkPropertyHateoasData(nino, response.responseData.metadata.calculationId, parsedRequest.taxYear)
           val hateoasResponse = hateoasFactory.wrap(response.responseData, hateoasData)
 
           logger.info(

--- a/app/v3/controllers/SubmitForeignPropertyBsasController.scala
+++ b/app/v3/controllers/SubmitForeignPropertyBsasController.scala
@@ -77,7 +77,8 @@ class SubmitForeignPropertyBsasController @Inject()(val authService: EnrolmentsA
             EitherT(service.submitForeignPropertyBsas(parsedRequest))
           }
         } yield {
-          val vendorResponse = hateoasFactory.wrap(response.responseData, SubmitForeignPropertyBsasHateoasData(nino, calculationId, None))
+          val vendorResponse =
+            hateoasFactory.wrap(response.responseData, SubmitForeignPropertyBsasHateoasData(nino, calculationId, parsedRequest.taxYear))
 
           logger.info(
             s"[${endpointLogContext.controllerName}][${endpointLogContext.endpointName}] - " +

--- a/app/v3/controllers/SubmitSelfEmploymentBsasController.scala
+++ b/app/v3/controllers/SubmitSelfEmploymentBsasController.scala
@@ -74,7 +74,7 @@ class SubmitSelfEmploymentBsasController @Inject()(val authService: EnrolmentsAu
             EitherT(service.submitSelfEmploymentBsas(parsedRequest))
           }
         } yield {
-          val hateoasResponse = hateoasFactory.wrap(response.responseData, SubmitSelfEmploymentBsasHateoasData(nino, calculationId, None))
+          val hateoasResponse = hateoasFactory.wrap(response.responseData, SubmitSelfEmploymentBsasHateoasData(nino, calculationId, parsedRequest.taxYear))
 
           logger.info(
             s"[${endpointLogContext.controllerName}][${endpointLogContext.endpointName}] - " +

--- a/app/v3/controllers/SubmitUkPropertyBsasController.scala
+++ b/app/v3/controllers/SubmitUkPropertyBsasController.scala
@@ -74,7 +74,8 @@ class SubmitUkPropertyBsasController @Inject()(val authService: EnrolmentsAuthSe
             EitherT(service.submitPropertyBsas(parsedRequest))
           }
         } yield {
-          val hateoasResponse = hateoasFactory.wrap(response.responseData, SubmitUkPropertyBsasHateoasData(nino, calculationId, None))
+          val hateoasResponse =
+            hateoasFactory.wrap(response.responseData, SubmitUkPropertyBsasHateoasData(nino, calculationId, parsedRequest.taxYear))
 
           logger.info(
             s"[${endpointLogContext.controllerName}][${endpointLogContext.endpointName}] - " +

--- a/app/v3/controllers/TriggerBsasController.scala
+++ b/app/v3/controllers/TriggerBsasController.scala
@@ -68,8 +68,13 @@ class TriggerBsasController @Inject()(val authService: EnrolmentsAuthService,
           parsedRequest <- EitherT.fromEither[Future](requestParser.parseRequest(rawData))
           response      <- EitherT(triggerBsasService.triggerBsas(parsedRequest))
         } yield {
-          val hateoasData =
-            TriggerBsasHateoasData(nino, TypeOfBusiness.parser(parsedRequest.body.typeOfBusiness), response.responseData.calculationId, None)
+          val hateoasData = TriggerBsasHateoasData(
+            nino = nino,
+            typeOfBusiness = TypeOfBusiness.parser(parsedRequest.body.typeOfBusiness),
+            bsasId = response.responseData.calculationId,
+            taxYear = Some(parsedRequest.taxYear)
+          )
+
           val hateoasResponse = hateoasFactory.wrap(response.responseData, hateoasData)
 
           logger.info(

--- a/it/v3/endpoints/ListBsasControllerISpec.scala
+++ b/it/v3/endpoints/ListBsasControllerISpec.scala
@@ -114,7 +114,7 @@ class ListBsasControllerISpec extends IntegrationBaseSpec with ListBsasFixture {
 
         response.status shouldBe OK
         response.header("Content-Type") shouldBe Some("application/json")
-        response.json shouldBe summariesJSONWithHateoas(nino)
+        response.json shouldBe summariesJSONWithHateoas(nino, Some("2023-24"))
       }
 
       "valid request is made with foreign property" in new NonTysTest {
@@ -146,7 +146,7 @@ class ListBsasControllerISpec extends IntegrationBaseSpec with ListBsasFixture {
 
         response.status shouldBe OK
         response.header("Content-Type") shouldBe Some("application/json")
-        response.json shouldBe summariesJSONForeignWithHateoas(nino)
+        response.json shouldBe summariesJSONForeignWithHateoas(nino, Some("2023-24"))
       }
 
       "valid request is made without a tax year" in new NonTysTest {

--- a/it/v3/endpoints/RetrieveSelfEmploymentBsasControllerISpec.scala
+++ b/it/v3/endpoints/RetrieveSelfEmploymentBsasControllerISpec.scala
@@ -89,7 +89,7 @@ class RetrieveSelfEmploymentBsasControllerISpec extends IntegrationBaseSpec {
 
         response.status shouldBe OK
         response.header("Content-Type") shouldBe Some("application/json")
-        response.json shouldBe mtdRetrieveBsasReponseJsonWithHateoas(nino, calculationId)
+        response.json shouldBe mtdRetrieveBsasReponseJsonWithHateoasAndTaxYearParam(nino, calculationId, "2023-24")
       }
     }
 

--- a/it/v3/endpoints/RetrieveUkPropertyBsasControllerISpec.scala
+++ b/it/v3/endpoints/RetrieveUkPropertyBsasControllerISpec.scala
@@ -106,7 +106,7 @@ class RetrieveUkPropertyBsasControllerISpec extends IntegrationBaseSpec {
 
         response.status shouldBe OK
         response.header("Content-Type") shouldBe Some("application/json")
-        response.json shouldBe mtdRetrieveBsasReponseFhlJsonWithHateoas(nino, calculationId)
+        response.json shouldBe mtdRetrieveBsasReponseFhlJsonWithHateoas(nino, calculationId, taxYear)
       }
 
       "any valid Tax Year Specific request is made and Non-FHL is returned" in new TysIfsTest {
@@ -119,7 +119,7 @@ class RetrieveUkPropertyBsasControllerISpec extends IntegrationBaseSpec {
 
         response.status shouldBe OK
         response.header("Content-Type") shouldBe Some("application/json")
-        response.json shouldBe mtdRetrieveBsasReponseNonFhlJsonWithHateoas(nino, calculationId)
+        response.json shouldBe mtdRetrieveBsasReponseNonFhlJsonWithHateoas(nino, calculationId, taxYear)
       }
     }
 

--- a/it/v3/endpoints/SubmitForeignPropertyBsasControllerISpec.scala
+++ b/it/v3/endpoints/SubmitForeignPropertyBsasControllerISpec.scala
@@ -33,6 +33,7 @@ class SubmitForeignPropertyBsasControllerISpec extends IntegrationBaseSpec {
     val nino: String            = "AA123456A"
     val calculationId: String   = "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4"
     def taxYear: Option[String] = None
+    def retrieveHateoasLink: String
 
     // Downstream returns the adjustments and adjusted calculation - we ignore whatever we get back...
     val ignoredDownstreamResponse: JsValue = Json.parse("""{"ignored": "doesn't matter"}""")
@@ -51,7 +52,7 @@ class SubmitForeignPropertyBsasControllerISpec extends IntegrationBaseSpec {
          |{
          |  "links":[
          |    {
-         |      "href":"/individuals/self-assessment/adjustable-summary/$nino/foreign-property/$calculationId",
+         |      "href":"$retrieveHateoasLink",
          |      "rel":"self",
          |      "method":"GET"
          |    }
@@ -97,13 +98,15 @@ class SubmitForeignPropertyBsasControllerISpec extends IntegrationBaseSpec {
   }
 
   private trait NonTysTest extends Test {
-    def downstreamUrl: String = s"/income-tax/adjustable-summary-calculation/$nino/$calculationId"
+    def downstreamUrl: String       = s"/income-tax/adjustable-summary-calculation/$nino/$calculationId"
+    def retrieveHateoasLink: String = s"/individuals/self-assessment/adjustable-summary/$nino/foreign-property/$calculationId"
   }
 
   private trait TysIfsTest extends Test {
     override def taxYear: Option[String] = Some("2023-24")
 
-    def downstreamUrl: String = s"/income-tax/adjustable-summary-calculation/23-24/$nino/$calculationId"
+    def downstreamUrl: String       = s"/income-tax/adjustable-summary-calculation/23-24/$nino/$calculationId"
+    def retrieveHateoasLink: String = s"/individuals/self-assessment/adjustable-summary/$nino/foreign-property/$calculationId?taxYear=2023-24"
   }
 
   "Calling the submit foreign property bsas endpoint" should {

--- a/it/v3/endpoints/SubmitSelfEmploymentBsasControllerISpec.scala
+++ b/it/v3/endpoints/SubmitSelfEmploymentBsasControllerISpec.scala
@@ -19,11 +19,10 @@ package v3.endpoints
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.http.HeaderNames.ACCEPT
 import play.api.http.Status._
-import play.api.libs.json.{ Json, JsValue }
+import play.api.libs.json.{ JsValue, Json }
 import play.api.libs.ws.{ WSRequest, WSResponse }
 import play.api.test.Helpers.AUTHORIZATION
 import support.IntegrationBaseSpec
-import v3.fixtures.selfEmployment.SubmitSelfEmploymentBsasFixtures.mtdRequest
 import v3.models.errors._
 import v3.stubs._
 
@@ -114,7 +113,7 @@ class SubmitSelfEmploymentBsasControllerISpec extends IntegrationBaseSpec {
 
         val result: WSResponse = await(request().post(requestBody))
         result.status shouldBe OK
-        result.json shouldBe Json.parse(hateoasResponse(nino, calculationId))
+        result.json shouldBe Json.parse(hateoasResponseWithTaxYear(nino, calculationId, "2023-24"))
         result.header("Content-Type") shouldBe Some("application/json")
       }
 
@@ -146,7 +145,7 @@ class SubmitSelfEmploymentBsasControllerISpec extends IntegrationBaseSpec {
 
         val result: WSResponse = await(request().post(requestBody))
         result.status shouldBe OK
-        result.json shouldBe Json.parse(hateoasResponse(nino, calculationId))
+        result.json shouldBe Json.parse(hateoasResponseWithTaxYear(nino, calculationId, "2023-24"))
         result.header("Content-Type") shouldBe Some("application/json")
       }
     }

--- a/it/v3/endpoints/SubmitUkPropertyBsasControllerISpec.scala
+++ b/it/v3/endpoints/SubmitUkPropertyBsasControllerISpec.scala
@@ -22,10 +22,10 @@ import play.api.libs.json._
 import play.api.libs.ws.{ WSRequest, WSResponse }
 import play.api.test.Helpers.AUTHORIZATION
 import support.IntegrationBaseSpec
+import v3.fixtures.ukProperty.SubmitUKPropertyBsasRequestBodyFixtures._
 import v3.models.errors._
 import v3.models.utils.JsonErrorValidators
-import v3.stubs.{ AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub, NrsStub }
-import v3.fixtures.ukProperty.SubmitUKPropertyBsasRequestBodyFixtures._
+import v3.stubs._
 
 class SubmitUkPropertyBsasControllerISpec extends IntegrationBaseSpec with JsonErrorValidators {
 
@@ -55,7 +55,7 @@ class SubmitUkPropertyBsasControllerISpec extends IntegrationBaseSpec with JsonE
 
         val response: WSResponse = await(request().post(requestBodyJson))
         response.status shouldBe OK
-        response.json shouldBe Json.parse(hateoasResponse(nino, calculationId))
+        response.json shouldBe Json.parse(hateoasResponseWithTaxYearParam(nino, calculationId, "2023-24"))
         response.header("Content-Type") shouldBe Some("application/json")
       }
 

--- a/it/v3/endpoints/TriggerBsasControllerISpec.scala
+++ b/it/v3/endpoints/TriggerBsasControllerISpec.scala
@@ -33,13 +33,14 @@ class TriggerBsasControllerISpec extends IntegrationBaseSpec {
 
     val nino = "AA123456A"
 
-    def taxYear: String
+    def mtdTaxYear: String
     def downstreamTaxYear: String
 
     def uri: String = s"/$nino/trigger"
     def downstreamUri: String
 
     def setupStubs(): StubMapping
+    def triggerHateoasLink(hateoasLinkPath: String): String
 
     def request(): WSRequest = {
       setupStubs()
@@ -81,7 +82,7 @@ class TriggerBsasControllerISpec extends IntegrationBaseSpec {
       |  "calculationId": "c75f40a6-a3df-4429-a697-471eeec46435",
       |  "links":[
       |    {
-      |      "href":"/individuals/self-assessment/adjustable-summary/$nino/$hateoasLinkPath/c75f40a6-a3df-4429-a697-471eeec46435",
+      |      "href":"${triggerHateoasLink(hateoasLinkPath)}",
       |      "rel":"self",
       |      "method":"GET"
       |    }
@@ -91,15 +92,21 @@ class TriggerBsasControllerISpec extends IntegrationBaseSpec {
   }
 
   private trait NonTysTest extends Test {
-    def taxYear: String                = "2019-20"
+    def mtdTaxYear: String             = "2019-20"
     def downstreamTaxYear: String      = "2020"
     override def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/$nino"
+
+    def triggerHateoasLink(hateoasLinkPath: String): String =
+      s"/individuals/self-assessment/adjustable-summary/$nino/$hateoasLinkPath/c75f40a6-a3df-4429-a697-471eeec46435"
   }
 
   private trait TysIfsTest extends Test {
-    def taxYear: String                = "2023-24"
+    def mtdTaxYear: String             = "2023-24"
     def downstreamTaxYear: String      = "23-24"
     override def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/23-24/$nino"
+
+    def triggerHateoasLink(hateoasLinkPath: String): String =
+      s"/individuals/self-assessment/adjustable-summary/$nino/$hateoasLinkPath/c75f40a6-a3df-4429-a697-471eeec46435?taxYear=$mtdTaxYear"
   }
 
   "Calling the triggerBsas" should {

--- a/test/v3/controllers/ListBsasControllerSpec.scala
+++ b/test/v3/controllers/ListBsasControllerSpec.scala
@@ -161,7 +161,7 @@ class ListBsasControllerSpec
         )
 
         MockHateoasFactory
-          .wrapList(response, ListBsasHateoasData(nino, response, None))
+          .wrapList(response, ListBsasHateoasData(nino, response, Some(requestData.taxYear)))
           .returns(responseWithHateoas)
 
         val result: Future[Result] = controller.listBsas(nino, taxYear, typeOfBusiness, businessId)(fakeGetRequest)

--- a/test/v3/controllers/RetrieveForeignPropertyBsasControllerSpec.scala
+++ b/test/v3/controllers/RetrieveForeignPropertyBsasControllerSpec.scala
@@ -49,8 +49,8 @@ class RetrieveForeignPropertyBsasControllerSpec
   private val nino   = "AA123456A"
   private val calcId = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c"
 
-  private val request        = RetrieveForeignPropertyBsasRequestData(Nino(nino), calcId, taxYear=None)
-  private val requestRawData = RetrieveForeignPropertyBsasRawData(nino, calcId, taxYear=None)
+  private val request        = RetrieveForeignPropertyBsasRequestData(Nino(nino), calcId, taxYear = None)
+  private val requestRawData = RetrieveForeignPropertyBsasRawData(nino, calcId, taxYear = None)
 
   private val testHateoasLinks =
     Seq(Link(href = "/some/link", method = GET, rel = "someRel"))
@@ -91,7 +91,7 @@ class RetrieveForeignPropertyBsasControllerSpec
           .wrap(retrieveForeignPropertyBsasResponseNonFhlModel, RetrieveForeignPropertyHateoasData(nino, calcId, None)) returns
           HateoasWrapper(retrieveForeignPropertyBsasResponseNonFhlModel, testHateoasLinks)
 
-        val result: Future[Result] = controller.retrieve(nino, calcId, taxYear=None)(fakeGetRequest)
+        val result: Future[Result] = controller.retrieve(nino, calcId, taxYear = None)(fakeGetRequest)
 
         contentAsJson(result) shouldBe hateoasResponse
         status(result) shouldBe OK
@@ -105,7 +105,7 @@ class RetrieveForeignPropertyBsasControllerSpec
           s"a ${error.code} error is returned from the parser" in new Test {
             MockRetrieveForeignPropertyRequestParser.parse(requestRawData) returns Left(ErrorWrapper(correlationId, error, None))
 
-            val result: Future[Result] = controller.retrieve(nino, calcId, taxYear=None)(fakeGetRequest)
+            val result: Future[Result] = controller.retrieve(nino, calcId, taxYear = None)(fakeGetRequest)
 
             contentAsJson(result) shouldBe Json.toJson(error)
             status(result) shouldBe expectedStatus
@@ -132,7 +132,7 @@ class RetrieveForeignPropertyBsasControllerSpec
 
             MockRetrieveForeignPropertyBsasService.retrieveBsas(request) returns Future.successful(Left(ErrorWrapper(correlationId, mtdError)))
 
-            val result: Future[Result] = controller.retrieve(nino, calcId, taxYear=None)(fakeGetRequest)
+            val result: Future[Result] = controller.retrieve(nino, calcId, taxYear = None)(fakeGetRequest)
 
             contentAsJson(result) shouldBe Json.toJson(mtdError)
             status(result) shouldBe expectedStatus

--- a/test/v3/controllers/SubmitForeignPropertyBsasControllerSpec.scala
+++ b/test/v3/controllers/SubmitForeignPropertyBsasControllerSpec.scala
@@ -173,7 +173,7 @@ class SubmitForeignPropertyBsasControllerSpec
           .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
 
         MockHateoasFactory
-          .wrap((), SubmitForeignPropertyBsasHateoasData(nino, bsasId, None))
+          .wrap((), SubmitForeignPropertyBsasHateoasData(nino, bsasId, requestData.taxYear))
           .returns(HateoasWrapper((), Seq(testHateoasLink)))
 
         val result: Future[Result] = controller.handleRequest(nino, bsasId, Some(rawTaxYear))(fakePostRequest(requestJson))

--- a/test/v3/controllers/SubmitSelfEmploymentBsasControllerSpec.scala
+++ b/test/v3/controllers/SubmitSelfEmploymentBsasControllerSpec.scala
@@ -120,7 +120,7 @@ class SubmitSelfEmploymentBsasControllerSpec
           .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
 
         MockHateoasFactory
-          .wrap((), SubmitSelfEmploymentBsasHateoasData(nino, calculationId, None))
+          .wrap((), SubmitSelfEmploymentBsasHateoasData(nino, calculationId, request.taxYear))
           .returns(HateoasWrapper((), testHateoasLinks))
 
         val result: Future[Result] = controller.submitSelfEmploymentBsas(nino, calculationId, None)(fakePostRequest(Json.toJson(mtdRequest)))

--- a/test/v3/controllers/SubmitUkPropertyBsasControllerSpec.scala
+++ b/test/v3/controllers/SubmitUkPropertyBsasControllerSpec.scala
@@ -132,7 +132,7 @@ class SubmitUkPropertyBsasControllerSpec
           .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
 
         MockHateoasFactory
-          .wrap((), SubmitUkPropertyBsasHateoasData(nino, calculationId, None))
+          .wrap((), SubmitUkPropertyBsasHateoasData(nino, calculationId, Some(taxYear)))
           .returns(HateoasWrapper((), testHateoasLinks))
 
         val result: Future[Result] = controller.handleRequest(nino, calculationId, Some(rawTaxYear))(fakePostRequest(validNonFHLInputJson))

--- a/test/v3/fixtures/ListBsasFixture.scala
+++ b/test/v3/fixtures/ListBsasFixture.scala
@@ -258,7 +258,7 @@ trait ListBsasFixture {
   )
 
   def summariesJSONWithHateoas(nino: String, taxYear: Option[String] = None): JsValue = {
-    val taxYearParam = taxYear.fold("")(ty => s"?taxYear=$ty")
+    val taxYearParam = taxYear.fold("")("?taxYear=" + _)
 
     Json.parse(
       s"""
@@ -355,7 +355,7 @@ trait ListBsasFixture {
   }
 
   def summariesJSONForeignWithHateoas(nino: String, taxYear: Option[String] = None): JsValue = {
-    val taxYearParam = taxYear.fold("")(ty => s"?taxYear=$ty")
+    val taxYearParam = taxYear.fold("")("?taxYear=" + _)
 
     Json.parse(
       s"""

--- a/test/v3/fixtures/ListBsasFixture.scala
+++ b/test/v3/fixtures/ListBsasFixture.scala
@@ -257,7 +257,9 @@ trait ListBsasFixture {
     """.stripMargin
   )
 
-  val summariesJSONWithHateoas: String => JsValue = nino =>
+  def summariesJSONWithHateoas(nino: String, taxYear: Option[String] = None): JsValue = {
+    val taxYearParam = taxYear.fold("")(ty => s"?taxYear=$ty")
+
     Json.parse(
       s"""
       |{
@@ -278,7 +280,7 @@ trait ListBsasFixture {
       |          "adjustedSummary": false,
       |          "links": [
       |            {
-      |              "href": "/individuals/self-assessment/adjustable-summary/$nino/self-employment/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+      |              "href": "/individuals/self-assessment/adjustable-summary/$nino/self-employment/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4$taxYearParam",
       |              "method": "GET",
       |              "rel": "self"
       |            }
@@ -302,7 +304,7 @@ trait ListBsasFixture {
       |          "adjustedSummary": false,
       |          "links": [
       |            {
-      |              "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce5",
+      |              "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce5$taxYearParam",
       |              "method": "GET",
       |              "rel": "self"
       |            }
@@ -326,7 +328,7 @@ trait ListBsasFixture {
       |          "adjustedSummary": false,
       |          "links": [
       |            {
-      |              "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce6",
+      |              "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce6$taxYearParam",
       |              "method": "GET",
       |              "rel": "self"
       |            }
@@ -342,16 +344,19 @@ trait ListBsasFixture {
       |      "rel": "trigger-business-source-adjustable-summary"
       |    },
       |    {
-      |      "href": "/individuals/self-assessment/adjustable-summary/$nino",
+      |      "href": "/individuals/self-assessment/adjustable-summary/$nino$taxYearParam",
       |      "method": "GET",
       |      "rel": "self"
       |    }
       |  ]
       |}
     """.stripMargin
-  )
+    )
+  }
 
-  val summariesJSONForeignWithHateoas: String => JsValue = nino =>
+  def summariesJSONForeignWithHateoas(nino: String, taxYear: Option[String] = None): JsValue = {
+    val taxYearParam = taxYear.fold("")(ty => s"?taxYear=$ty")
+
     Json.parse(
       s"""
        |{
@@ -372,7 +377,7 @@ trait ListBsasFixture {
        |          "adjustedSummary": false,
        |          "links": [
        |            {
-       |              "href": "/individuals/self-assessment/adjustable-summary/$nino/foreign-property/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+       |              "href": "/individuals/self-assessment/adjustable-summary/$nino/foreign-property/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4$taxYearParam",
        |              "method": "GET",
        |              "rel": "self"
        |            }
@@ -388,14 +393,15 @@ trait ListBsasFixture {
        |      "rel": "trigger-business-source-adjustable-summary"
        |    },
        |    {
-       |      "href": "/individuals/self-assessment/adjustable-summary/$nino",
+       |      "href": "/individuals/self-assessment/adjustable-summary/$nino$taxYearParam",
        |      "method": "GET",
        |      "rel": "self"
        |    }
        |  ]
        |}
     """.stripMargin
-  )
+    )
+  }
 
   val listBsasDownstreamJsonMultiple: JsArray = JsArray(
     Seq(

--- a/test/v3/fixtures/selfEmployment/RetrieveSelfEmploymentBsasFixtures.scala
+++ b/test/v3/fixtures/selfEmployment/RetrieveSelfEmploymentBsasFixtures.scala
@@ -16,13 +16,13 @@
 
 package v3.fixtures.selfEmployment
 
-import play.api.libs.json.{JsObject, JsValue, Json}
-import v3.models.domain.{IncomeSourceType, Source, Status, TypeOfBusiness}
+import play.api.libs.json.{ JsObject, JsValue, Json }
+import v3.models.domain.{ IncomeSourceType, Source, Status, TypeOfBusiness }
 import v3.models.response.retrieveBsas.selfEmployment._
 
 object RetrieveSelfEmploymentBsasFixtures {
 
-  private val now = "2019-04-06"
+  private val now          = "2019-04-06"
   private val aYearFromNow = "2020-04-05"
 
   val downstreamMetadataJson: JsValue = Json.parse(
@@ -277,8 +277,7 @@ object RetrieveSelfEmploymentBsasFixtures {
       |""".stripMargin
   )
 
-  val downstreamRetrieveBsasResponseJson: JsValue = Json.parse(
-    s"""
+  val downstreamRetrieveBsasResponseJson: JsValue = Json.parse(s"""
        |{
        |  "metadata": $downstreamMetadataJson,
        |  "inputs": $downstreamInputsJson,
@@ -288,8 +287,7 @@ object RetrieveSelfEmploymentBsasFixtures {
        |}
        |""".stripMargin)
 
-  def downstreamRetrieveBsasResponseJsonInvalidIncomeSourceType(incomeSourceType: IncomeSourceType): JsValue = Json.parse(
-    s"""
+  def downstreamRetrieveBsasResponseJsonInvalidIncomeSourceType(incomeSourceType: IncomeSourceType): JsValue = Json.parse(s"""
        |{
        |  "metadata": $downstreamMetadataJson,
        |  "inputs": ${downstreamInputsInvalidIncomeSourceTypeJson(incomeSourceType)},
@@ -535,8 +533,8 @@ object RetrieveSelfEmploymentBsasFixtures {
        |""".stripMargin
   )
 
-  def mtdRetrieveBsasReponseJsonWithHateoas(nino: String, calculationId: String): JsValue = mtdRetrieveBsasResponseJson.as[JsObject] ++ Json.parse(
-    s"""
+  def mtdRetrieveBsasReponseJsonWithHateoas(nino: String, calculationId: String): JsValue =
+    mtdRetrieveBsasResponseJson.as[JsObject] ++ Json.parse(s"""
       |{
       |  "links": [
       |    {
@@ -552,6 +550,23 @@ object RetrieveSelfEmploymentBsasFixtures {
       |}
       |""".stripMargin).as[JsObject]
 
+  def mtdRetrieveBsasReponseJsonWithHateoasAndTaxYearParam(nino: String, calculationId: String, taxYear: String): JsValue =
+    mtdRetrieveBsasResponseJson.as[JsObject] ++ Json.parse(s"""
+       |{
+       |  "links": [
+       |    {
+       |      "href": "/individuals/self-assessment/adjustable-summary/$nino/self-employment/$calculationId?taxYear=2023-24",
+       |      "method": "GET",
+       |      "rel": "self"
+       |    }, {
+       |      "href": "/individuals/self-assessment/adjustable-summary/$nino/self-employment/$calculationId/adjust?taxYear=2023-24",
+       |      "method": "POST",
+       |      "rel": "submit-self-employment-accounting-adjustments"
+       |    }
+       |  ]
+       |}
+       |""".stripMargin).as[JsObject]
+
   val metadataModel: Metadata = Metadata(
     calculationId = "03e3bc8b-910d-4f5b-88d7-b627c84f2ed7",
     requestedDateTime = "2000-01-01T10:12:10Z",
@@ -560,7 +575,7 @@ object RetrieveSelfEmploymentBsasFixtures {
     taxYear = "2020-21",
     summaryStatus = Status.`valid`
   )
-  
+
   val submissionPeriodWithPeriodIdModel: SubmissionPeriod = SubmissionPeriod(
     periodId = Some("1234567890123456"),
     submissionId = None,
@@ -593,22 +608,22 @@ object RetrieveSelfEmploymentBsasFixtures {
   )
 
   val summaryCalculationExpensesModel: SummaryCalculationExpenses = SummaryCalculationExpenses(
-      consolidatedExpenses = Some(2.01),
-      costOfGoodsAllowable = Some(2.02),
-      paymentsToSubcontractorsAllowable = Some(2.03),
-      wagesAndStaffCostsAllowable = Some(2.04),
-      carVanTravelExpensesAllowable = Some(2.05),
-      premisesRunningCostsAllowable = Some(2.06),
-      maintenanceCostsAllowable = Some(2.07),
-      adminCostsAllowable = Some(2.08),
-      interestOnBankOtherLoansAllowable = Some(2.09),
-      financeChargesAllowable = Some(2.10),
-      irrecoverableDebtsAllowable = Some(2.11),
-      professionalFeesAllowable = Some(2.12),
-      depreciationAllowable = Some(2.13),
-      otherExpensesAllowable = Some(2.14),
-      advertisingCostsAllowable = Some(2.15),
-      businessEntertainmentCostsAllowable = Some(2.16)
+    consolidatedExpenses = Some(2.01),
+    costOfGoodsAllowable = Some(2.02),
+    paymentsToSubcontractorsAllowable = Some(2.03),
+    wagesAndStaffCostsAllowable = Some(2.04),
+    carVanTravelExpensesAllowable = Some(2.05),
+    premisesRunningCostsAllowable = Some(2.06),
+    maintenanceCostsAllowable = Some(2.07),
+    adminCostsAllowable = Some(2.08),
+    interestOnBankOtherLoansAllowable = Some(2.09),
+    financeChargesAllowable = Some(2.10),
+    irrecoverableDebtsAllowable = Some(2.11),
+    professionalFeesAllowable = Some(2.12),
+    depreciationAllowable = Some(2.13),
+    otherExpensesAllowable = Some(2.14),
+    advertisingCostsAllowable = Some(2.15),
+    businessEntertainmentCostsAllowable = Some(2.16)
   )
 
   val summaryCalculationAdditionsModel: SummaryCalculationAdditions = SummaryCalculationAdditions(
@@ -651,10 +666,10 @@ object RetrieveSelfEmploymentBsasFixtures {
   )
 
   val summaryCalculationAccountingAdjustmentsModel: SummaryCalculationAccountingAdjustments = SummaryCalculationAccountingAdjustments(
-      basisAdjustment = Some(7.01),
-      overlapReliefUsed = Some(7.02),
-      accountingAdjustment = Some(7.03),
-      averagingAdjustment = Some(7.04)
+    basisAdjustment = Some(7.01),
+    overlapReliefUsed = Some(7.02),
+    accountingAdjustment = Some(7.03),
+    averagingAdjustment = Some(7.04)
   )
 
   val adjustableSummaryCalculationModel: AdjustableSummaryCalculation = AdjustableSummaryCalculation(
@@ -680,40 +695,40 @@ object RetrieveSelfEmploymentBsasFixtures {
   )
 
   val adjustmentsExpensesModel: AdjustmentsExpenses = AdjustmentsExpenses(
-      consolidatedExpenses = Some(2.01),
-      costOfGoodsAllowable = Some(2.02),
-      paymentsToSubcontractorsAllowable = Some(2.03),
-      wagesAndStaffCostsAllowable = Some(2.04),
-      carVanTravelExpensesAllowable = Some(2.05),
-      premisesRunningCostsAllowable = Some(2.06),
-      maintenanceCostsAllowable = Some(2.07),
-      adminCostsAllowable = Some(2.08),
-      interestOnBankOtherLoansAllowable = Some(2.09),
-      financeChargesAllowable = Some(2.10),
-      irrecoverableDebtsAllowable = Some(2.11),
-      professionalFeesAllowable = Some(2.12),
-      depreciationAllowable = Some(2.13),
-      otherExpensesAllowable = Some(2.14),
-      advertisingCostsAllowable = Some(2.15),
-      businessEntertainmentCostsAllowable = Some(2.16)
+    consolidatedExpenses = Some(2.01),
+    costOfGoodsAllowable = Some(2.02),
+    paymentsToSubcontractorsAllowable = Some(2.03),
+    wagesAndStaffCostsAllowable = Some(2.04),
+    carVanTravelExpensesAllowable = Some(2.05),
+    premisesRunningCostsAllowable = Some(2.06),
+    maintenanceCostsAllowable = Some(2.07),
+    adminCostsAllowable = Some(2.08),
+    interestOnBankOtherLoansAllowable = Some(2.09),
+    financeChargesAllowable = Some(2.10),
+    irrecoverableDebtsAllowable = Some(2.11),
+    professionalFeesAllowable = Some(2.12),
+    depreciationAllowable = Some(2.13),
+    otherExpensesAllowable = Some(2.14),
+    advertisingCostsAllowable = Some(2.15),
+    businessEntertainmentCostsAllowable = Some(2.16)
   )
 
   val adjustmentsAdditionsModel: AdjustmentsAdditions = AdjustmentsAdditions(
-      costOfGoodsDisallowable = Some(3.01),
-      paymentsToSubcontractorsDisallowable = Some(3.02),
-      wagesAndStaffCostsDisallowable = Some(3.03),
-      carVanTravelExpensesDisallowable = Some(3.04),
-      premisesRunningCostsDisallowable = Some(3.05),
-      maintenanceCostsDisallowable = Some(3.06),
-      adminCostsDisallowable = Some(3.07),
-      interestOnBankOtherLoansDisallowable = Some(3.08),
-      financeChargesDisallowable = Some(3.09),
-      irrecoverableDebtsDisallowable = Some(3.10),
-      professionalFeesDisallowable = Some(3.11),
-      depreciationDisallowable = Some(3.12),
-      otherExpensesDisallowable = Some(3.13),
-      advertisingCostsDisallowable = Some(3.14),
-      businessEntertainmentCostsDisallowable = Some(3.15)
+    costOfGoodsDisallowable = Some(3.01),
+    paymentsToSubcontractorsDisallowable = Some(3.02),
+    wagesAndStaffCostsDisallowable = Some(3.03),
+    carVanTravelExpensesDisallowable = Some(3.04),
+    premisesRunningCostsDisallowable = Some(3.05),
+    maintenanceCostsDisallowable = Some(3.06),
+    adminCostsDisallowable = Some(3.07),
+    interestOnBankOtherLoansDisallowable = Some(3.08),
+    financeChargesDisallowable = Some(3.09),
+    irrecoverableDebtsDisallowable = Some(3.10),
+    professionalFeesDisallowable = Some(3.11),
+    depreciationDisallowable = Some(3.12),
+    otherExpensesDisallowable = Some(3.13),
+    advertisingCostsDisallowable = Some(3.14),
+    businessEntertainmentCostsDisallowable = Some(3.15)
   )
 
   val adjustmentsModel: Adjustments = Adjustments(
@@ -747,11 +762,12 @@ object RetrieveSelfEmploymentBsasFixtures {
     adjustedSummaryCalculation = Some(adjustedSummaryCalculationModel)
   )
 
-  def retrieveBsasResponseInvalidTypeOfBusinessModel(typeOfBusiness: TypeOfBusiness): RetrieveSelfEmploymentBsasResponse = RetrieveSelfEmploymentBsasResponse(
-    metadata = metadataModel,
-    inputs = inputsModel.copy(typeOfBusiness = typeOfBusiness),
-    adjustableSummaryCalculation = adjustableSummaryCalculationModel,
-    adjustments = Some(adjustmentsModel),
-    adjustedSummaryCalculation = Some(adjustedSummaryCalculationModel)
-  )
+  def retrieveBsasResponseInvalidTypeOfBusinessModel(typeOfBusiness: TypeOfBusiness): RetrieveSelfEmploymentBsasResponse =
+    RetrieveSelfEmploymentBsasResponse(
+      metadata = metadataModel,
+      inputs = inputsModel.copy(typeOfBusiness = typeOfBusiness),
+      adjustableSummaryCalculation = adjustableSummaryCalculationModel,
+      adjustments = Some(adjustmentsModel),
+      adjustedSummaryCalculation = Some(adjustedSummaryCalculationModel)
+    )
 }

--- a/test/v3/fixtures/selfEmployment/SubmitSelfEmploymentBsasFixtures.scala
+++ b/test/v3/fixtures/selfEmployment/SubmitSelfEmploymentBsasFixtures.scala
@@ -244,11 +244,24 @@ object SubmitSelfEmploymentBsasFixtures {
                                 |   }
                                 |}""".stripMargin)
 
-  val hateoasResponse: (String, String) => String = (nino: String, calcId: String) => s"""
+  def hateoasResponse(nino: String, calcId: String): String = s"""
        |{
        |  "links":[
        |    {
        |      "href":"/individuals/self-assessment/adjustable-summary/$nino/self-employment/$calcId",
+       |      "rel":"self",
+       |      "method":"GET"
+       |    }
+       |  ]
+       |}
+    """.stripMargin
+
+  def hateoasResponseWithTaxYear(nino: String, calcId: String, taxYear: String): String =
+    s"""
+       |{
+       |  "links":[
+       |    {
+       |      "href":"/individuals/self-assessment/adjustable-summary/$nino/self-employment/$calcId?taxYear=$taxYear",
        |      "rel":"self",
        |      "method":"GET"
        |    }

--- a/test/v3/fixtures/ukProperty/RetrieveUkPropertyBsasFixtures.scala
+++ b/test/v3/fixtures/ukProperty/RetrieveUkPropertyBsasFixtures.scala
@@ -548,39 +548,45 @@ object RetrieveUkPropertyBsasFixtures {
        |""".stripMargin
   )
 
-  def mtdRetrieveBsasReponseFhlJsonWithHateoas(nino: String, calculationId: String): JsValue =
+  def mtdRetrieveBsasReponseFhlJsonWithHateoas(nino: String, calculationId: String, taxYear: Option[String] = None): JsValue = {
+    val taxYearParam = taxYear.fold("")("?taxYear=" + _)
+
     mtdRetrieveBsasResponseFhlJson.as[JsObject] ++ Json.parse(s"""
       |{
       |  "links": [
       |    {
-      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId",
+      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId$taxYearParam",
       |      "method": "GET",
       |      "rel": "self"
       |    }, {
-      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId/adjust",
+      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId/adjust$taxYearParam",
       |      "method": "POST",
       |      "rel": "submit-uk-property-accounting-adjustments"
       |    }
       |  ]
       |}
       |""".stripMargin).as[JsObject]
+  }
 
-  def mtdRetrieveBsasReponseNonFhlJsonWithHateoas(nino: String, calculationId: String): JsValue =
+  def mtdRetrieveBsasReponseNonFhlJsonWithHateoas(nino: String, calculationId: String, taxYear: Option[String] = None): JsValue = {
+    val taxYearParam = taxYear.fold("")("?taxYear=" + _)
+
     mtdRetrieveBsasResponseNonFhlJson.as[JsObject] ++ Json.parse(s"""
       |{
       |  "links": [
       |    {
-      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId",
+      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId$taxYearParam",
       |      "method": "GET",
       |      "rel": "self"
       |    }, {
-      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId/adjust",
+      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId/adjust$taxYearParam",
       |      "method": "POST",
       |      "rel": "submit-uk-property-accounting-adjustments"
       |    }
       |  ]
       |}
       |""".stripMargin).as[JsObject]
+  }
 
   val metadataModel: Metadata = Metadata(
     calculationId = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",

--- a/test/v3/fixtures/ukProperty/SubmitUKPropertyBsasRequestBodyFixtures.scala
+++ b/test/v3/fixtures/ukProperty/SubmitUKPropertyBsasRequestBodyFixtures.scala
@@ -250,11 +250,24 @@ object SubmitUKPropertyBsasRequestBodyFixtures {
           expenses.fold(Json.obj())(expenses => Json.obj("expenses" -> expenses))))
   }
 
-  val hateoasResponse: (String, String) => String = (nino: String, calcId: String) => s"""
+  def hateoasResponse(nino: String, calcId: String): String = s"""
        |{
        |  "links":[
        |    {
        |      "href":"/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calcId",
+       |      "rel":"self",
+       |      "method":"GET"
+       |    }
+       |  ]
+       |}
+    """.stripMargin
+
+  def hateoasResponseWithTaxYearParam(nino: String, calcId: String, taxYear: String): String =
+    s"""
+       |{
+       |  "links":[
+       |    {
+       |      "href":"/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calcId?taxYear=$taxYear",
        |      "rel":"self",
        |      "method":"GET"
        |    }


### PR DESCRIPTION
Part 2 of this ticket, the Hateoas Links and Factories have already been updated. This wires the taxYear into the hateoas data class from the controller, and updates the specs and ITs to handle the taxYear param.