### PR TITLE
MTDSA-15855: Fix failing IT test due to new tax year

### DIFF
--- a/app/v3/controllers/requestParsers/validators/ListBsasValidator.scala
+++ b/app/v3/controllers/requestParsers/validators/ListBsasValidator.scala
@@ -17,7 +17,7 @@
 package v3.controllers.requestParsers.validators
 
 import api.controllers.requestParsers.validators.Validator
-import api.controllers.requestParsers.validators.validations.{BusinessIdValidation, NinoValidation, TaxYearValidation}
+import api.controllers.requestParsers.validators.validations.{ BusinessIdValidation, NinoValidation, TaxYearValidation }
 import api.models.errors.MtdError
 import config.FixedConfig
 import v3.controllers.requestParsers.validators.validations._

--- a/it/v3/endpoints/ListBsasControllerISpec.scala
+++ b/it/v3/endpoints/ListBsasControllerISpec.scala
@@ -16,13 +16,23 @@
 
 package v3.endpoints
 
-import api.models.errors.{BusinessIdFormatError, InternalError, MtdError, NinoFormatError, NotFoundError, RuleTaxYearNotSupportedError, RuleTaxYearRangeInvalidError, TaxYearFormatError, TypeOfBusinessFormatError}
-import api.stubs.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
+import api.models.errors.{
+  BusinessIdFormatError,
+  InternalError,
+  MtdError,
+  NinoFormatError,
+  NotFoundError,
+  RuleTaxYearNotSupportedError,
+  RuleTaxYearRangeInvalidError,
+  TaxYearFormatError,
+  TypeOfBusinessFormatError
+}
+import api.stubs.{ AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub }
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.http.HeaderNames.ACCEPT
 import play.api.http.Status._
 import play.api.libs.json.Json
-import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.libs.ws.{ WSRequest, WSResponse }
 import play.api.test.Helpers.AUTHORIZATION
 import support.IntegrationBaseSpec
 import v3.fixtures.ListBsasFixture
@@ -149,7 +159,7 @@ class ListBsasControllerISpec extends IntegrationBaseSpec with ListBsasFixture {
         response.json shouldBe summariesJSONForeignWithHateoas(nino, Some("2023-24"))
       }
 
-      "valid request is made without a tax year" in new NonTysTest {
+      "valid request is made without a tax year" in new TysIfsTest {
         override val taxYear: Option[String] = None
 
         override def setupStubs(): StubMapping = {
@@ -163,7 +173,7 @@ class ListBsasControllerISpec extends IntegrationBaseSpec with ListBsasFixture {
 
         response.status shouldBe OK
         response.header("Content-Type") shouldBe Some("application/json")
-        response.json shouldBe summariesJSONWithHateoas(nino)
+        response.json shouldBe summariesJSONWithHateoas(nino, Some("2023-24"))
       }
     }
 

--- a/resources/public/api/conf/3.0/common/queryParameters.yaml
+++ b/resources/public/api/conf/3.0/common/queryParameters.yaml
@@ -7,8 +7,6 @@ components:
         The tax year to which the data applies in the format YYYY-YY. The range must not be greater than a single year.
         For example, 2023-25 is not valid.
   
-        This is mandatory for tax years 2023-24 and onwards.
-  
         The minimum tax year is 2019-20.
   
         Where no tax year is provided, it will default to the current tax year.


### PR DESCRIPTION
I also noticed a discrepancy where the code defaults the `taxYear` query param to the current year, even for TYS, but the [spec](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=539165187) said that it was a mandatory param for TYS. Confirmed with Fatih that it is fine for us to default and leave it optional, so he has updated the param description, which I have updated in the OAS.