### PR TITLE
MTDSA-22029 - TYS schemas V5

### DIFF
--- a/app/shared/connectors/DownstreamUri.scala
+++ b/app/shared/connectors/DownstreamUri.scala
@@ -16,7 +16,7 @@
 
 package shared.connectors
 
-sealed trait DownstreamUri[Resp] {
+sealed trait DownstreamUri[+Resp] {
   val value: String
 }
 

--- a/app/shared/controllers/validators/resolvers/ResolveNonEmptyJsonObject.scala
+++ b/app/shared/controllers/validators/resolvers/ResolveNonEmptyJsonObject.scala
@@ -39,3 +39,10 @@ class ResolveNonEmptyJsonObject[T: OFormat: EmptinessChecker]()(implicit val rea
   def apply(data: JsValue): Validated[Seq[MtdError], T] = resolver(data)
 
 }
+
+object ResolveNonEmptyJsonObject extends ResolverSupport {
+
+  def resolver[T: OFormat: EmptinessChecker]: Resolver[JsValue, T] =
+    new ResolveNonEmptyJsonObject().resolver
+
+}

--- a/app/shared/hateoas/HateoasWrapper.scala
+++ b/app/shared/hateoas/HateoasWrapper.scala
@@ -44,4 +44,4 @@ object HateoasWrapper {
 
 }
 
-case class HateoasWrapper[A](payload: A, links: Seq[Link])
+case class HateoasWrapper[+A](payload: A, links: Seq[Link])

--- a/app/v5/controllers/validators/resolvers/ResolveOnlyOneJsonProperty.scala
+++ b/app/v5/controllers/validators/resolvers/ResolveOnlyOneJsonProperty.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.controllers.validators.resolvers
+
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
+import play.api.libs.json.JsValue
+import shared.models.errors.MtdError
+import v5.models.errors.RuleBothPropertiesSuppliedError
+
+class ResolveOnlyOneJsonProperty(fieldOneName: String, fieldTwoName: String) {
+
+  def apply(body: JsValue): Validated[Seq[MtdError], Unit] = {
+    if (List(fieldOneName, fieldTwoName).forall(field => (body \ field).isDefined)) {
+      Invalid(List(RuleBothPropertiesSuppliedError))
+    } else {
+      Valid(())
+    }
+  }
+
+}

--- a/app/v5/controllers/validators/resolvers/ResolveTypeOfBusiness.scala
+++ b/app/v5/controllers/validators/resolvers/ResolveTypeOfBusiness.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.controllers.validators.resolvers
+
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
+import shared.controllers.validators.resolvers.ResolverSupport
+import shared.models.errors.MtdError
+import v5.models.domain.TypeOfBusiness
+import v5.models.errors.TypeOfBusinessFormatError
+
+import scala.util.{Failure, Success, Try}
+
+object ResolveTypeOfBusiness extends ResolverSupport {
+
+  val resolver: Resolver[String, TypeOfBusiness] = value =>
+    Try(TypeOfBusiness.parser(value)) match {
+      case Failure(_)              => Invalid(List(TypeOfBusinessFormatError))
+      case Success(typeOfBusiness) => Valid(typeOfBusiness)
+    }
+
+  def apply(value: String): Validated[Seq[MtdError], TypeOfBusiness] = resolver(value)
+
+}

--- a/app/v5/hateoas/HateoasLinks.scala
+++ b/app/v5/hateoas/HateoasLinks.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.hateoas
+
+import shared.config.AppConfig
+import shared.hateoas.Link
+import shared.hateoas.Method._
+import shared.models.domain.TaxYear
+import v5.hateoas.RelType._
+
+trait HateoasLinks {
+
+  // API resource links
+  // L1
+  def triggerBsas(appConfig: AppConfig, nino: String): Link =
+    Link(href = bsasBasUri(appConfig, nino) + "/trigger", method = POST, rel = TRIGGER)
+
+  // L2
+  def getSelfEmploymentBsas(appConfig: AppConfig, nino: String, calcId: String, taxYear: Option[TaxYear]): Link = {
+    val href = withTaxYearParameter(bsasBasUri(appConfig, nino) + s"/self-employment/$calcId", taxYear)
+    Link(href = href, method = GET, rel = SELF)
+  }
+
+  // L3
+  def getUkPropertyBsas(appConfig: AppConfig, nino: String, calcId: String, taxYear: Option[TaxYear]): Link = {
+    val href = withTaxYearParameter(bsasBasUri(appConfig, nino) + s"/uk-property/$calcId", taxYear)
+    Link(href = href, method = GET, rel = SELF)
+  }
+
+  private def withTaxYearParameter(uri: String, maybeTaxYear: Option[TaxYear]): String = {
+    maybeTaxYear match {
+      case Some(taxYear) if taxYear.useTaxYearSpecificApi => s"$uri?taxYear=${taxYear.asMtd}"
+      case _                                              => uri
+    }
+  }
+
+  private def bsasBasUri(appConfig: AppConfig, nino: String) =
+    s"/${appConfig.apiGatewayContext}/$nino"
+
+  // L4
+  def getForeignPropertyBsas(appConfig: AppConfig, nino: String, calcId: String, taxYear: Option[TaxYear]): Link = {
+    val href = withTaxYearParameter(bsasBasUri(appConfig, nino) + s"/foreign-property/$calcId", taxYear)
+    Link(href = href, method = GET, rel = SELF)
+  }
+
+  // L5
+  def listBsas(appConfig: AppConfig, nino: String, taxYear: Option[TaxYear]): Link = {
+    val href = withTaxYearParameter(bsasBasUri(appConfig, nino), taxYear)
+    Link(href = href, method = GET, rel = SELF)
+  }
+
+  // L6
+  def adjustSelfEmploymentBsas(appConfig: AppConfig, nino: String, calcId: String, taxYear: Option[TaxYear]): Link = {
+    val href = withTaxYearParameter(bsasBasUri(appConfig, nino) + s"/self-employment/$calcId/adjust", taxYear)
+    Link(href = href, method = POST, rel = SUBMIT_SE_ADJUSTMENTS)
+  }
+
+  // L7
+  def adjustUkPropertyBsas(appConfig: AppConfig, nino: String, calcId: String, taxYear: Option[TaxYear]): Link = {
+    val href = withTaxYearParameter(bsasBasUri(appConfig, nino) + s"/uk-property/$calcId/adjust", taxYear)
+    Link(href = href, method = POST, rel = SUBMIT_UK_PROPERTY_ADJUSTMENTS)
+  }
+
+  // L8
+  def adjustForeignPropertyBsas(appConfig: AppConfig, nino: String, calcId: String, taxYear: Option[TaxYear]): Link = {
+    val href = withTaxYearParameter(bsasBasUri(appConfig, nino) + s"/foreign-property/$calcId/adjust", taxYear)
+    Link(href = href, method = POST, rel = SUBMIT_FOREIGN_PROPERTY_ADJUSTMENTS)
+  }
+
+}

--- a/app/v5/hateoas/RelType.scala
+++ b/app/v5/hateoas/RelType.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.hateoas
+
+object RelType {
+  val TRIGGER = "trigger-business-source-adjustable-summary"
+  val SUBMIT_SE_ADJUSTMENTS = "submit-self-employment-accounting-adjustments"
+  val SUBMIT_UK_PROPERTY_ADJUSTMENTS = "submit-uk-property-accounting-adjustments"
+  val SUBMIT_FOREIGN_PROPERTY_ADJUSTMENTS = "submit-foreign-property-accounting-adjustments"
+
+  val SELF = "self"
+}

--- a/app/v5/listBsas/connectors/ListBsasConnector.scala
+++ b/app/v5/listBsas/connectors/ListBsasConnector.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.connectors
+
+import shared.config.AppConfig
+import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.httpparsers.StandardDownstreamHttpParser._
+import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import v5.listBsas.models.{BsasSummary, ListBsasRequestData, ListBsasResponse}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ListBsasConnector @Inject() (val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+
+  def listBsas(request: ListBsasRequestData)(implicit
+      hc: HeaderCarrier,
+      ec: ExecutionContext,
+      correlationId: String): Future[DownstreamOutcome[ListBsasResponse[BsasSummary]]] = {
+
+    import request._
+    import schema._
+
+    val queryParams = Map(
+      "incomeSourceId"   -> incomeSourceId.map(_.businessId),
+      "incomeSourceType" -> incomeSourceType
+    )
+
+    val mappedQueryParams: Map[String, String] = queryParams.collect { case (k: String, Some(v: String)) => (k, v) }
+
+    if (taxYear.useTaxYearSpecificApi) {
+      get(
+        TaxYearSpecificIfsUri[DownstreamResp](s"income-tax/adjustable-summary-calculation/${taxYear.asTysDownstream}/$nino"),
+        mappedQueryParams.toList
+      )
+    } else {
+      val mappedQueryParamsWithTaxYear: Map[String, String] = mappedQueryParams ++ Map("taxYear" -> taxYear.asDownstream)
+      get(IfsUri[DownstreamResp](s"income-tax/adjustable-summary-calculation/$nino"), mappedQueryParamsWithTaxYear.toSeq)
+    }
+
+  }
+
+}

--- a/app/v5/listBsas/controllers/ListBsasController.scala
+++ b/app/v5/listBsas/controllers/ListBsasController.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.controllers
+
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import shared.config.AppConfig
+import shared.controllers._
+import shared.hateoas.HateoasFactory
+import shared.services.{EnrolmentsAuthService, MtdIdLookupService}
+import shared.utils._
+import v5.listBsas.models.{BsasSummary, ListBsasHateoasData, ListBsasRequestData, ListBsasResponse}
+import v5.listBsas.schema.ListBsasSchema
+import v5.listBsas.services.ListBsasService
+import v5.listBsas.validators.ListBsasValidatorFactory
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class ListBsasController @Inject() (val authService: EnrolmentsAuthService,
+                                    val lookupService: MtdIdLookupService,
+                                    validatorFactory: ListBsasValidatorFactory,
+                                    service: ListBsasService,
+                                    hateoasFactory: HateoasFactory,
+                                    cc: ControllerComponents,
+                                    val idGenerator: IdGenerator)(implicit ec: ExecutionContext, appConfig: AppConfig)
+    extends AuthorisedController(cc)
+    with Logging {
+
+  implicit val endpointLogContext: EndpointLogContext =
+    EndpointLogContext(controllerName = "ListBsasController", endpointName = "listBsas")
+
+  def listBsas(nino: String, taxYear: Option[String], typeOfBusiness: Option[String], businessId: Option[String]): Action[AnyContent] =
+    authorisedAction(nino).async { implicit request =>
+      implicit val ctx: RequestContext = RequestContext.from(idGenerator, endpointLogContext)
+
+      val validator = validatorFactory.validator(nino, taxYear, typeOfBusiness, businessId, ListBsasSchema.schemaFor(taxYear))
+
+      val requestHandler =
+        RequestHandler
+          .withValidator(validator)
+          .withService(service.listBsas)
+          .withResultCreator(
+            ResultCreator.hateoasListWrapping(hateoasFactory)((parsedRequest: ListBsasRequestData, response: ListBsasResponse[BsasSummary]) =>
+              ListBsasHateoasData(nino, response, Some(parsedRequest.taxYear))))
+
+      requestHandler.handleRequest()
+    }
+
+}

--- a/app/v5/listBsas/models/ListBsasRequestData.scala
+++ b/app/v5/listBsas/models/ListBsasRequestData.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models
+
+import shared.models.domain.{BusinessId, Nino, TaxYear}
+import v5.listBsas.schema.ListBsasSchema
+
+trait ListBsasRequestData {
+  def nino: Nino
+  def taxYear: TaxYear
+  def incomeSourceId: Option[BusinessId]
+  def incomeSourceType: Option[String]
+
+  val schema: ListBsasSchema
+}

--- a/app/v5/listBsas/models/ListBsasResponse.scala
+++ b/app/v5/listBsas/models/ListBsasResponse.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models
+
+import cats.Functor
+import play.api.libs.json.{OWrites, Writes}
+import shared.config.AppConfig
+import shared.hateoas.{HateoasData, HateoasListLinksFactory, Link}
+import shared.models.domain.TaxYear
+import v5.hateoas.HateoasLinks
+import v5.listBsas.models.def1.{Def1_BsasSummary, Def1_ListBsasResponse}
+import v5.models.domain.TypeOfBusiness
+import v5.models.domain.TypeOfBusiness.{`foreign-property-fhl-eea`, `foreign-property`, `self-employment`, `uk-property-fhl`, `uk-property-non-fhl`}
+
+trait BsasSummary {
+  def calculationId: String
+}
+
+object BsasSummary {
+
+  implicit val writes: OWrites[BsasSummary] = OWrites.apply[BsasSummary] {
+    case a: Def1_BsasSummary =>
+      implicitly[OWrites[Def1_BsasSummary]].writes(a)
+
+    case a: BsasSummary => throw new RuntimeException(s"No writes defined for type ${a.getClass.getName}")
+  }
+
+}
+
+trait ListBsasResponse[+I] {
+  def typeOfBusinessFor[A >: I](item: A): Option[TypeOfBusiness]
+
+  def mapItems[B](f: I => B): ListBsasResponse[B]
+}
+
+object ListBsasResponse extends HateoasLinks {
+
+  implicit def writes[I: Writes]: OWrites[ListBsasResponse[I]] = OWrites.apply[ListBsasResponse[I]] {
+    case a: Def1_ListBsasResponse[I] => implicitly[OWrites[Def1_ListBsasResponse[I]]].writes(a)
+
+    case a: ListBsasResponse[I] => throw new RuntimeException(s"No writes defined for type ${a.getClass.getName}")
+  }
+
+  implicit object LinksFactory extends HateoasListLinksFactory[ListBsasResponse, BsasSummary, ListBsasHateoasData] {
+
+    override def links(appConfig: AppConfig, data: ListBsasHateoasData): Seq[Link] = Seq(
+      triggerBsas(appConfig, data.nino),
+      listBsas(appConfig, data.nino, data.taxYear)
+    )
+
+    override def itemLinks(appConfig: AppConfig, data: ListBsasHateoasData, summaryItem: BsasSummary): Seq[Link] = {
+      data.listBsasResponse.typeOfBusinessFor(summaryItem).toSeq.map {
+        case `self-employment`                               => getSelfEmploymentBsas(appConfig, data.nino, summaryItem.calculationId, data.taxYear)
+        case `uk-property-fhl` | `uk-property-non-fhl`       => getUkPropertyBsas(appConfig, data.nino, summaryItem.calculationId, data.taxYear)
+        case `foreign-property` | `foreign-property-fhl-eea` => getForeignPropertyBsas(appConfig, data.nino, summaryItem.calculationId, data.taxYear)
+      }
+    }
+
+  }
+
+  implicit object ResponseFunctor extends Functor[ListBsasResponse] {
+    override def map[A, B](fa: ListBsasResponse[A])(f: A => B): ListBsasResponse[B] = fa.mapItems(f)
+  }
+
+}
+
+case class ListBsasHateoasData(nino: String, listBsasResponse: ListBsasResponse[BsasSummary], taxYear: Option[TaxYear]) extends HateoasData

--- a/app/v5/listBsas/models/def1/AccountingPeriod.scala
+++ b/app/v5/listBsas/models/def1/AccountingPeriod.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models.def1
+
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class AccountingPeriod(startDate: String, endDate: String)
+
+object AccountingPeriod {
+  implicit val reads: Reads[AccountingPeriod] = (
+    (JsPath \ "accountingStartDate").read[String] and
+      (JsPath \ "accountingEndDate").read[String]
+    ) (AccountingPeriod.apply _)
+
+  implicit val writes: OWrites[AccountingPeriod] = Json.writes[AccountingPeriod]
+}

--- a/app/v5/listBsas/models/def1/BusinessSource.scala
+++ b/app/v5/listBsas/models/def1/BusinessSource.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import shared.models.domain.TaxYear
+import v5.models.domain.{IncomeSourceType, TypeOfBusiness}
+
+case class BusinessSource[I](businessId: String,
+                             typeOfBusiness: TypeOfBusiness,
+                             accountingPeriod: AccountingPeriod,
+                             taxYear: TaxYear,
+                             summaries: Seq[I])
+
+object BusinessSource {
+
+  implicit def reads[I: Reads]: Reads[BusinessSource[I]] =
+    (
+      (JsPath \ "incomeSourceId").read[String] and
+        (JsPath \ "incomeSourceType").read[IncomeSourceType].map(_.toTypeOfBusiness) and
+        JsPath.read[AccountingPeriod] and
+        (JsPath \ "taxYear").read[Int].map(TaxYear.fromDownstreamInt) and
+        (JsPath \ "ascCalculations").read[Seq[I]]
+    )(BusinessSource(_, _, _, _, _))
+
+  implicit def writes[I: Writes]: OWrites[BusinessSource[I]] = Json.writes[BusinessSource[I]]
+}

--- a/app/v5/listBsas/models/def1/Def1_BsasSummary.scala
+++ b/app/v5/listBsas/models/def1/Def1_BsasSummary.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+import shared.models.domain.Status
+import v5.listBsas.models.BsasSummary
+
+case class Def1_BsasSummary(calculationId: String,
+                            requestedDateTime: String,
+                            summaryStatus: Status,
+                            adjustedSummary: Boolean,
+                            adjustedDateTime: Option[String])
+    extends BsasSummary
+
+object Def1_BsasSummary {
+
+  implicit val reads: Reads[Def1_BsasSummary] = (
+    (JsPath \ "calculationId").read[String] and
+      (JsPath \ "requestedDateTime").read[String] and
+      (JsPath \ "status").read[Status] and
+      (JsPath \ "adjusted").read[Boolean] and
+      (JsPath \ "adjustedDateTime").readNullable[String]
+  )(Def1_BsasSummary.apply _)
+
+  implicit val writes: OWrites[Def1_BsasSummary] = Json.writes[Def1_BsasSummary]
+}

--- a/app/v5/listBsas/models/def1/Def1_ListBsasRequestData.scala
+++ b/app/v5/listBsas/models/def1/Def1_ListBsasRequestData.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models.def1
+
+import shared.models.domain.{BusinessId, Nino, TaxYear}
+import v5.listBsas.models.ListBsasRequestData
+import v5.listBsas.schema.ListBsasSchema
+
+case class Def1_ListBsasRequestData(nino: Nino, taxYear: TaxYear, incomeSourceId: Option[BusinessId], incomeSourceType: Option[String])
+    extends ListBsasRequestData {
+  override val schema: ListBsasSchema = ListBsasSchema.Def1
+}

--- a/app/v5/listBsas/models/def1/Def1_ListBsasResponse.scala
+++ b/app/v5/listBsas/models/def1/Def1_ListBsasResponse.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models.def1
+
+import play.api.libs.json.{Json, OWrites, Reads, Writes}
+import v5.hateoas.HateoasLinks
+import v5.listBsas.models.ListBsasResponse
+import v5.models.domain.TypeOfBusiness
+
+case class Def1_ListBsasResponse[I](businessSources: Seq[BusinessSource[I]]) extends ListBsasResponse[I] {
+
+  override def typeOfBusinessFor[A >: I](item: A): Option[TypeOfBusiness] =
+    businessSources.find(_.summaries.contains(item)).map(_.typeOfBusiness)
+
+  override def mapItems[B](f: I => B): ListBsasResponse[B] = {
+    Def1_ListBsasResponse(businessSources.map { businessSource =>
+      businessSource.copy(summaries = businessSource.summaries.map(f))
+    })
+  }
+}
+
+object Def1_ListBsasResponse extends HateoasLinks {
+
+  implicit def reads[I: Reads]: Reads[Def1_ListBsasResponse[I]] =
+    implicitly[Reads[Seq[BusinessSource[I]]]].map(Def1_ListBsasResponse(_))
+
+  implicit def writes[I: Writes]: OWrites[Def1_ListBsasResponse[I]] = Json.writes[Def1_ListBsasResponse[I]]
+}

--- a/app/v5/listBsas/schema/ListBsasSchema.scala
+++ b/app/v5/listBsas/schema/ListBsasSchema.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.schema
+
+import play.api.libs.json.Reads
+import shared.controllers.validators.resolvers.ResolveTaxYear
+import shared.models.domain.TaxYear
+import v5.listBsas.models.{BsasSummary, ListBsasResponse}
+import v5.listBsas.models.def1.{Def1_BsasSummary, Def1_ListBsasResponse}
+import v5.schema.DownstreamReadable
+
+import scala.math.Ordered.orderingToOrdered
+
+sealed trait ListBsasSchema extends DownstreamReadable[ListBsasResponse[BsasSummary]]
+
+object ListBsasSchema {
+
+  case object Def1 extends ListBsasSchema {
+    type DownstreamResp = Def1_ListBsasResponse[Def1_BsasSummary]
+    val connectorReads: Reads[DownstreamResp] = Def1_ListBsasResponse.reads
+  }
+
+  private val defaultSchema = Def1
+
+  def schemaFor(maybeTaxYear: Option[String]): ListBsasSchema = {
+    maybeTaxYear
+      .map(ResolveTaxYear.resolver)
+      .flatMap(_.toOption.map(schemaFor))
+      .getOrElse(defaultSchema)
+  }
+
+  def schemaFor(taxYear: TaxYear): ListBsasSchema = {
+    if (TaxYear.starting(2023) <= taxYear) {
+      Def1
+    } else {
+      defaultSchema
+    }
+  }
+
+}

--- a/app/v5/listBsas/services/ListBsasService.scala
+++ b/app/v5/listBsas/services/ListBsasService.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.services
+
+import cats.implicits._
+import shared.controllers.RequestContext
+import shared.models.errors._
+import shared.services.{BaseService, ServiceOutcome}
+import v5.listBsas.connectors.ListBsasConnector
+import v5.listBsas.models.{BsasSummary, ListBsasRequestData, ListBsasResponse}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ListBsasService @Inject() (connector: ListBsasConnector) extends BaseService {
+
+  def listBsas(
+      request: ListBsasRequestData
+  )(implicit ctx: RequestContext, ec: ExecutionContext): Future[ServiceOutcome[ListBsasResponse[BsasSummary]]] = {
+
+    connector
+      .listBsas(request)
+      .map(_.leftMap(mapDownstreamErrors(errorMap)))
+  }
+
+  private val errorMap: Map[String, MtdError] = {
+    val errors = Map(
+      "INVALID_CORRELATIONID"     -> InternalError,
+      "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+      "INVALID_TAXYEAR"           -> TaxYearFormatError,
+      "INVALID_INCOMESOURCEID"    -> BusinessIdFormatError,
+      "INVALID_INCOMESOURCE_TYPE" -> InternalError,
+      "NO_DATA_FOUND"             -> NotFoundError,
+      "SERVER_ERROR"              -> InternalError,
+      "SERVICE_UNAVAILABLE"       -> InternalError
+    )
+
+    val extraTysErrors = Map(
+      "INVALID_CORRELATION_ID"  -> InternalError,
+      "INVALID_TAX_YEAR"        -> TaxYearFormatError,
+      "INVALID_INCOMESOURCE_ID" -> BusinessIdFormatError,
+      "NOT_FOUND"               -> NotFoundError,
+      "TAX_YEAR_NOT_SUPPORTED"  -> RuleTaxYearNotSupportedError
+    )
+
+    errors ++ extraTysErrors
+  }
+
+}

--- a/app/v5/listBsas/validators/ListBsasValidatorFactory.scala
+++ b/app/v5/listBsas/validators/ListBsasValidatorFactory.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.validators
+
+import shared.controllers.validators.Validator
+import v5.listBsas.models.ListBsasRequestData
+import v5.listBsas.schema.ListBsasSchema
+import v5.listBsas.validators.def1.Def1_ListBsasValidator
+
+import javax.inject.Singleton
+
+@Singleton
+class ListBsasValidatorFactory {
+
+  def validator(nino: String,
+                taxYear: Option[String],
+                typeOfBusiness: Option[String],
+                businessId: Option[String],
+                schema: ListBsasSchema): Validator[ListBsasRequestData] =
+    schema match {
+      case ListBsasSchema.Def1 => new Def1_ListBsasValidator(nino, taxYear, typeOfBusiness, businessId)
+    }
+
+}
+
+

--- a/app/v5/listBsas/validators/def1/Def1_ListBsasValidator.scala
+++ b/app/v5/listBsas/validators/def1/Def1_ListBsasValidator.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.validators.def1
+
+import cats.data.Validated
+import cats.data.Validated._
+import cats.implicits._
+import shared.controllers.validators.Validator
+import shared.controllers.validators.resolvers.{ResolveBusinessId, ResolveNino, ResolveTaxYear, ResolverSupport}
+import shared.models.domain.TaxYear
+import shared.models.errors.{MtdError, RuleTaxYearNotSupportedError}
+import v5.controllers.validators.resolvers.ResolveTypeOfBusiness
+import v5.listBsas.models.ListBsasRequestData
+import v5.listBsas.models.def1.Def1_ListBsasRequestData
+
+class Def1_ListBsasValidator(nino: String, taxYear: Option[String], typeOfBusiness: Option[String], businessId: Option[String])
+    extends Validator[ListBsasRequestData]
+    with ResolverSupport {
+
+  private val listMinimumTaxYear = TaxYear.fromMtd("2019-20")
+
+  private val resolveTaxYear = ResolveTaxYear.resolver.resolveOptionallyWithDefault(TaxYear.currentTaxYear) thenValidate
+    satisfiesMin(listMinimumTaxYear, RuleTaxYearNotSupportedError)
+
+  private val resolveBusinessId     = ResolveBusinessId.resolver.resolveOptionally
+  private val resolveTypeOfBusiness = ResolveTypeOfBusiness.resolver.resolveOptionally
+
+  def validate: Validated[Seq[MtdError], ListBsasRequestData] =
+    (
+      ResolveNino(nino),
+      resolveTaxYear(taxYear),
+      resolveBusinessId(businessId),
+      resolveTypeOfBusiness(typeOfBusiness).map(_.map(_.asDownstreamValue))
+    ).mapN(Def1_ListBsasRequestData)
+
+}

--- a/app/v5/listBsas/validators/def1/Def1_ListBsasValidator.scala
+++ b/app/v5/listBsas/validators/def1/Def1_ListBsasValidator.scala
@@ -27,10 +27,7 @@ import v5.controllers.validators.resolvers.ResolveTypeOfBusiness
 import v5.listBsas.models.ListBsasRequestData
 import v5.listBsas.models.def1.Def1_ListBsasRequestData
 
-class Def1_ListBsasValidator(nino: String, taxYear: Option[String], typeOfBusiness: Option[String], businessId: Option[String])
-    extends Validator[ListBsasRequestData]
-    with ResolverSupport {
-
+object Def1_ListBsasValidator extends ResolverSupport {
   private val listMinimumTaxYear = TaxYear.fromMtd("2019-20")
 
   private val resolveTaxYear = ResolveTaxYear.resolver.resolveOptionallyWithDefault(TaxYear.currentTaxYear) thenValidate
@@ -38,6 +35,11 @@ class Def1_ListBsasValidator(nino: String, taxYear: Option[String], typeOfBusine
 
   private val resolveBusinessId     = ResolveBusinessId.resolver.resolveOptionally
   private val resolveTypeOfBusiness = ResolveTypeOfBusiness.resolver.resolveOptionally
+}
+
+class Def1_ListBsasValidator(nino: String, taxYear: Option[String], typeOfBusiness: Option[String], businessId: Option[String])
+    extends Validator[ListBsasRequestData] {
+  import Def1_ListBsasValidator._
 
   def validate: Validated[Seq[MtdError], ListBsasRequestData] =
     (

--- a/app/v5/models/domain/IncomeSourceType.scala
+++ b/app/v5/models/domain/IncomeSourceType.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.models.domain
+
+import play.api.libs.json
+import shared.utils.enums.Enums
+
+sealed trait IncomeSourceType {
+  def toTypeOfBusiness: TypeOfBusiness
+}
+
+//noinspection ScalaStyle
+object IncomeSourceType {
+
+  case object `01` extends IncomeSourceType {
+    override def toTypeOfBusiness: TypeOfBusiness = TypeOfBusiness.`self-employment`
+  }
+
+  case object `02` extends IncomeSourceType {
+    override def toTypeOfBusiness: TypeOfBusiness = TypeOfBusiness.`uk-property-non-fhl`
+  }
+
+  case object `03` extends IncomeSourceType {
+    override def toTypeOfBusiness: TypeOfBusiness = TypeOfBusiness.`foreign-property-fhl-eea`
+  }
+
+  case object `04` extends IncomeSourceType {
+    override def toTypeOfBusiness: TypeOfBusiness = TypeOfBusiness.`uk-property-fhl`
+  }
+
+  case object `15` extends IncomeSourceType {
+    override def toTypeOfBusiness: TypeOfBusiness = TypeOfBusiness.`foreign-property`
+  }
+
+  implicit val format: json.Format[IncomeSourceType] = Enums.format[IncomeSourceType]
+}

--- a/app/v5/models/domain/TypeOfBusiness.scala
+++ b/app/v5/models/domain/TypeOfBusiness.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.models.domain
+
+import play.api.libs.json.Format
+import shared.utils.enums.Enums
+
+sealed trait TypeOfBusiness {
+  def asDownstreamValue: String
+}
+
+trait HasTypeOfBusiness {
+  def typeOfBusiness: TypeOfBusiness
+}
+
+//noinspection ScalaStyle
+object TypeOfBusiness {
+  val parser: PartialFunction[String, TypeOfBusiness] = Enums.parser[TypeOfBusiness]
+
+  case object `self-employment` extends TypeOfBusiness {
+    val asDownstreamValue: String = "01"
+  }
+
+  case object `uk-property-fhl` extends TypeOfBusiness {
+    val asDownstreamValue: String = "04"
+  }
+
+  case object `uk-property-non-fhl` extends TypeOfBusiness {
+    val asDownstreamValue: String = "02"
+  }
+
+  case object `foreign-property-fhl-eea` extends TypeOfBusiness {
+    val asDownstreamValue: String = "03"
+  }
+
+  implicit val format: Format[TypeOfBusiness] = Enums.format[TypeOfBusiness]
+
+  case object `foreign-property` extends TypeOfBusiness {
+    val asDownstreamValue: String = "15"
+  }
+}

--- a/app/v5/models/errors/BsasApiCommonErrors.scala
+++ b/app/v5/models/errors/BsasApiCommonErrors.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.models.errors
+
+import play.api.http.Status.{BAD_REQUEST, NOT_FOUND}
+import shared.models.errors.MtdError
+
+// MtdError types that are common to SA BSAS API.
+
+object TypeOfBusinessFormatError extends MtdError("FORMAT_TYPE_OF_BUSINESS", "The provided type of business is invalid", BAD_REQUEST)
+
+object AdjustedStatusFormatError extends MtdError("FORMAT_ADJUSTED_STATUS", "The supplied adjusted status format is invalid", BAD_REQUEST)
+
+object FormatAdjustmentValueError extends MtdError("FORMAT_ADJUSTMENT_VALUE", "The format of the adjustment value is invalid", BAD_REQUEST)
+
+object BsasIdFormatError extends MtdError("FORMAT_BSAS_ID", "The format of the BSAS ID is invalid", BAD_REQUEST)
+
+object TriggerNotFoundError
+    extends MtdError(
+      "MATCHING_RESOURCE_NOT_FOUND",
+      "A matching incomeSourceId record was not found, or the incomeSourceType provided does not relate to the incomeSourceId",
+      NOT_FOUND)

--- a/app/v5/models/errors/SelfAssessmentBsasMtdErrors.scala
+++ b/app/v5/models/errors/SelfAssessmentBsasMtdErrors.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.models.errors
+
+import play.api.http.Status.BAD_REQUEST
+import shared.models.errors.MtdError
+
+// Rule Errors
+
+object RuleBothPropertiesSuppliedError
+    extends MtdError("RULE_BOTH_PROPERTIES_SUPPLIED", "Both FHL and Non-FHL properties cannot be present at the same time", BAD_REQUEST)
+
+object RuleBothExpensesError
+    extends MtdError("RULE_BOTH_EXPENSES_SUPPLIED", "Both expenses and consolidated expenses cannot be present at the same time", BAD_REQUEST)
+
+object RuleSelfEmploymentAdjustedError
+    extends MtdError(
+      "RULE_SELF_EMPLOYMENT_ADJUSTED",
+      "A self-employment business type was adjusted. Re-trigger an adjustable summary for the self-employment to correct",
+      BAD_REQUEST
+    )
+
+object RuleAccountingPeriodNotSupportedError
+    extends MtdError(
+      "RULE_ACCOUNTING_PERIOD_NOT_SUPPORTED",
+      "The specified accounting period is not supported, that is, the accounting period specified falls before the minimum tax year value",
+      BAD_REQUEST
+    )
+
+object RuleResultingValueNotPermitted
+    extends MtdError(
+      "RULE_RESULTING_VALUE_NOT_PERMITTED",
+      "The adjustments provided would produce an unacceptable negative monetary value",
+      BAD_REQUEST)
+
+object RuleDuplicateCountryCodeError
+    extends MtdError("RULE_DUPLICATE_COUNTRY_CODE", "The same countryCode cannot be supplied multiple times", BAD_REQUEST) {
+
+  def forDuplicatedCodesAndPaths(code: String, paths: Seq[String]): MtdError =
+    RuleDuplicateCountryCodeError.copy(message = s"The country code '$code' is supplied multiple times", paths = Some(paths))
+
+}
+
+object RuleAccountingPeriodNotEndedError
+    extends MtdError("RULE_ACCOUNTING_PERIOD_NOT_ENDED", "The supplied accounting period has not ended", BAD_REQUEST)
+
+object RuleNoAccountingPeriodError extends MtdError("RULE_NO_ACCOUNTING_PERIOD", "The supplied accounting period does not exist", BAD_REQUEST)
+
+object RulePeriodicDataIncompleteError
+    extends MtdError("RULE_PERIODIC_DATA_INCOMPLETE", "One or more periodic updates missing for this accounting period", BAD_REQUEST)
+
+object RuleTypeOfBusinessIncorrectError
+    extends MtdError("RULE_TYPE_OF_BUSINESS_INCORRECT", "The calculation ID supplied relates to a different type of business", BAD_REQUEST)
+
+object RuleSummaryStatusInvalid extends MtdError("RULE_SUMMARY_STATUS_INVALID", "Periodic data has changed. Request a new summary", BAD_REQUEST)
+
+object RuleSummaryStatusSuperseded
+    extends MtdError("RULE_SUMMARY_STATUS_SUPERSEDED", "A newer summary calculation exists for this accounting period", BAD_REQUEST)
+
+object RuleAlreadyAdjusted extends MtdError("RULE_ALREADY_ADJUSTED", "A summary may only be adjusted once. Request a new summary", BAD_REQUEST)
+
+object RuleOverConsolidatedExpensesThreshold
+    extends MtdError(
+      "RULE_OVER_CONSOLIDATED_EXPENSES_THRESHOLD",
+      "The cumulative turnover amount exceeds the consolidated expenses threshold",
+      BAD_REQUEST)
+
+object RuleTradingIncomeAllowanceClaimed
+    extends MtdError("RULE_TRADING_INCOME_ALLOWANCE_CLAIMED", "A claim for trading income allowance was made. Cannot also have expenses", BAD_REQUEST)
+
+object RulePropertyIncomeAllowanceClaimed
+    extends MtdError(
+      "RULE_PROPERTY_INCOME_ALLOWANCE_CLAIMED",
+      "A claim for property income allowance was made. Cannot also have expenses",
+      BAD_REQUEST)
+
+object RuleNoAdjustmentsMade extends MtdError("RULE_NO_ADJUSTMENTS_MADE", "An adjusted summary calculation does not exist", BAD_REQUEST)
+
+object RuleNotSelfEmployment
+    extends MtdError("RULE_NOT_SELF_EMPLOYMENT", "The adjustments requested are not for a self-employment business", BAD_REQUEST)

--- a/app/v5/retrieveForeignPropertyBsas/connectors/RetrieveForeignPropertyBsasConnector.scala
+++ b/app/v5/retrieveForeignPropertyBsas/connectors/RetrieveForeignPropertyBsasConnector.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.connectors
+
+import shared.config.AppConfig
+import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.httpparsers.StandardDownstreamHttpParser._
+import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import v5.retrieveForeignPropertyBsas.models.{RetrieveForeignPropertyBsasRequestData, RetrieveForeignPropertyBsasResponse}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class RetrieveForeignPropertyBsasConnector @Inject() (val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+
+  def retrieveForeignPropertyBsas(request: RetrieveForeignPropertyBsasRequestData)(implicit
+      hc: HeaderCarrier,
+      ec: ExecutionContext,
+      correlationId: String): Future[DownstreamOutcome[RetrieveForeignPropertyBsasResponse]] = {
+
+    import request._
+    import schema._
+
+    val downstreamUri: DownstreamUri[DownstreamResp] = taxYear match {
+      case Some(ty) if ty.useTaxYearSpecificApi =>
+        TaxYearSpecificIfsUri(s"income-tax/adjustable-summary-calculation/${ty.asTysDownstream}/$nino/$calculationId")
+      case _ =>
+        IfsUri(s"income-tax/adjustable-summary-calculation/$nino/$calculationId")
+    }
+
+    get(downstreamUri)
+  }
+
+}

--- a/app/v5/retrieveForeignPropertyBsas/controllers/RetrieveForeignPropertyBsasController.scala
+++ b/app/v5/retrieveForeignPropertyBsas/controllers/RetrieveForeignPropertyBsasController.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.controllers
+
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import shared.config.AppConfig
+import shared.controllers.{AuthorisedController, EndpointLogContext, RequestContext, RequestHandler}
+import shared.hateoas.HateoasFactory
+import shared.services.{EnrolmentsAuthService, MtdIdLookupService}
+import shared.utils.{IdGenerator, Logging}
+import v5.retrieveForeignPropertyBsas.models.RetrieveForeignPropertyHateoasData
+import v5.retrieveForeignPropertyBsas.schema.RetrieveForeignPropertyBsasSchema
+import v5.retrieveForeignPropertyBsas.services.RetrieveForeignPropertyBsasService
+import v5.retrieveForeignPropertyBsas.validators.RetrieveForeignPropertyBsasValidatorFactory
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class RetrieveForeignPropertyBsasController @Inject() (val authService: EnrolmentsAuthService,
+                                                       val lookupService: MtdIdLookupService,
+                                                       validatorFactory: RetrieveForeignPropertyBsasValidatorFactory,
+                                                       service: RetrieveForeignPropertyBsasService,
+                                                       hateoasFactory: HateoasFactory,
+                                                       cc: ControllerComponents,
+                                                       val idGenerator: IdGenerator)(implicit ec: ExecutionContext, appConfig: AppConfig)
+    extends AuthorisedController(cc)
+    with Logging {
+
+  implicit val endpointLogContext: EndpointLogContext =
+    EndpointLogContext(controllerName = "RetrieveForeignPropertyBsasController", endpointName = "retrieve")
+
+  def retrieve(nino: String, calculationId: String, taxYear: Option[String]): Action[AnyContent] =
+    authorisedAction(nino).async { implicit request =>
+      implicit val ctx: RequestContext = RequestContext.from(idGenerator, endpointLogContext)
+
+      val validator = validatorFactory.validator(nino, calculationId, taxYear, RetrieveForeignPropertyBsasSchema.schemaFor(taxYear))
+
+      val requestHandler =
+        RequestHandler
+          .withValidator(validator)
+          .withService(service.retrieveForeignPropertyBsas)
+          .withHateoasResultFrom(hateoasFactory)((parsedRequest, _) => RetrieveForeignPropertyHateoasData(nino, calculationId, parsedRequest.taxYear))
+
+      requestHandler.handleRequest()
+    }
+
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/RetrieveForeignPropertyBsasRequestData.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/RetrieveForeignPropertyBsasRequestData.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.retrieveForeignPropertyBsas.schema.RetrieveForeignPropertyBsasSchema
+
+trait RetrieveForeignPropertyBsasRequestData {
+  def nino: Nino
+  def calculationId: CalculationId
+  def taxYear: Option[TaxYear]
+
+  val schema: RetrieveForeignPropertyBsasSchema
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/RetrieveForeignPropertyBsasResponse.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/RetrieveForeignPropertyBsasResponse.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models
+
+import play.api.libs.json._
+import shared.config.AppConfig
+import shared.hateoas.{HateoasData, HateoasLinksFactory, Link}
+import shared.models.domain.TaxYear
+import v5.models.domain.HasTypeOfBusiness
+import v5.retrieveForeignPropertyBsas.models.def1.Def1_RetrieveForeignPropertyBsasResponse
+import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyBsasResponse._
+
+trait RetrieveForeignPropertyBsasResponse extends HasTypeOfBusiness
+
+object RetrieveForeignPropertyBsasResponse {
+
+  implicit val writes: OWrites[RetrieveForeignPropertyBsasResponse] = OWrites.apply[RetrieveForeignPropertyBsasResponse] {
+    case a: Def1_RetrieveForeignPropertyBsasResponse =>
+      implicitly[OWrites[Def1_RetrieveForeignPropertyBsasResponse]].writes(a)
+
+    case a: RetrieveForeignPropertyBsasResponse => throw new RuntimeException(s"No writes defined for type ${a.getClass.getName}")
+  }
+
+  implicit object RetrieveSelfAssessmentBsasHateoasFactory
+    extends HateoasLinksFactory[RetrieveForeignPropertyBsasResponse, RetrieveForeignPropertyHateoasData] {
+    override def links(appConfig: AppConfig, data: RetrieveForeignPropertyHateoasData): Seq[Link] = {
+      import data._
+
+      Seq(
+        getForeignPropertyBsas(appConfig, nino, calculationId, taxYear),
+        adjustForeignPropertyBsas(appConfig, nino, calculationId, taxYear)
+      )
+    }
+  }
+}
+
+case class RetrieveForeignPropertyHateoasData(nino: String, calculationId: String, taxYear: Option[TaxYear]) extends HateoasData

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/Adjustments.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/Adjustments.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class Adjustments(countryLevelDetail: Option[Seq[Adjustments]],
+                       countryCode: Option[String],
+                       income: Option[AdjustmentsIncome],
+                       expenses: Option[AdjustmentsExpenses])
+
+object Adjustments {
+
+  val readsFhl: Reads[Adjustments] = (
+    Reads.pure(None) and
+      Reads.pure(None) and
+      (JsPath \ "income").readNullable[AdjustmentsIncome](AdjustmentsIncome.readsFhl) and
+      (JsPath \ "expenses").readNullable[AdjustmentsExpenses](AdjustmentsExpenses.readsFhl)
+    ) (Adjustments.apply _)
+
+  val readsNonFhl: Reads[Adjustments] = (
+    Reads.pure(None) and
+      (JsPath \ "countryCode").readNullable[String] and
+      (JsPath \ "income").readNullable[AdjustmentsIncome](AdjustmentsIncome.readsNonFhl) and
+      (JsPath \ "expenses").readNullable[AdjustmentsExpenses](AdjustmentsExpenses.readsNonFhl)
+    ) (Adjustments.apply _)
+
+  val readsNonFhlSeq: Reads[Seq[Adjustments]] = Reads.traversableReads[Seq, Adjustments](implicitly, readsNonFhl)
+
+  implicit val writes: OWrites[Adjustments] = Json.writes[Adjustments]
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/AdjustmentsExpenses.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/AdjustmentsExpenses.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class AdjustmentsExpenses(consolidatedExpenses: Option[BigDecimal],
+                               premisesRunningCosts: Option[BigDecimal],
+                               repairsAndMaintenance: Option[BigDecimal],
+                               financialCosts: Option[BigDecimal],
+                               professionalFees: Option[BigDecimal],
+                               costOfServices: Option[BigDecimal],
+                               residentialFinancialCost: Option[BigDecimal],
+                               other: Option[BigDecimal],
+                               travelCosts: Option[BigDecimal],
+                              )
+
+object AdjustmentsExpenses {
+
+  val readsFhl: Reads[AdjustmentsExpenses] = (
+    (JsPath \ "consolidatedExpenses").readNullable[BigDecimal] and
+      (JsPath \ "premisesRunningCosts").readNullable[BigDecimal] and
+      (JsPath \ "repairsAndMaintenance").readNullable[BigDecimal] and
+      (JsPath \ "financialCosts").readNullable[BigDecimal] and
+      (JsPath \ "professionalFees").readNullable[BigDecimal] and
+      (JsPath \ "costOfServices").readNullable[BigDecimal] and
+      Reads.pure(None) and
+      (JsPath \ "other").readNullable[BigDecimal] and
+      (JsPath \ "travelCosts").readNullable[BigDecimal]
+    ) (AdjustmentsExpenses.apply _)
+
+  val readsNonFhl: Reads[AdjustmentsExpenses] = (
+    (JsPath \ "consolidatedExpenses").readNullable[BigDecimal] and
+      (JsPath \ "premisesRunningCosts").readNullable[BigDecimal] and
+      (JsPath \ "repairsAndMaintenance").readNullable[BigDecimal] and
+      (JsPath \ "financialCosts").readNullable[BigDecimal] and
+      (JsPath \ "professionalFees").readNullable[BigDecimal] and
+      (JsPath \ "costOfServices").readNullable[BigDecimal] and
+      (JsPath \ "residentialFinancialCost").readNullable[BigDecimal] and
+      (JsPath \ "other").readNullable[BigDecimal] and
+      (JsPath \ "travelCosts").readNullable[BigDecimal]
+    ) (AdjustmentsExpenses.apply _)
+
+  implicit val writes: OWrites[AdjustmentsExpenses] = Json.writes[AdjustmentsExpenses]
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/AdjustmentsIncome.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/AdjustmentsIncome.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class AdjustmentsIncome(totalRentsReceived: Option[BigDecimal],
+                             premiumsOfLeaseGrant: Option[BigDecimal],
+                             otherPropertyIncome: Option[BigDecimal])
+
+object AdjustmentsIncome {
+
+  val readsFhl: Reads[AdjustmentsIncome] = (
+    (JsPath \ "rent").readNullable[BigDecimal] and
+      Reads.pure(None) and
+      Reads.pure(None)
+    ) (AdjustmentsIncome.apply _)
+
+  val readsNonFhl: Reads[AdjustmentsIncome] = (
+    (JsPath \ "rentReceived").readNullable[BigDecimal] and
+      (JsPath \ "premiumsOfLeaseGrant").readNullable[BigDecimal] and
+      (JsPath \ "otherPropertyIncome").readNullable[BigDecimal]
+    ) (AdjustmentsIncome.apply _)
+
+  implicit val writes: OWrites[AdjustmentsIncome] = Json.writes[AdjustmentsIncome]
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/Def1_RetrieveForeignPropertyBsasRequestData.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/Def1_RetrieveForeignPropertyBsasRequestData.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.retrieveForeignPropertyBsas.models.RetrieveForeignPropertyBsasRequestData
+import v5.retrieveForeignPropertyBsas.schema.RetrieveForeignPropertyBsasSchema
+
+case class Def1_RetrieveForeignPropertyBsasRequestData(nino: Nino, calculationId: CalculationId, taxYear: Option[TaxYear])
+    extends RetrieveForeignPropertyBsasRequestData {
+  val schema: RetrieveForeignPropertyBsasSchema = RetrieveForeignPropertyBsasSchema.Def1
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/Def1_RetrieveForeignPropertyBsasResponse.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/Def1_RetrieveForeignPropertyBsasResponse.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.json._
+import v5.models.domain.TypeOfBusiness
+import v5.retrieveForeignPropertyBsas.models.RetrieveForeignPropertyBsasResponse
+
+case class Def1_RetrieveForeignPropertyBsasResponse(metadata: Metadata,
+                                                    inputs: Inputs,
+                                                    adjustableSummaryCalculation: SummaryCalculation,
+                                                    adjustments: Option[Adjustments],
+                                                    adjustedSummaryCalculation: Option[SummaryCalculation])
+    extends RetrieveForeignPropertyBsasResponse {
+  override def typeOfBusiness: TypeOfBusiness = inputs.typeOfBusiness
+}
+
+object Def1_RetrieveForeignPropertyBsasResponse {
+
+  implicit val reads: Reads[Def1_RetrieveForeignPropertyBsasResponse] = (json: JsValue) =>
+    for {
+      metadata <- (json \ "metadata").validate[Metadata]
+      inputs   <- (json \ "inputs").validate[Inputs]
+
+      isFhl = inputs.typeOfBusiness == TypeOfBusiness.`foreign-property-fhl-eea`
+
+      adjustableSummaryCalculation <- (json \ "adjustableSummaryCalculation").validate[SummaryCalculation](
+        if (isFhl) SummaryCalculation.readsFhl else SummaryCalculation.readsNonFhl
+      )
+
+      adjustments <- if (isFhl) fhlEeaAdjustmentsReads(json) else nonFhlAdjustmentsReads(json)
+
+      adjustedSummaryCalculation <- (json \ "adjustedSummaryCalculation").validateOpt[SummaryCalculation](
+        if (isFhl) SummaryCalculation.readsFhl else SummaryCalculation.readsNonFhl
+      )
+    } yield Def1_RetrieveForeignPropertyBsasResponse(
+      metadata = metadata,
+      inputs = inputs,
+      adjustableSummaryCalculation = adjustableSummaryCalculation,
+      adjustments = adjustments,
+      adjustedSummaryCalculation = adjustedSummaryCalculation
+    )
+
+  private def fhlEeaAdjustmentsReads(json: JsValue): JsResult[Option[Adjustments]] =
+    (json \ "adjustments").validateOpt[Adjustments](Adjustments.readsFhl)
+
+  private def nonFhlAdjustmentsReads(json: JsValue): JsResult[Option[Adjustments]] =
+    (json \ "adjustments")
+      .validateOpt[Seq[Adjustments]](Adjustments.readsNonFhlSeq)
+      .map(s => Some(Adjustments(s, None, None, None)))
+      .orElse(JsSuccess(None)) // Not an array, e.g. typeOfBusiness is self-employment
+
+  implicit val writes: OWrites[Def1_RetrieveForeignPropertyBsasResponse] = Json.writes[Def1_RetrieveForeignPropertyBsasResponse]
+
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/Inputs.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/Inputs.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+import v5.models.domain.{IncomeSourceType, TypeOfBusiness}
+
+case class Inputs(businessId: String,
+                  typeOfBusiness: TypeOfBusiness,
+                  businessName: Option[String],
+                  accountingPeriodStartDate: String,
+                  accountingPeriodEndDate: String,
+                  source: String,
+                  submissionPeriods: Seq[SubmissionPeriods])
+
+object Inputs {
+  implicit val reads: Reads[Inputs] = (
+    (JsPath \ "incomeSourceId").read[String] and
+      (JsPath \ "incomeSourceType").read[IncomeSourceType].map(_.toTypeOfBusiness) and
+      (JsPath \ "incomeSourceName").readNullable[String] and
+      (JsPath \ "accountingPeriodStartDate").read[String] and
+      (JsPath \ "accountingPeriodEndDate").read[String] and
+      (JsPath \ "source").read[String] and
+      (JsPath \ "submissionPeriods").read[Seq[SubmissionPeriods]]
+    ) (Inputs.apply _)
+
+  implicit val writes: OWrites[Inputs] = Json.writes[Inputs]
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/Metadata.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/Metadata.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+import shared.models.domain.TaxYear
+
+case class Metadata(calculationId: String,
+                    requestedDateTime: String,
+                    adjustedDateTime: Option[String],
+                    nino: String,
+                    taxYear: String,
+                    summaryStatus: String)
+
+object Metadata {
+  implicit val reads: Reads[Metadata] = ((JsPath \ "calculationId").read[String] and
+    (JsPath \ "requestedDateTime").read[String] and
+    (JsPath \ "adjustedDateTime").readNullable[String] and
+    (JsPath \ "taxableEntityId").read[String] and
+    (JsPath \ "taxYear").read[Int].map(TaxYear.fromDownstreamInt(_).asMtd) and
+    (JsPath \ "status").read[String]) (Metadata.apply _)
+
+  implicit val writes: OWrites[Metadata] = Json.writes[Metadata]
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/SubmissionPeriods.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/SubmissionPeriods.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class SubmissionPeriods(submissionId: String, startDate: String, endDate: String, receivedDateTime: String)
+
+object SubmissionPeriods {
+  implicit val reads: Reads[SubmissionPeriods] = ((JsPath \ "periodId").read[String] and
+    (JsPath \ "startDate").read[String] and
+    (JsPath \ "endDate").read[String] and
+    (JsPath \ "receivedDateTime").read[String]) (SubmissionPeriods.apply _)
+
+  implicit val writes: OWrites[SubmissionPeriods] = Json.writes[SubmissionPeriods]
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculation.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculation.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class SummaryCalculation(totalIncome: Option[BigDecimal],
+                              income: Option[SummaryCalculationIncome],
+                              totalExpenses: Option[BigDecimal],
+                              expenses: Option[SummaryCalculationExpenses],
+                              netProfit: Option[BigDecimal],
+                              netLoss: Option[BigDecimal],
+                              totalAdditions: Option[BigDecimal],
+                              additions: Option[SummaryCalculationAdditions],
+                              totalDeductions: Option[BigDecimal],
+                              deductions: Option[SummaryCalculationDeductions],
+                              taxableProfit: Option[BigDecimal],
+                              adjustedIncomeTaxLoss: Option[BigDecimal],
+                              countryLevelDetail: Option[Seq[SummaryCalculationCountryLevelDetail]])
+
+object SummaryCalculation {
+
+  val readsFhl: Reads[SummaryCalculation] = (
+    (JsPath \ "totalIncome").readNullable[BigDecimal] and
+      (JsPath \ "income").readNullable[SummaryCalculationIncome](SummaryCalculationIncome.readsFhl) and
+      (JsPath \ "totalExpenses").readNullable[BigDecimal] and
+      (JsPath \ "expenses").readNullable[SummaryCalculationExpenses] and
+      (JsPath \ "netProfit").readNullable[BigDecimal] and
+      (JsPath \ "netLoss").readNullable[BigDecimal] and
+      (JsPath \ "totalAdditions").readNullable[BigDecimal] and
+      (JsPath \ "additions").readNullable[SummaryCalculationAdditions] and
+      (JsPath \ "totalDeductions").readNullable[BigDecimal] and
+      (JsPath \ "deductions").readNullable[SummaryCalculationDeductions](SummaryCalculationDeductions.readsFhl) and
+      (JsPath \ "taxableProfit").readNullable[BigDecimal] and
+      (JsPath \ "adjustedIncomeTaxLoss").readNullable[BigDecimal] and
+      Reads.pure(None)
+    ) (SummaryCalculation.apply _)
+
+  val readsNonFhl: Reads[SummaryCalculation] = (
+    (JsPath \ "totalIncome").readNullable[BigDecimal] and
+      (JsPath \ "income").readNullable[SummaryCalculationIncome](SummaryCalculationIncome.readsNonFhl) and
+      (JsPath \ "totalExpenses").readNullable[BigDecimal] and
+      (JsPath \ "expenses").readNullable[SummaryCalculationExpenses] and
+      (JsPath \ "netProfit").readNullable[BigDecimal] and
+      (JsPath \ "netLoss").readNullable[BigDecimal] and
+      (JsPath \ "totalAdditions").readNullable[BigDecimal] and
+      (JsPath \ "additions").readNullable[SummaryCalculationAdditions] and
+      (JsPath \ "totalDeductions").readNullable[BigDecimal] and
+      (JsPath \ "deductions").readNullable[SummaryCalculationDeductions](SummaryCalculationDeductions.readsNonFhl) and
+      (JsPath \ "taxableProfit").readNullable[BigDecimal] and
+      (JsPath \ "adjustedIncomeTaxLoss").readNullable[BigDecimal] and
+      (JsPath \ "countryLevelDetail").readNullable[Seq[SummaryCalculationCountryLevelDetail]]
+    ) (SummaryCalculation.apply _)
+
+  implicit val writes: OWrites[SummaryCalculation] = Json.writes[SummaryCalculation]
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationAdditions.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationAdditions.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{Json, OWrites, Reads}
+
+case class SummaryCalculationAdditions(privateUseAdjustment: Option[BigDecimal], balancingCharge: Option[BigDecimal])
+
+object SummaryCalculationAdditions {
+  implicit val reads: Reads[SummaryCalculationAdditions] = Json.reads[SummaryCalculationAdditions]
+
+  implicit val writes: OWrites[SummaryCalculationAdditions] = Json.writes[SummaryCalculationAdditions]
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationCountryLevelDetail.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationCountryLevelDetail.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class SummaryCalculationCountryLevelDetail(countryCode: String,
+                                                totalIncome: Option[BigDecimal],
+                                                income: Option[SummaryCalculationIncome],
+                                                totalExpenses: Option[BigDecimal],
+                                                expenses: Option[SummaryCalculationExpenses],
+                                                netProfit: Option[BigDecimal],
+                                                netLoss: Option[BigDecimal],
+                                                totalAdditions: Option[BigDecimal],
+                                                additions: Option[SummaryCalculationAdditions],
+                                                totalDeductions: Option[BigDecimal],
+                                                deductions: Option[SummaryCalculationDeductions],
+                                                taxableProfit: Option[BigDecimal],
+                                                adjustedIncomeTaxLoss: Option[BigDecimal])
+
+object SummaryCalculationCountryLevelDetail {
+  implicit val reads: Reads[SummaryCalculationCountryLevelDetail] = (
+    (JsPath \ "countryCode").read[String] and
+      (JsPath \ "totalIncome").readNullable[BigDecimal] and
+      (JsPath \ "income").readNullable[SummaryCalculationIncome](SummaryCalculationIncome.readsNonFhl) and
+      (JsPath \ "totalExpenses").readNullable[BigDecimal] and
+      (JsPath \ "expenses").readNullable[SummaryCalculationExpenses] and
+      (JsPath \ "netProfit").readNullable[BigDecimal] and
+      (JsPath \ "netLoss").readNullable[BigDecimal] and
+      (JsPath \ "totalAdditions").readNullable[BigDecimal] and
+      (JsPath \ "additions").readNullable[SummaryCalculationAdditions] and
+      (JsPath \ "totalDeductions").readNullable[BigDecimal] and
+      (JsPath \ "deductions").readNullable[SummaryCalculationDeductions](SummaryCalculationDeductions.readsNonFhl) and
+      (JsPath \ "taxableProfit").readNullable[BigDecimal] and
+      (JsPath \ "adjustedIncomeTaxLoss").readNullable[BigDecimal]
+    ) (SummaryCalculationCountryLevelDetail.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationCountryLevelDetail] = Json.writes[SummaryCalculationCountryLevelDetail]
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationDeductions.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationDeductions.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class SummaryCalculationDeductions(annualInvestmentAllowance: Option[BigDecimal],
+                                        costOfReplacingDomesticItems: Option[BigDecimal],
+                                        zeroEmissionGoods: Option[BigDecimal],
+                                        propertyAllowance: Option[BigDecimal],
+                                        otherCapitalAllowance: Option[BigDecimal],
+                                        electricChargePointAllowance: Option[BigDecimal],
+                                        structuredBuildingAllowance: Option[BigDecimal],
+                                        zeroEmissionsCarAllowance: Option[BigDecimal])
+
+object SummaryCalculationDeductions {
+
+  val readsFhl: Reads[SummaryCalculationDeductions] = (
+    (JsPath \ "annualInvestmentAllowance").readNullable[BigDecimal] and
+      Reads.pure(None) and
+      Reads.pure(None) and
+      (JsPath \ "propertyAllowance").readNullable[BigDecimal] and
+      (JsPath \ "otherCapitalAllowance").readNullable[BigDecimal] and
+      (JsPath \ "electricChargePointAllowance").readNullable[BigDecimal] and
+      Reads.pure(None) and
+      (JsPath \ "zeroEmissionsCarAllowance").readNullable[BigDecimal]
+    ) (SummaryCalculationDeductions.apply _)
+
+  val readsNonFhl: Reads[SummaryCalculationDeductions] = (
+    (JsPath \ "annualInvestmentAllowance").readNullable[BigDecimal] and
+      (JsPath \ "costOfReplacingDomesticItems").readNullable[BigDecimal] and
+      (JsPath \ "zeroEmissionsGoodsVehicleAllowance").readNullable[BigDecimal] and
+      (JsPath \ "propertyAllowance").readNullable[BigDecimal] and
+      (JsPath \ "otherCapitalAllowance").readNullable[BigDecimal] and
+      (JsPath \ "electricChargePointAllowance").readNullable[BigDecimal] and
+      (JsPath \ "structuredBuildingAllowance").readNullable[BigDecimal] and
+      (JsPath \ "zeroEmissionsCarAllowance").readNullable[BigDecimal]
+    ) (SummaryCalculationDeductions.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationDeductions] = Json.writes[SummaryCalculationDeductions]
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationExpenses.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationExpenses.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{Json, OWrites, Reads}
+
+case class SummaryCalculationExpenses(consolidatedExpenses: Option[BigDecimal],
+                                      premisesRunningCosts: Option[BigDecimal],
+                                      repairsAndMaintenance: Option[BigDecimal],
+                                      financialCosts: Option[BigDecimal],
+                                      professionalFees: Option[BigDecimal],
+                                      costOfServices: Option[BigDecimal],
+                                      residentialFinancialCost: Option[BigDecimal],
+                                      broughtFwdResidentialFinancialCost: Option[BigDecimal],
+                                      other: Option[BigDecimal],
+                                      travelCosts: Option[BigDecimal],
+                                     )
+
+object SummaryCalculationExpenses {
+  implicit val reads: Reads[SummaryCalculationExpenses] = Json.reads[SummaryCalculationExpenses]
+
+  implicit val writes: OWrites[SummaryCalculationExpenses] = Json.writes[SummaryCalculationExpenses]
+}

--- a/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationIncome.scala
+++ b/app/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationIncome.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class SummaryCalculationIncome(totalRentsReceived: Option[BigDecimal],
+                                    premiumsOfLeaseGrant: Option[BigDecimal],
+                                    otherPropertyIncome: Option[BigDecimal])
+
+object SummaryCalculationIncome {
+
+  val readsFhl: Reads[SummaryCalculationIncome] = (
+    (JsPath \ "rent").readNullable[BigDecimal] and
+      Reads.pure(None) and
+      Reads.pure(None)
+    ) (SummaryCalculationIncome.apply _)
+
+  val readsNonFhl: Reads[SummaryCalculationIncome] = (
+    (JsPath \ "rent").readNullable[BigDecimal] and
+      (JsPath \ "premiumsOfLeaseGrant").readNullable[BigDecimal] and
+      (JsPath \ "otherPropertyIncome").readNullable[BigDecimal]
+    ) (SummaryCalculationIncome.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationIncome] = Json.writes[SummaryCalculationIncome]
+}

--- a/app/v5/retrieveForeignPropertyBsas/schema/RetrieveForeignPropertyBsasSchema.scala
+++ b/app/v5/retrieveForeignPropertyBsas/schema/RetrieveForeignPropertyBsasSchema.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.schema
+
+import play.api.libs.json.Reads
+import shared.controllers.validators.resolvers.ResolveTaxYear
+import shared.models.domain.TaxYear
+import v5.retrieveForeignPropertyBsas.models.RetrieveForeignPropertyBsasResponse
+import v5.retrieveForeignPropertyBsas.models.def1.Def1_RetrieveForeignPropertyBsasResponse
+import v5.schema.DownstreamReadable
+
+import scala.math.Ordered.orderingToOrdered
+
+sealed trait RetrieveForeignPropertyBsasSchema extends DownstreamReadable[RetrieveForeignPropertyBsasResponse]
+
+object RetrieveForeignPropertyBsasSchema {
+
+  case object Def1 extends RetrieveForeignPropertyBsasSchema {
+    type DownstreamResp = Def1_RetrieveForeignPropertyBsasResponse
+    val connectorReads: Reads[DownstreamResp] = Def1_RetrieveForeignPropertyBsasResponse.reads
+  }
+
+  private val defaultSchema = Def1
+
+  def schemaFor(maybeTaxYear: Option[String]): RetrieveForeignPropertyBsasSchema = {
+    maybeTaxYear
+      .map(ResolveTaxYear.resolver)
+      .flatMap(_.toOption.map(schemaFor))
+      .getOrElse(defaultSchema)
+  }
+
+  def schemaFor(taxYear: TaxYear): RetrieveForeignPropertyBsasSchema = {
+    if (TaxYear.starting(2023) <= taxYear) {
+      Def1
+    } else {
+      defaultSchema
+    }
+  }
+
+}

--- a/app/v5/retrieveForeignPropertyBsas/services/RetrieveForeignPropertyBsasService.scala
+++ b/app/v5/retrieveForeignPropertyBsas/services/RetrieveForeignPropertyBsasService.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.services
+
+import cats.data.EitherT
+import cats.implicits._
+import shared.controllers.RequestContext
+import shared.models.errors._
+import shared.services.ServiceOutcome
+import v5.models.domain.TypeOfBusiness
+import v5.retrieveForeignPropertyBsas.connectors.RetrieveForeignPropertyBsasConnector
+import v5.retrieveForeignPropertyBsas.models.{RetrieveForeignPropertyBsasRequestData, RetrieveForeignPropertyBsasResponse}
+import v5.services.BaseRetrieveBsasService
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class RetrieveForeignPropertyBsasService @Inject()(connector: RetrieveForeignPropertyBsasConnector) extends BaseRetrieveBsasService {
+
+  protected val supportedTypesOfBusiness: Set[TypeOfBusiness] = Set(TypeOfBusiness.`foreign-property`, TypeOfBusiness.`foreign-property-fhl-eea`)
+  private val errorMap: Map[String, MtdError] = {
+    val errors = Map(
+      "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+      "INVALID_CALCULATION_ID" -> CalculationIdFormatError,
+      "INVALID_RETURN" -> InternalError,
+      "INVALID_CORRELATIONID" -> InternalError,
+      "NO_DATA_FOUND" -> NotFoundError,
+      "UNPROCESSABLE_ENTITY" -> InternalError,
+      "SERVER_ERROR" -> InternalError,
+      "SERVICE_UNAVAILABLE" -> InternalError
+    )
+
+    val extraTysErrors: Map[String, MtdError] = Map(
+      "INVALID_TAX_YEAR" -> TaxYearFormatError,
+      "NOT_FOUND" -> NotFoundError,
+      "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError
+    )
+
+    errors ++ extraTysErrors
+  }
+
+  def retrieveForeignPropertyBsas(request: RetrieveForeignPropertyBsasRequestData)(
+    implicit ctx: RequestContext,
+    ec: ExecutionContext): Future[ServiceOutcome[RetrieveForeignPropertyBsasResponse]] = {
+
+    val result = for {
+      desResponseWrapper <- EitherT(connector.retrieveForeignPropertyBsas(request)).leftMap(mapDownstreamErrors(errorMap))
+      mtdResponseWrapper <- EitherT.fromEither[Future](validateTypeOfBusiness(desResponseWrapper))
+    } yield mtdResponseWrapper
+
+    result.value
+  }
+}

--- a/app/v5/retrieveForeignPropertyBsas/validators/RetrieveForeignPropertyBsasValidatorFactory.scala
+++ b/app/v5/retrieveForeignPropertyBsas/validators/RetrieveForeignPropertyBsasValidatorFactory.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.validators
+
+import shared.controllers.validators.Validator
+import v5.retrieveForeignPropertyBsas.models.RetrieveForeignPropertyBsasRequestData
+import v5.retrieveForeignPropertyBsas.schema.RetrieveForeignPropertyBsasSchema
+import v5.retrieveForeignPropertyBsas.schema.RetrieveForeignPropertyBsasSchema._
+import v5.retrieveForeignPropertyBsas.validators.def1.Def1_RetrieveForeignPropertyBsasValidator
+
+import javax.inject.Singleton
+
+@Singleton
+class RetrieveForeignPropertyBsasValidatorFactory {
+
+  def validator(nino: String,
+                calculationId: String,
+                taxYear: Option[String],
+                schema: RetrieveForeignPropertyBsasSchema): Validator[RetrieveForeignPropertyBsasRequestData] =
+    schema match {
+      case Def1 => new Def1_RetrieveForeignPropertyBsasValidator(nino, calculationId, taxYear)
+    }
+
+}
+
+

--- a/app/v5/retrieveForeignPropertyBsas/validators/def1/Def1_RetrieveForeignPropertyBsasValidator.scala
+++ b/app/v5/retrieveForeignPropertyBsas/validators/def1/Def1_RetrieveForeignPropertyBsasValidator.scala
@@ -25,11 +25,13 @@ import shared.models.errors.MtdError
 import v5.retrieveForeignPropertyBsas.models.RetrieveForeignPropertyBsasRequestData
 import v5.retrieveForeignPropertyBsas.models.def1.Def1_RetrieveForeignPropertyBsasRequestData
 
-class Def1_RetrieveForeignPropertyBsasValidator(nino: String, calculationId: String, taxYear: Option[String])
-    extends Validator[RetrieveForeignPropertyBsasRequestData]
-    with ResolverSupport {
-
+object Def1_RetrieveForeignPropertyBsasValidator extends ResolverSupport {
   private val resolveTysTaxYear = ResolveTysTaxYear.resolver.resolveOptionally
+}
+
+class Def1_RetrieveForeignPropertyBsasValidator(nino: String, calculationId: String, taxYear: Option[String])
+    extends Validator[RetrieveForeignPropertyBsasRequestData] {
+  import Def1_RetrieveForeignPropertyBsasValidator._
 
   def validate: Validated[Seq[MtdError], RetrieveForeignPropertyBsasRequestData] =
     (

--- a/app/v5/retrieveForeignPropertyBsas/validators/def1/Def1_RetrieveForeignPropertyBsasValidator.scala
+++ b/app/v5/retrieveForeignPropertyBsas/validators/def1/Def1_RetrieveForeignPropertyBsasValidator.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.validators.def1
+
+import cats.data.Validated
+import cats.data.Validated._
+import cats.implicits._
+import shared.controllers.validators.Validator
+import shared.controllers.validators.resolvers.{ResolveCalculationId, ResolveNino, ResolveTysTaxYear, ResolverSupport}
+import shared.models.errors.MtdError
+import v5.retrieveForeignPropertyBsas.models.RetrieveForeignPropertyBsasRequestData
+import v5.retrieveForeignPropertyBsas.models.def1.Def1_RetrieveForeignPropertyBsasRequestData
+
+class Def1_RetrieveForeignPropertyBsasValidator(nino: String, calculationId: String, taxYear: Option[String])
+    extends Validator[RetrieveForeignPropertyBsasRequestData]
+    with ResolverSupport {
+
+  private val resolveTysTaxYear = ResolveTysTaxYear.resolver.resolveOptionally
+
+  def validate: Validated[Seq[MtdError], RetrieveForeignPropertyBsasRequestData] =
+    (
+      ResolveNino(nino),
+      ResolveCalculationId(calculationId),
+      resolveTysTaxYear(taxYear)
+    ).mapN(Def1_RetrieveForeignPropertyBsasRequestData)
+
+}

--- a/app/v5/retrieveSelfEmploymentBsas/connectors/RetrieveSelfEmploymentBsasConnector.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/connectors/RetrieveSelfEmploymentBsasConnector.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.connectors
+
+import shared.config.AppConfig
+import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.httpparsers.StandardDownstreamHttpParser._
+import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import v5.retrieveSelfEmploymentBsas.models.{RetrieveSelfEmploymentBsasRequestData, RetrieveSelfEmploymentBsasResponse}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class RetrieveSelfEmploymentBsasConnector @Inject() (val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+
+  def retrieveSelfEmploymentBsas(request: RetrieveSelfEmploymentBsasRequestData)(implicit
+      hc: HeaderCarrier,
+      ec: ExecutionContext,
+      correlationId: String): Future[DownstreamOutcome[RetrieveSelfEmploymentBsasResponse]] = {
+
+    import request._
+    import schema._
+
+    val downstreamUri: DownstreamUri[DownstreamResp] = taxYear match {
+      case Some(taxYear) =>
+        TaxYearSpecificIfsUri(s"income-tax/adjustable-summary-calculation/${taxYear.asTysDownstream}/$nino/$calculationId")
+      case None =>
+        IfsUri(s"income-tax/adjustable-summary-calculation/$nino/$calculationId")
+    }
+
+    get(downstreamUri)
+  }
+
+}

--- a/app/v5/retrieveSelfEmploymentBsas/controllers/RetrieveSelfEmploymentBsasController.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/controllers/RetrieveSelfEmploymentBsasController.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.controllers
+
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import shared.config.AppConfig
+import shared.controllers.{AuthorisedController, EndpointLogContext, RequestContext, RequestHandler}
+import shared.hateoas.HateoasFactory
+import shared.services.{EnrolmentsAuthService, MtdIdLookupService}
+import shared.utils.{IdGenerator, Logging}
+import v5.retrieveSelfEmploymentBsas.models.RetrieveSelfEmploymentBsasHateoasData
+import v5.retrieveSelfEmploymentBsas.schema.RetrieveSelfEmploymentBsasSchema
+import v5.retrieveSelfEmploymentBsas.services.RetrieveSelfEmploymentBsasService
+import v5.retrieveSelfEmploymentBsas.validators.RetrieveSelfEmploymentBsasValidatorFactory
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class RetrieveSelfEmploymentBsasController @Inject() (val authService: EnrolmentsAuthService,
+                                                      val lookupService: MtdIdLookupService,
+                                                      validatorFactory: RetrieveSelfEmploymentBsasValidatorFactory,
+                                                      service: RetrieveSelfEmploymentBsasService,
+                                                      hateoasFactory: HateoasFactory,
+                                                      cc: ControllerComponents,
+                                                      val idGenerator: IdGenerator)(implicit ec: ExecutionContext, appConfig: AppConfig)
+    extends AuthorisedController(cc)
+    with Logging {
+
+  implicit val endpointLogContext: EndpointLogContext =
+    EndpointLogContext(controllerName = "RetrieveSelfEmploymentBsasController", endpointName = "retrieve")
+
+  def handleRequest(nino: String, calculationId: String, taxYear: Option[String] = None): Action[AnyContent] =
+    authorisedAction(nino).async { implicit request =>
+      implicit val ctx: RequestContext = RequestContext.from(idGenerator, endpointLogContext)
+
+      val validator = validatorFactory.validator(nino, calculationId, taxYear, RetrieveSelfEmploymentBsasSchema.schemaFor(taxYear))
+
+      val requestHandler =
+        RequestHandler
+          .withValidator(validator)
+          .withService(service.retrieveSelfEmploymentBsas)
+          .withHateoasResultFrom(hateoasFactory)((parsedRequest, _) =>
+            RetrieveSelfEmploymentBsasHateoasData(nino, calculationId, parsedRequest.taxYear))
+
+      requestHandler.handleRequest()
+    }
+
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/RetrieveSelfEmploymentBsasRequestData.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/RetrieveSelfEmploymentBsasRequestData.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.retrieveSelfEmploymentBsas.schema.RetrieveSelfEmploymentBsasSchema
+
+
+trait RetrieveSelfEmploymentBsasRequestData {
+  def nino: Nino
+  def calculationId: CalculationId
+  def taxYear: Option[TaxYear]
+
+  val schema: RetrieveSelfEmploymentBsasSchema
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/RetrieveSelfEmploymentBsasResponse.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/RetrieveSelfEmploymentBsasResponse.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models
+
+import play.api.libs.json._
+import shared.config.AppConfig
+import shared.hateoas.{HateoasData, HateoasLinksFactory, Link}
+import shared.models.domain.TaxYear
+import v5.hateoas.HateoasLinks
+import v5.models.domain.HasTypeOfBusiness
+import v5.retrieveSelfEmploymentBsas.models.def1.Def1_RetrieveSelfEmploymentBsasResponse
+
+trait RetrieveSelfEmploymentBsasResponse extends HasTypeOfBusiness
+
+object RetrieveSelfEmploymentBsasResponse extends HateoasLinks {
+
+  implicit val writes: OWrites[RetrieveSelfEmploymentBsasResponse] = OWrites.apply[RetrieveSelfEmploymentBsasResponse] {
+    case a: Def1_RetrieveSelfEmploymentBsasResponse =>
+      implicitly[OWrites[Def1_RetrieveSelfEmploymentBsasResponse]].writes(a)
+
+    case a: RetrieveSelfEmploymentBsasResponse => throw new RuntimeException(s"No writes defined for type ${a.getClass.getName}")
+  }
+
+  implicit object RetrieveSelfAssessmentBsasHateoasFactory
+      extends HateoasLinksFactory[RetrieveSelfEmploymentBsasResponse, RetrieveSelfEmploymentBsasHateoasData] {
+
+    override def links(appConfig: AppConfig, data: RetrieveSelfEmploymentBsasHateoasData): Seq[Link] = {
+      import data._
+
+      Seq(
+        getSelfEmploymentBsas(appConfig, nino, bsasId, taxYear),
+        adjustSelfEmploymentBsas(appConfig, nino, bsasId, taxYear)
+      )
+    }
+
+  }
+
+}
+
+case class RetrieveSelfEmploymentBsasHateoasData(nino: String, bsasId: String, taxYear: Option[TaxYear]) extends HateoasData

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/AdjustableSummaryCalculation.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/AdjustableSummaryCalculation.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json._
+
+case class AdjustableSummaryCalculation(
+                                         totalIncome: Option[BigDecimal],
+                                         income: Option[SummaryCalculationIncome],
+                                         totalExpenses: Option[BigDecimal],
+                                         expenses: Option[SummaryCalculationExpenses],
+                                         netProfit: Option[BigDecimal],
+                                         netLoss: Option[BigDecimal],
+                                         totalAdditions: Option[BigDecimal],
+                                         additions: Option[SummaryCalculationAdditions],
+                                         totalDeductions: Option[BigDecimal],
+                                         deductions: Option[SummaryCalculationDeductions],
+                                         totalAccountingAdjustments: Option[BigDecimal],
+                                         accountingAdjustments: Option[SummaryCalculationAccountingAdjustments],
+                                         taxableProfit: Option[BigDecimal],
+                                         adjustedIncomeTaxLoss: Option[BigDecimal],
+                                       )
+
+object AdjustableSummaryCalculation {
+  implicit val reads: Reads[AdjustableSummaryCalculation] = summaryCalculationReads(AdjustableSummaryCalculation.apply _)
+
+  implicit val writes: OWrites[AdjustableSummaryCalculation] = Json.writes[AdjustableSummaryCalculation]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/AdjustedSummaryCalculation.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/AdjustedSummaryCalculation.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json._
+
+case class AdjustedSummaryCalculation(
+                                       totalIncome: Option[BigDecimal],
+                                       income: Option[SummaryCalculationIncome],
+                                       totalExpenses: Option[BigDecimal],
+                                       expenses: Option[SummaryCalculationExpenses],
+                                       netProfit: Option[BigDecimal],
+                                       netLoss: Option[BigDecimal],
+                                       totalAdditions: Option[BigDecimal],
+                                       additions: Option[SummaryCalculationAdditions],
+                                       totalDeductions: Option[BigDecimal],
+                                       deductions: Option[SummaryCalculationDeductions],
+                                       totalAccountingAdjustments: Option[BigDecimal],
+                                       accountingAdjustments: Option[SummaryCalculationAccountingAdjustments],
+                                       taxableProfit: Option[BigDecimal],
+                                       adjustedIncomeTaxLoss: Option[BigDecimal],
+                                     )
+
+object AdjustedSummaryCalculation {
+  implicit val reads: Reads[AdjustedSummaryCalculation] = summaryCalculationReads(AdjustedSummaryCalculation.apply _)
+
+  implicit val writes: OWrites[AdjustedSummaryCalculation] = Json.writes[AdjustedSummaryCalculation]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/Adjustments.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/Adjustments.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class Adjustments(
+                        income: Option[AdjustmentsIncome],
+                        expenses: Option[AdjustmentsExpenses],
+                        additions: Option[AdjustmentsAdditions],
+                      )
+
+object Adjustments {
+  implicit val reads: Reads[Adjustments] = (
+    (JsPath \ "income").readNullable[AdjustmentsIncome] and
+      (JsPath \ "expenses").readNullable[AdjustmentsExpenses] and
+      (JsPath \ "additions").readNullable[AdjustmentsAdditions]
+    ) (Adjustments.apply _)
+
+  implicit val writes: OWrites[Adjustments] = Json.writes[Adjustments]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsAdditions.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsAdditions.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class AdjustmentsAdditions(
+                                 costOfGoodsDisallowable: Option[BigDecimal],
+                                 paymentsToSubcontractorsDisallowable: Option[BigDecimal],
+                                 wagesAndStaffCostsDisallowable: Option[BigDecimal],
+                                 carVanTravelExpensesDisallowable: Option[BigDecimal],
+                                 premisesRunningCostsDisallowable: Option[BigDecimal],
+                                 maintenanceCostsDisallowable: Option[BigDecimal],
+                                 adminCostsDisallowable: Option[BigDecimal],
+                                 interestOnBankOtherLoansDisallowable: Option[BigDecimal],
+                                 financeChargesDisallowable: Option[BigDecimal],
+                                 irrecoverableDebtsDisallowable: Option[BigDecimal],
+                                 professionalFeesDisallowable: Option[BigDecimal],
+                                 depreciationDisallowable: Option[BigDecimal],
+                                 otherExpensesDisallowable: Option[BigDecimal],
+                                 advertisingCostsDisallowable: Option[BigDecimal],
+                                 businessEntertainmentCostsDisallowable: Option[BigDecimal],
+                               )
+
+object AdjustmentsAdditions {
+  implicit val reads: Reads[AdjustmentsAdditions] = (
+    (JsPath \ "costOfGoodsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "paymentsToSubcontractorsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "wagesAndStaffCostsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "carVanTravelExpensesDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "premisesRunningCostsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "maintenanceCostsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "adminCostsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "interestOnBankOtherLoansDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "financeChargesDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "irrecoverableDebtsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "professionalFeesDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "depreciationDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "otherExpensesDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "advertisingCostsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "businessEntertainmentCostsDisallowable").readNullable[BigDecimal]
+    ) (AdjustmentsAdditions.apply _)
+
+  implicit val writes: OWrites[AdjustmentsAdditions] = Json.writes[AdjustmentsAdditions]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsExpenses.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsExpenses.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class AdjustmentsExpenses(
+                                consolidatedExpenses: Option[BigDecimal],
+                                costOfGoodsAllowable: Option[BigDecimal],
+                                paymentsToSubcontractorsAllowable: Option[BigDecimal],
+                                wagesAndStaffCostsAllowable: Option[BigDecimal],
+                                carVanTravelExpensesAllowable: Option[BigDecimal],
+                                premisesRunningCostsAllowable: Option[BigDecimal],
+                                maintenanceCostsAllowable: Option[BigDecimal],
+                                adminCostsAllowable: Option[BigDecimal],
+                                interestOnBankOtherLoansAllowable: Option[BigDecimal],
+                                financeChargesAllowable: Option[BigDecimal],
+                                irrecoverableDebtsAllowable: Option[BigDecimal],
+                                professionalFeesAllowable: Option[BigDecimal],
+                                depreciationAllowable: Option[BigDecimal],
+                                otherExpensesAllowable: Option[BigDecimal],
+                                advertisingCostsAllowable: Option[BigDecimal],
+                                businessEntertainmentCostsAllowable: Option[BigDecimal],
+                              )
+
+object AdjustmentsExpenses {
+  implicit val reads: Reads[AdjustmentsExpenses] = (
+    (JsPath \ "consolidatedExpenses").readNullable[BigDecimal] and
+      (JsPath \ "costOfGoodsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "paymentsToSubcontractorsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "wagesAndStaffCostsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "carVanTravelExpensesAllowable").readNullable[BigDecimal] and
+      (JsPath \ "premisesRunningCostsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "maintenanceCostsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "adminCostsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "interestOnBankOtherLoansAllowable").readNullable[BigDecimal] and
+      (JsPath \ "financeChargesAllowable").readNullable[BigDecimal] and
+      (JsPath \ "irrecoverableDebtsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "professionalFeesAllowable").readNullable[BigDecimal] and
+      (JsPath \ "depreciationAllowable").readNullable[BigDecimal] and
+      (JsPath \ "otherExpensesAllowable").readNullable[BigDecimal] and
+      (JsPath \ "advertisingCostsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "businessEntertainmentCostsAllowable").readNullable[BigDecimal]
+    ) (AdjustmentsExpenses.apply _)
+
+  implicit val writes: OWrites[AdjustmentsExpenses] = Json.writes[AdjustmentsExpenses]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsIncome.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsIncome.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class AdjustmentsIncome(
+                              turnover: Option[BigDecimal],
+                              other: Option[BigDecimal],
+                            )
+
+object AdjustmentsIncome {
+  implicit val reads: Reads[AdjustmentsIncome] = (
+    (JsPath \ "turnover").readNullable[BigDecimal] and
+      (JsPath \ "other").readNullable[BigDecimal]
+    ) (AdjustmentsIncome.apply _)
+
+  implicit val writes: OWrites[AdjustmentsIncome] = Json.writes[AdjustmentsIncome]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/Def1_RetrieveSelfEmploymentBsasRequestData.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/Def1_RetrieveSelfEmploymentBsasRequestData.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.retrieveSelfEmploymentBsas.models.RetrieveSelfEmploymentBsasRequestData
+import v5.retrieveSelfEmploymentBsas.schema.RetrieveSelfEmploymentBsasSchema
+
+case class Def1_RetrieveSelfEmploymentBsasRequestData(nino: Nino, calculationId: CalculationId, taxYear: Option[TaxYear])
+  extends RetrieveSelfEmploymentBsasRequestData{
+  val schema: RetrieveSelfEmploymentBsasSchema = RetrieveSelfEmploymentBsasSchema.Def1
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/Def1_RetrieveSelfEmploymentBsasResponse.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/Def1_RetrieveSelfEmploymentBsasResponse.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import v5.hateoas.HateoasLinks
+import v5.models.domain.TypeOfBusiness
+import v5.retrieveSelfEmploymentBsas.models.RetrieveSelfEmploymentBsasResponse
+
+case class Def1_RetrieveSelfEmploymentBsasResponse(
+                                               metadata: Metadata,
+                                               inputs: Inputs,
+                                               adjustableSummaryCalculation: AdjustableSummaryCalculation,
+                                               adjustments: Option[Adjustments],
+                                               adjustedSummaryCalculation: Option[AdjustedSummaryCalculation]
+                                             ) extends RetrieveSelfEmploymentBsasResponse {
+  override def typeOfBusiness: TypeOfBusiness = inputs.typeOfBusiness
+}
+
+object Def1_RetrieveSelfEmploymentBsasResponse extends HateoasLinks {
+
+  implicit val reads: Reads[Def1_RetrieveSelfEmploymentBsasResponse] = (
+    (JsPath \ "metadata").read[Metadata] and
+      (JsPath \ "inputs").read[Inputs] and
+      (JsPath \ "adjustableSummaryCalculation").read[AdjustableSummaryCalculation] and
+      (JsPath \ "adjustments").readNullable[Adjustments] and
+      (JsPath \ "adjustedSummaryCalculation").readNullable[AdjustedSummaryCalculation]
+    ) (Def1_RetrieveSelfEmploymentBsasResponse.apply _)
+
+  implicit val writes: OWrites[Def1_RetrieveSelfEmploymentBsasResponse] = Json.writes
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/Inputs.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/Inputs.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
+import shared.models.domain.Source
+import v5.models.domain.{IncomeSourceType, TypeOfBusiness}
+
+case class Inputs(
+                   typeOfBusiness: TypeOfBusiness,
+                   businessId: String,
+                   businessName: Option[String],
+                   accountingPeriodStartDate: String,
+                   accountingPeriodEndDate: String,
+                   source: Source,
+                   submissionPeriods: Seq[SubmissionPeriod]
+                 )
+
+object Inputs {
+
+  implicit val reads: Reads[Inputs] = (
+    (JsPath \ "incomeSourceType").read[IncomeSourceType].map(_.toTypeOfBusiness) and
+      (JsPath \ "incomeSourceId").read[String] and
+      (JsPath \ "incomeSourceName").readNullable[String] and
+      (JsPath \ "accountingPeriodStartDate").read[String] and
+      (JsPath \ "accountingPeriodEndDate").read[String] and
+      (JsPath \ "source").read[Source] and
+      (JsPath \ "submissionPeriods").read[Seq[SubmissionPeriod]]
+    ) (Inputs.apply _)
+
+  implicit val writes: OWrites[Inputs] = Json.writes[Inputs]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/Metadata.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/Metadata.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import shared.models.domain.{Status, TaxYear}
+
+case class Metadata(
+    calculationId: String,
+    requestedDateTime: String,
+    adjustedDateTime: Option[String],
+    nino: String,
+    taxYear: String,
+    summaryStatus: Status
+)
+
+object Metadata {
+
+  implicit val reads: Reads[Metadata] = (
+    (JsPath \ "calculationId").read[String] and
+      (JsPath \ "requestedDateTime").read[String] and
+      (JsPath \ "adjustedDateTime").readNullable[String] and
+      (JsPath \ "taxableEntityId").read[String] and
+      (JsPath \ "taxYear").read[Int].map(taxYear => TaxYear.fromDownstreamInt(taxYear).asMtd) and
+      (JsPath \ "status").read[Status]
+  )(Metadata.apply _)
+
+  implicit val writes: OWrites[Metadata] = Json.writes[Metadata]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/SubmissionPeriod.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/SubmissionPeriod.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json._
+
+case class SubmissionPeriod(
+                             periodId: Option[String],
+                             submissionId: Option[String],
+                             startDate: String,
+                             endDate: String,
+                             receivedDateTime: String,
+                           )
+
+object SubmissionPeriod {
+
+  private val periodIdRegex = "^[0-9]{16}$"
+
+  implicit val reads: Reads[SubmissionPeriod] = (json: JsValue) => {
+    for {
+      startDate <- (json \ "startDate").validate[String]
+      endDate <- (json \ "endDate").validate[String]
+      receivedDateTime <- (json \ "receivedDateTime").validate[String]
+      id <- (json \ "periodId").validate[String]
+      (periodId, submissionId) = {
+        if (id.matches(periodIdRegex)) {
+          (Some(id), None)
+        } else {
+          (None, Some(s"${startDate}_$endDate"))
+        }
+      }
+    } yield {
+      SubmissionPeriod(periodId = periodId,
+        submissionId = submissionId,
+        startDate = startDate,
+        endDate = endDate,
+        receivedDateTime = receivedDateTime)
+    }
+  }
+
+  implicit val writes: OWrites[SubmissionPeriod] = Json.writes[SubmissionPeriod]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationAccountingAdjustments.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationAccountingAdjustments.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class SummaryCalculationAccountingAdjustments(
+                                                    basisAdjustment: Option[BigDecimal],
+                                                    overlapReliefUsed: Option[BigDecimal],
+                                                    accountingAdjustment: Option[BigDecimal],
+                                                    averagingAdjustment: Option[BigDecimal],
+                                                  )
+
+object SummaryCalculationAccountingAdjustments {
+  implicit val reads: Reads[SummaryCalculationAccountingAdjustments] = (
+    (JsPath \ "basisAdjustment").readNullable[BigDecimal] and
+      (JsPath \ "overlapReliefUsed").readNullable[BigDecimal] and
+      (JsPath \ "accountingAdjustment").readNullable[BigDecimal] and
+      (JsPath \ "averagingAdjustment").readNullable[BigDecimal]
+    ) (SummaryCalculationAccountingAdjustments.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationAccountingAdjustments] = Json.writes[SummaryCalculationAccountingAdjustments]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationAdditions.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationAdditions.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class SummaryCalculationAdditions(
+                                        costOfGoodsDisallowable: Option[BigDecimal],
+                                        paymentsToSubcontractorsDisallowable: Option[BigDecimal],
+                                        wagesAndStaffCostsDisallowable: Option[BigDecimal],
+                                        carVanTravelExpensesDisallowable: Option[BigDecimal],
+                                        premisesRunningCostsDisallowable: Option[BigDecimal],
+                                        maintenanceCostsDisallowable: Option[BigDecimal],
+                                        adminCostsDisallowable: Option[BigDecimal],
+                                        interestOnBankOtherLoansDisallowable: Option[BigDecimal],
+                                        financeChargesDisallowable: Option[BigDecimal],
+                                        irrecoverableDebtsDisallowable: Option[BigDecimal],
+                                        professionalFeesDisallowable: Option[BigDecimal],
+                                        depreciationDisallowable: Option[BigDecimal],
+                                        otherExpensesDisallowable: Option[BigDecimal],
+                                        advertisingCostsDisallowable: Option[BigDecimal],
+                                        businessEntertainmentCostsDisallowable: Option[BigDecimal],
+                                        outstandingBusinessIncome: Option[BigDecimal],
+                                        balancingChargeOther: Option[BigDecimal],
+                                        balancingChargeBpra: Option[BigDecimal],
+                                        goodsAndServicesOwnUse: Option[BigDecimal],
+                                      )
+
+object SummaryCalculationAdditions {
+  implicit val reads: Reads[SummaryCalculationAdditions] = (
+    (JsPath \ "costOfGoodsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "paymentsToSubcontractorsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "wagesAndStaffCostsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "carVanTravelExpensesDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "premisesRunningCostsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "maintenanceCostsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "adminCostsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "interestOnBankOtherLoansDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "financeChargesDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "irrecoverableDebtsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "professionalFeesDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "depreciationDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "otherExpensesDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "advertisingCostsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "businessEntertainmentCostsDisallowable").readNullable[BigDecimal] and
+      (JsPath \ "outstandingBusinessIncome").readNullable[BigDecimal] and
+      (JsPath \ "balancingChargeOther").readNullable[BigDecimal] and
+      (JsPath \ "balancingChargeBpra").readNullable[BigDecimal] and
+      (JsPath \ "goodAndServicesOwnUse").readNullable[BigDecimal]
+    ) (SummaryCalculationAdditions.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationAdditions] = Json.writes[SummaryCalculationAdditions]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationDeductions.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationDeductions.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class SummaryCalculationDeductions(
+                                         tradingAllowance: Option[BigDecimal],
+                                         annualInvestmentAllowance: Option[BigDecimal],
+                                         capitalAllowanceMainPool: Option[BigDecimal],
+                                         capitalAllowanceSpecialRatePool: Option[BigDecimal],
+                                         zeroEmissionGoods: Option[BigDecimal],
+                                         businessPremisesRenovationAllowance: Option[BigDecimal],
+                                         enhancedCapitalAllowance: Option[BigDecimal],
+                                         allowanceOnSales: Option[BigDecimal],
+                                         capitalAllowanceSingleAssetPool: Option[BigDecimal],
+                                         includedNonTaxableProfits: Option[BigDecimal],
+                                         electricChargePointAllowance: Option[BigDecimal],
+                                         structuredBuildingAllowance: Option[BigDecimal],
+                                         enhancedStructuredBuildingAllowance: Option[BigDecimal],
+                                         zeroEmissionsCarAllowance: Option[BigDecimal],
+                                       )
+
+object SummaryCalculationDeductions {
+  implicit val reads: Reads[SummaryCalculationDeductions] = (
+    (JsPath \ "tradingAllowance").readNullable[BigDecimal] and
+      (JsPath \ "annualInvestmentAllowance").readNullable[BigDecimal] and
+      (JsPath \ "capitalAllowanceMainPool").readNullable[BigDecimal] and
+      (JsPath \ "capitalAllowanceSpecialRatePool").readNullable[BigDecimal] and
+      (JsPath \ "zeroEmissionGoods").readNullable[BigDecimal] and
+      (JsPath \ "businessPremisesRenovationAllowance").readNullable[BigDecimal] and
+      (JsPath \ "enhancedCapitalAllowance").readNullable[BigDecimal] and
+      (JsPath \ "allowanceOnSales").readNullable[BigDecimal] and
+      (JsPath \ "capitalAllowanceSingleAssetPool").readNullable[BigDecimal] and
+      (JsPath \ "includedNonTaxableProfits").readNullable[BigDecimal] and
+      (JsPath \ "electricChargePointAllowance").readNullable[BigDecimal] and
+      (JsPath \ "structuredBuildingAllowance").readNullable[BigDecimal] and
+      (JsPath \ "enhancedStructuredBuildingAllowance").readNullable[BigDecimal] and
+      (JsPath \ "zeroEmissionsCarAllowance").readNullable[BigDecimal]
+    ) (SummaryCalculationDeductions.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationDeductions] = Json.writes[SummaryCalculationDeductions]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationExpenses.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationExpenses.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class SummaryCalculationExpenses(
+                                       consolidatedExpenses: Option[BigDecimal],
+                                       costOfGoodsAllowable: Option[BigDecimal],
+                                       paymentsToSubcontractorsAllowable: Option[BigDecimal],
+                                       wagesAndStaffCostsAllowable: Option[BigDecimal],
+                                       carVanTravelExpensesAllowable: Option[BigDecimal],
+                                       premisesRunningCostsAllowable: Option[BigDecimal],
+                                       maintenanceCostsAllowable: Option[BigDecimal],
+                                       adminCostsAllowable: Option[BigDecimal],
+                                       interestOnBankOtherLoansAllowable: Option[BigDecimal],
+                                       financeChargesAllowable: Option[BigDecimal],
+                                       irrecoverableDebtsAllowable: Option[BigDecimal],
+                                       professionalFeesAllowable: Option[BigDecimal],
+                                       depreciationAllowable: Option[BigDecimal],
+                                       otherExpensesAllowable: Option[BigDecimal],
+                                       advertisingCostsAllowable: Option[BigDecimal],
+                                       businessEntertainmentCostsAllowable: Option[BigDecimal],
+                                     )
+
+object SummaryCalculationExpenses {
+  implicit val reads: Reads[SummaryCalculationExpenses] = (
+    (JsPath \ "consolidatedExpenses").readNullable[BigDecimal] and
+      (JsPath \ "costOfGoodsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "paymentsToSubcontractorsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "wagesAndStaffCostsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "carVanTravelExpensesAllowable").readNullable[BigDecimal] and
+      (JsPath \ "premisesRunningCostsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "maintenanceCostsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "adminCostsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "interestOnBankOtherLoansAllowable").readNullable[BigDecimal] and
+      (JsPath \ "financeChargesAllowable").readNullable[BigDecimal] and
+      (JsPath \ "irrecoverableDebtsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "professionalFeesAllowable").readNullable[BigDecimal] and
+      (JsPath \ "depreciationAllowable").readNullable[BigDecimal] and
+      (JsPath \ "otherExpensesAllowable").readNullable[BigDecimal] and
+      (JsPath \ "advertisingCostsAllowable").readNullable[BigDecimal] and
+      (JsPath \ "businessEntertainmentCostsAllowable").readNullable[BigDecimal]
+    ) (SummaryCalculationExpenses.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationExpenses] = Json.writes[SummaryCalculationExpenses]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationIncome.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationIncome.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class SummaryCalculationIncome(
+                                     turnover: Option[BigDecimal],
+                                     other: Option[BigDecimal]
+                                   )
+
+object SummaryCalculationIncome {
+  implicit val reads: Reads[SummaryCalculationIncome] = (
+    (JsPath \ "turnover").readNullable[BigDecimal] and
+      (JsPath \ "other").readNullable[BigDecimal]
+    ) (SummaryCalculationIncome.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationIncome] = Json.writes[SummaryCalculationIncome]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/models/def1/def1.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/models/def1/def1.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models
+
+import play.api.libs.functional.FunctionalBuilder
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+package object def1 {
+
+  private type SummaryCalculationReads = FunctionalBuilder[Reads]#CanBuild14[Option[BigDecimal],
+    Option[SummaryCalculationIncome],
+    Option[BigDecimal],
+    Option[SummaryCalculationExpenses],
+    Option[BigDecimal],
+    Option[BigDecimal],
+    Option[BigDecimal],
+    Option[SummaryCalculationAdditions],
+    Option[BigDecimal],
+    Option[SummaryCalculationDeductions],
+    Option[BigDecimal],
+    Option[SummaryCalculationAccountingAdjustments],
+    Option[BigDecimal],
+    Option[BigDecimal]]
+
+  val summaryCalculationReads: SummaryCalculationReads =
+    (JsPath \ "totalIncome").readNullable[BigDecimal] and
+      (JsPath \ "income").readNullable[SummaryCalculationIncome] and
+      (JsPath \ "totalExpenses").readNullable[BigDecimal] and
+      (JsPath \ "expenses").readNullable[SummaryCalculationExpenses] and
+      (JsPath \ "netProfit").readNullable[BigDecimal] and
+      (JsPath \ "netLoss").readNullable[BigDecimal] and
+      (JsPath \ "totalAdditions").readNullable[BigDecimal] and
+      (JsPath \ "additions").readNullable[SummaryCalculationAdditions] and
+      (JsPath \ "totalDeductions").readNullable[BigDecimal] and
+      (JsPath \ "deductions").readNullable[SummaryCalculationDeductions] and
+      (JsPath \ "accountingAdjustments").readNullable[BigDecimal] and
+      (JsPath \ "selfEmploymentAccountingAdjustments").readNullable[SummaryCalculationAccountingAdjustments] and
+      (JsPath \ "taxableProfit").readNullable[BigDecimal] and
+      (JsPath \ "adjustedIncomeTaxLoss").readNullable[BigDecimal]
+}

--- a/app/v5/retrieveSelfEmploymentBsas/schema/RetrieveSelfEmploymentBsasSchema.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/schema/RetrieveSelfEmploymentBsasSchema.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.schema
+
+import play.api.libs.json.Reads
+import shared.controllers.validators.resolvers.ResolveTaxYear
+import shared.models.domain.TaxYear
+import v5.retrieveSelfEmploymentBsas.models.RetrieveSelfEmploymentBsasResponse
+import v5.retrieveSelfEmploymentBsas.models.def1.Def1_RetrieveSelfEmploymentBsasResponse
+import v5.schema.DownstreamReadable
+
+import scala.math.Ordered.orderingToOrdered
+
+sealed trait RetrieveSelfEmploymentBsasSchema extends DownstreamReadable[RetrieveSelfEmploymentBsasResponse]
+
+object RetrieveSelfEmploymentBsasSchema {
+
+  case object Def1 extends RetrieveSelfEmploymentBsasSchema {
+    type DownstreamResp = Def1_RetrieveSelfEmploymentBsasResponse
+    val connectorReads: Reads[DownstreamResp] = Def1_RetrieveSelfEmploymentBsasResponse.reads
+  }
+
+  private val defaultSchema = Def1
+
+  def schemaFor(maybeTaxYear: Option[String]): RetrieveSelfEmploymentBsasSchema = {
+    maybeTaxYear
+      .map(ResolveTaxYear.resolver)
+      .flatMap(_.toOption.map(schemaFor))
+      .getOrElse(defaultSchema)
+  }
+
+  def schemaFor(taxYear: TaxYear): RetrieveSelfEmploymentBsasSchema = {
+    if (TaxYear.starting(2023) <= taxYear) {
+      Def1
+    } else {
+      defaultSchema
+    }
+  }
+
+}

--- a/app/v5/retrieveSelfEmploymentBsas/services/RetrieveSelfEmploymentBsasService.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/services/RetrieveSelfEmploymentBsasService.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.services
+
+import cats.data.EitherT
+import cats.implicits._
+import shared.controllers.RequestContext
+import shared.models.errors._
+import shared.services.ServiceOutcome
+import v5.models.domain.TypeOfBusiness
+import v5.retrieveSelfEmploymentBsas.connectors.RetrieveSelfEmploymentBsasConnector
+import v5.retrieveSelfEmploymentBsas.models.{RetrieveSelfEmploymentBsasRequestData, RetrieveSelfEmploymentBsasResponse}
+import v5.services.BaseRetrieveBsasService
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class RetrieveSelfEmploymentBsasService @Inject()(connector: RetrieveSelfEmploymentBsasConnector) extends BaseRetrieveBsasService {
+
+  protected val supportedTypesOfBusiness: Set[TypeOfBusiness] = Set(TypeOfBusiness.`self-employment`)
+  private val errorMap: Map[String, MtdError] = {
+
+    val errors = Map(
+      "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+      "INVALID_CALCULATION_ID" -> CalculationIdFormatError,
+      "INVALID_CORRELATIONID" -> InternalError,
+      "INVALID_RETURN" -> InternalError,
+      "UNPROCESSABLE_ENTITY" -> InternalError,
+      "NO_DATA_FOUND" -> NotFoundError,
+      "SERVER_ERROR" -> InternalError,
+      "SERVICE_UNAVAILABLE" -> InternalError
+    )
+
+    val extraTysErrors = Map(
+      "INVALID_TAX_YEAR" -> TaxYearFormatError,
+      "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError,
+      "NOT_FOUND" -> NotFoundError,
+    )
+
+    errors ++ extraTysErrors
+  }
+
+  def retrieveSelfEmploymentBsas(request: RetrieveSelfEmploymentBsasRequestData)(
+    implicit ctx: RequestContext,
+    ec: ExecutionContext): Future[ServiceOutcome[RetrieveSelfEmploymentBsasResponse]] = {
+
+    val result = for {
+      responseWrapper <- EitherT(connector.retrieveSelfEmploymentBsas(request)).leftMap(mapDownstreamErrors(errorMap))
+      mtdResponseWrapper <- EitherT.fromEither[Future](validateTypeOfBusiness(responseWrapper))
+    } yield mtdResponseWrapper
+
+    result.value
+  }
+}

--- a/app/v5/retrieveSelfEmploymentBsas/validators/RetrieveSelfEmploymentBsasValidatorFactory.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/validators/RetrieveSelfEmploymentBsasValidatorFactory.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.validators
+
+import shared.controllers.validators.Validator
+import v5.retrieveSelfEmploymentBsas.models.RetrieveSelfEmploymentBsasRequestData
+import v5.retrieveSelfEmploymentBsas.schema.RetrieveSelfEmploymentBsasSchema
+import v5.retrieveSelfEmploymentBsas.schema.RetrieveSelfEmploymentBsasSchema._
+import v5.retrieveSelfEmploymentBsas.validators.def1.Def1_RetrieveSelfEmploymentBsasValidator
+
+import javax.inject.Singleton
+
+@Singleton
+class RetrieveSelfEmploymentBsasValidatorFactory {
+
+  def validator(nino: String,
+                calculationId: String,
+                taxYear: Option[String],
+                schema: RetrieveSelfEmploymentBsasSchema): Validator[RetrieveSelfEmploymentBsasRequestData] =
+    schema match {
+      case Def1 => new Def1_RetrieveSelfEmploymentBsasValidator(nino, calculationId, taxYear)
+    }
+
+}
+
+

--- a/app/v5/retrieveSelfEmploymentBsas/validators/def1/Def1_RetrieveSelfEmploymentBsasValidator.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/validators/def1/Def1_RetrieveSelfEmploymentBsasValidator.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.validators.def1
+
+import cats.data.Validated
+import cats.data.Validated._
+import cats.implicits._
+import shared.controllers.validators.Validator
+import shared.controllers.validators.resolvers.{ResolveCalculationId, ResolveNino, ResolveTysTaxYear, ResolverSupport}
+import shared.models.errors.MtdError
+import v5.retrieveSelfEmploymentBsas.models.RetrieveSelfEmploymentBsasRequestData
+import v5.retrieveSelfEmploymentBsas.models.def1.Def1_RetrieveSelfEmploymentBsasRequestData
+
+class Def1_RetrieveSelfEmploymentBsasValidator(nino: String, calculationId: String, taxYear: Option[String])
+    extends Validator[RetrieveSelfEmploymentBsasRequestData]
+    with ResolverSupport {
+  private val resolveTysTaxYear = ResolveTysTaxYear.resolver.resolveOptionally
+
+  def validate: Validated[Seq[MtdError], RetrieveSelfEmploymentBsasRequestData] =
+    (
+      ResolveNino(nino),
+      ResolveCalculationId(calculationId),
+      resolveTysTaxYear(taxYear)
+    ).mapN(Def1_RetrieveSelfEmploymentBsasRequestData)
+
+}

--- a/app/v5/retrieveSelfEmploymentBsas/validators/def1/Def1_RetrieveSelfEmploymentBsasValidator.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/validators/def1/Def1_RetrieveSelfEmploymentBsasValidator.scala
@@ -25,10 +25,13 @@ import shared.models.errors.MtdError
 import v5.retrieveSelfEmploymentBsas.models.RetrieveSelfEmploymentBsasRequestData
 import v5.retrieveSelfEmploymentBsas.models.def1.Def1_RetrieveSelfEmploymentBsasRequestData
 
-class Def1_RetrieveSelfEmploymentBsasValidator(nino: String, calculationId: String, taxYear: Option[String])
-    extends Validator[RetrieveSelfEmploymentBsasRequestData]
-    with ResolverSupport {
+object Def1_RetrieveSelfEmploymentBsasValidator extends ResolverSupport {
   private val resolveTysTaxYear = ResolveTysTaxYear.resolver.resolveOptionally
+}
+
+class Def1_RetrieveSelfEmploymentBsasValidator(nino: String, calculationId: String, taxYear: Option[String])
+    extends Validator[RetrieveSelfEmploymentBsasRequestData] {
+  import Def1_RetrieveSelfEmploymentBsasValidator._
 
   def validate: Validated[Seq[MtdError], RetrieveSelfEmploymentBsasRequestData] =
     (

--- a/app/v5/retrieveUkPropertyBsas/connectors/RetrieveUkPropertyBsasConnector.scala
+++ b/app/v5/retrieveUkPropertyBsas/connectors/RetrieveUkPropertyBsasConnector.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.connectors
+
+import shared.config.AppConfig
+import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.httpparsers.StandardDownstreamHttpParser._
+import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import v5.retrieveUkPropertyBsas.models.{RetrieveUkPropertyBsasRequestData, RetrieveUkPropertyBsasResponse}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class RetrieveUkPropertyBsasConnector @Inject() (val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+
+  def retrieve(request: RetrieveUkPropertyBsasRequestData)(implicit
+      hc: HeaderCarrier,
+      ec: ExecutionContext,
+      correlationId: String): Future[DownstreamOutcome[RetrieveUkPropertyBsasResponse]] = {
+
+    import request._
+    import schema._
+
+    val downstreamUri: DownstreamUri[DownstreamResp] = taxYear match {
+      case Some(taxYear) if taxYear.useTaxYearSpecificApi =>
+        TaxYearSpecificIfsUri(
+          s"income-tax/adjustable-summary-calculation/${taxYear.asTysDownstream}/$nino/$calculationId")
+      case _ => IfsUri(s"income-tax/adjustable-summary-calculation/$nino/$calculationId")
+    }
+
+    get(downstreamUri)
+
+  }
+
+}

--- a/app/v5/retrieveUkPropertyBsas/controllers/RetrieveUkPropertyBsasController.scala
+++ b/app/v5/retrieveUkPropertyBsas/controllers/RetrieveUkPropertyBsasController.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.controllers
+
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import shared.config.AppConfig
+import shared.controllers.{AuthorisedController, EndpointLogContext, RequestContext, RequestHandler}
+import shared.hateoas.HateoasFactory
+import shared.services.{EnrolmentsAuthService, MtdIdLookupService}
+import shared.utils.{IdGenerator, Logging}
+import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyHateoasData
+import v5.retrieveUkPropertyBsas.schema.RetrieveUkPropertyBsasSchema
+import v5.retrieveUkPropertyBsas.services.RetrieveUkPropertyBsasService
+import v5.retrieveUkPropertyBsas.validators.RetrieveUkPropertyBsasValidatorFactory
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class RetrieveUkPropertyBsasController @Inject() (val authService: EnrolmentsAuthService,
+                                                  val lookupService: MtdIdLookupService,
+                                                  validatorFactory: RetrieveUkPropertyBsasValidatorFactory,
+                                                  service: RetrieveUkPropertyBsasService,
+                                                  hateoasFactory: HateoasFactory,
+                                                  cc: ControllerComponents,
+                                                  val idGenerator: IdGenerator)(implicit ec: ExecutionContext, appConfig: AppConfig)
+    extends AuthorisedController(cc)
+    with Logging {
+
+  implicit val endpointLogContext: EndpointLogContext =
+    EndpointLogContext(
+      controllerName = "RetrievePropertyBsasController",
+      endpointName = "retrieve"
+    )
+
+  def retrieve(nino: String, calculationId: String, taxYear: Option[String]): Action[AnyContent] =
+    authorisedAction(nino).async { implicit request =>
+      implicit val ctx: RequestContext = RequestContext.from(idGenerator, endpointLogContext)
+
+      val validator = validatorFactory.validator(nino, calculationId, taxYear, RetrieveUkPropertyBsasSchema.schemaFor(taxYear))
+
+      val requestHandler =
+        RequestHandler
+          .withValidator(validator)
+          .withService(service.retrieve)
+          .withHateoasResultFrom(hateoasFactory)((parsedRequest, responseData) =>
+            RetrieveUkPropertyHateoasData(nino, calculationId, parsedRequest.taxYear))
+
+      requestHandler.handleRequest()
+    }
+
+}

--- a/app/v5/retrieveUkPropertyBsas/models/RetrieveUkPropertyBsasRequestData.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/RetrieveUkPropertyBsasRequestData.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.retrieveUkPropertyBsas.schema.RetrieveUkPropertyBsasSchema
+
+trait RetrieveUkPropertyBsasRequestData {
+  def nino: Nino
+  def calculationId: CalculationId
+  def taxYear: Option[TaxYear]
+
+  val schema: RetrieveUkPropertyBsasSchema
+}

--- a/app/v5/retrieveUkPropertyBsas/models/RetrieveUkPropertyBsasResponse.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/RetrieveUkPropertyBsasResponse.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models
+
+import play.api.libs.json._
+import shared.config.AppConfig
+import shared.hateoas.{HateoasData, HateoasLinksFactory, Link}
+import shared.models.domain.TaxYear
+import v5.hateoas.HateoasLinks
+import v5.models.domain.HasTypeOfBusiness
+import v5.retrieveUkPropertyBsas.models.def1.Def1_RetrieveUkPropertyBsasResponse
+
+
+trait RetrieveUkPropertyBsasResponse extends HasTypeOfBusiness
+
+object RetrieveUkPropertyBsasResponse extends HateoasLinks {
+
+  implicit val writes: OWrites[RetrieveUkPropertyBsasResponse] = OWrites.apply[RetrieveUkPropertyBsasResponse] {
+    case a: Def1_RetrieveUkPropertyBsasResponse =>
+      implicitly[OWrites[Def1_RetrieveUkPropertyBsasResponse]].writes(a)
+
+    case a: RetrieveUkPropertyBsasResponse => throw new RuntimeException(s"No writes defined for type ${a.getClass.getName}")
+  }
+
+  implicit object RetrieveSelfAssessmentBsasHateoasFactory
+    extends HateoasLinksFactory[RetrieveUkPropertyBsasResponse, RetrieveUkPropertyHateoasData] {
+    override def links(appConfig: AppConfig, data: RetrieveUkPropertyHateoasData): Seq[Link] = {
+      import data._
+
+      Seq(
+        getUkPropertyBsas(appConfig, nino, calculationId, taxYear),
+        adjustUkPropertyBsas(appConfig, nino, calculationId, taxYear)
+      )
+    }
+  }
+}
+
+case class RetrieveUkPropertyHateoasData(nino: String, calculationId: String, taxYear: Option[TaxYear]) extends HateoasData

--- a/app/v5/retrieveUkPropertyBsas/models/def1/AdjustableSummaryCalculation.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/AdjustableSummaryCalculation.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.json._
+
+case class AdjustableSummaryCalculation(
+                                         totalIncome: Option[BigDecimal],
+                                         income: Option[SummaryCalculationIncome],
+                                         totalExpenses: Option[BigDecimal],
+                                         expenses: Option[SummaryCalculationExpenses],
+                                         netProfit: Option[BigDecimal],
+                                         netLoss: Option[BigDecimal],
+                                         totalAdditions: Option[BigDecimal],
+                                         additions: Option[SummaryCalculationAdditions],
+                                         totalDeductions: Option[BigDecimal],
+                                         deductions: Option[SummaryCalculationDeductions],
+                                         taxableProfit: Option[BigDecimal],
+                                         adjustedIncomeTaxLoss: Option[BigDecimal],
+                                       )
+
+object AdjustableSummaryCalculation {
+  val readsFhl: Reads[AdjustableSummaryCalculation] = summaryCalculationReadsFhl(AdjustableSummaryCalculation.apply _)
+
+  val readsNonFhl: Reads[AdjustableSummaryCalculation] = summaryCalculationReadsNonFhl(AdjustableSummaryCalculation.apply _)
+
+  implicit val writes: OWrites[AdjustableSummaryCalculation] = Json.writes[AdjustableSummaryCalculation]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/AdjustedSummaryCalculation.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/AdjustedSummaryCalculation.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.json._
+
+case class AdjustedSummaryCalculation(
+                                       totalIncome: Option[BigDecimal],
+                                       income: Option[SummaryCalculationIncome],
+                                       totalExpenses: Option[BigDecimal],
+                                       expenses: Option[SummaryCalculationExpenses],
+                                       netProfit: Option[BigDecimal],
+                                       netLoss: Option[BigDecimal],
+                                       totalAdditions: Option[BigDecimal],
+                                       additions: Option[SummaryCalculationAdditions],
+                                       totalDeductions: Option[BigDecimal],
+                                       deductions: Option[SummaryCalculationDeductions],
+                                       taxableProfit: Option[BigDecimal],
+                                       adjustedIncomeTaxLoss: Option[BigDecimal],
+                                     )
+
+object AdjustedSummaryCalculation {
+  implicit val readsFhl: Reads[AdjustedSummaryCalculation] = summaryCalculationReadsFhl(AdjustedSummaryCalculation.apply _)
+
+  implicit val readsNonFhl: Reads[AdjustedSummaryCalculation] = summaryCalculationReadsNonFhl(AdjustedSummaryCalculation.apply _)
+
+  implicit val writes: OWrites[AdjustedSummaryCalculation] = Json.writes[AdjustedSummaryCalculation]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/Adjustments.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/Adjustments.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class Adjustments(
+                        income: Option[AdjustmentsIncome],
+                        expenses: Option[AdjustmentsExpenses],
+                      )
+
+object Adjustments {
+
+  val readsFhl: Reads[Adjustments] = (
+    (JsPath \ "income").readNullable[AdjustmentsIncome](AdjustmentsIncome.readsFhl) and
+      (JsPath \ "expenses").readNullable[AdjustmentsExpenses](AdjustmentsExpenses.readsFhl)
+    ) (Adjustments.apply _)
+
+  implicit val readsNonFhl: Reads[Adjustments] = (
+    (JsPath \ "income").readNullable[AdjustmentsIncome](AdjustmentsIncome.readsNonFhl) and
+      (JsPath \ "expenses").readNullable[AdjustmentsExpenses](AdjustmentsExpenses.readsNonFhl)
+    ) (Adjustments.apply _)
+
+  implicit val writes: OWrites[Adjustments] = Json.writes[Adjustments]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/AdjustmentsExpenses.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/AdjustmentsExpenses.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class AdjustmentsExpenses(
+                                consolidatedExpenses: Option[BigDecimal],
+                                premisesRunningCosts: Option[BigDecimal],
+                                repairsAndMaintenance: Option[BigDecimal],
+                                financialCosts: Option[BigDecimal],
+                                professionalFees: Option[BigDecimal],
+                                costOfServices: Option[BigDecimal],
+                                residentialFinancialCost: Option[BigDecimal],
+                                other: Option[BigDecimal],
+                                travelCosts: Option[BigDecimal],
+                              )
+
+object AdjustmentsExpenses {
+
+  val readsFhl: Reads[AdjustmentsExpenses] = (
+    (JsPath \ "consolidatedExpenses").readNullable[BigDecimal] and
+      (JsPath \ "premisesRunningCosts").readNullable[BigDecimal] and
+      (JsPath \ "repairsAndMaintenance").readNullable[BigDecimal] and
+      (JsPath \ "financialCosts").readNullable[BigDecimal] and
+      (JsPath \ "professionalFees").readNullable[BigDecimal] and
+      (JsPath \ "costOfServices").readNullable[BigDecimal] and
+      Reads.pure(None) and
+      (JsPath \ "other").readNullable[BigDecimal] and
+      (JsPath \ "travelCosts").readNullable[BigDecimal]
+    ) (AdjustmentsExpenses.apply _)
+
+  val readsNonFhl: Reads[AdjustmentsExpenses] = (
+    (JsPath \ "consolidatedExpenses").readNullable[BigDecimal] and
+      (JsPath \ "premisesRunningCosts").readNullable[BigDecimal] and
+      (JsPath \ "repairsAndMaintenance").readNullable[BigDecimal] and
+      (JsPath \ "financialCosts").readNullable[BigDecimal] and
+      (JsPath \ "professionalFees").readNullable[BigDecimal] and
+      (JsPath \ "costOfServices").readNullable[BigDecimal] and
+      (JsPath \ "residentialFinancialCost").readNullable[BigDecimal] and
+      (JsPath \ "other").readNullable[BigDecimal] and
+      (JsPath \ "travelCosts").readNullable[BigDecimal]
+    ) (AdjustmentsExpenses.apply _)
+
+  implicit val writes: OWrites[AdjustmentsExpenses] = Json.writes[AdjustmentsExpenses]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/AdjustmentsIncome.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/AdjustmentsIncome.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class AdjustmentsIncome(
+                              totalRentsReceived: Option[BigDecimal],
+                              premiumsOfLeaseGrant: Option[BigDecimal],
+                              reversePremiums: Option[BigDecimal],
+                              otherPropertyIncome: Option[BigDecimal]
+                            )
+
+object AdjustmentsIncome {
+
+  val readsFhl: Reads[AdjustmentsIncome] = (
+    (JsPath \ "rentReceived").readNullable[BigDecimal] and
+      Reads.pure(None) and
+      Reads.pure(None) and
+      Reads.pure(None)
+    ) (AdjustmentsIncome.apply _)
+
+  val readsNonFhl: Reads[AdjustmentsIncome] = (
+    (JsPath \ "totalRentsReceived").readNullable[BigDecimal] and
+      (JsPath \ "premiumsOfLeaseGrant").readNullable[BigDecimal] and
+      (JsPath \ "reversePremiums").readNullable[BigDecimal] and
+      (JsPath \ "otherPropertyIncome").readNullable[BigDecimal]
+    ) (AdjustmentsIncome.apply _)
+
+  implicit val writes: OWrites[AdjustmentsIncome] = Json.writes[AdjustmentsIncome]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/Def1_RetrieveUkPropertyBsasRequestData.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/Def1_RetrieveUkPropertyBsasRequestData.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyBsasRequestData
+import v5.retrieveUkPropertyBsas.schema.RetrieveUkPropertyBsasSchema
+
+case class Def1_RetrieveUkPropertyBsasRequestData(nino: Nino, calculationId: CalculationId, taxYear: Option[TaxYear])
+  extends RetrieveUkPropertyBsasRequestData {
+  val schema: RetrieveUkPropertyBsasSchema = RetrieveUkPropertyBsasSchema.Def1
+}
+

--- a/app/v5/retrieveUkPropertyBsas/models/def1/Def1_RetrieveUkPropertyBsasResponse.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/Def1_RetrieveUkPropertyBsasResponse.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.json._
+import v5.models.domain.TypeOfBusiness
+import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyBsasResponse
+
+case class Def1_RetrieveUkPropertyBsasResponse(
+    metadata: Metadata,
+    inputs: Inputs,
+    adjustableSummaryCalculation: AdjustableSummaryCalculation,
+    adjustments: Option[Adjustments],
+    adjustedSummaryCalculation: Option[AdjustedSummaryCalculation]
+) extends RetrieveUkPropertyBsasResponse {
+  override def typeOfBusiness: TypeOfBusiness = inputs.typeOfBusiness
+}
+
+object Def1_RetrieveUkPropertyBsasResponse {
+
+  implicit val reads: Reads[Def1_RetrieveUkPropertyBsasResponse] = (json: JsValue) =>
+    for {
+      metadata <- (json \ "metadata").validate[Metadata]
+      inputs   <- (json \ "inputs").validate[Inputs]
+      isFhl = inputs.typeOfBusiness == TypeOfBusiness.`uk-property-fhl`
+      adjustableSummaryCalculation <- (json \ "adjustableSummaryCalculation")
+        .validate[AdjustableSummaryCalculation](if (isFhl) AdjustableSummaryCalculation.readsFhl else AdjustableSummaryCalculation.readsNonFhl)
+      adjustments <- (json \ "adjustments").validateOpt[Adjustments](if (isFhl) Adjustments.readsFhl else Adjustments.readsNonFhl)
+      adjustedSummaryCalculation <- (json \ "adjustedSummaryCalculation")
+        .validateOpt[AdjustedSummaryCalculation](if (isFhl) AdjustedSummaryCalculation.readsFhl else AdjustedSummaryCalculation.readsNonFhl)
+    } yield {
+      Def1_RetrieveUkPropertyBsasResponse(
+        metadata = metadata,
+        inputs = inputs,
+        adjustableSummaryCalculation = adjustableSummaryCalculation,
+        adjustments = adjustments,
+        adjustedSummaryCalculation = adjustedSummaryCalculation
+      )
+    }
+
+  implicit val writes: OWrites[Def1_RetrieveUkPropertyBsasResponse] = Json.writes
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/Inputs.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/Inputs.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
+import shared.models.domain.Source
+import v5.models.domain.{IncomeSourceType, TypeOfBusiness}
+
+case class Inputs(
+                   typeOfBusiness: TypeOfBusiness,
+                   businessId: String,
+                   businessName: Option[String],
+                   accountingPeriodStartDate: String,
+                   accountingPeriodEndDate: String,
+                   source: Source,
+                   submissionPeriods: Seq[SubmissionPeriod]
+                 )
+
+object Inputs {
+
+  implicit val reads: Reads[Inputs] = (
+    (JsPath \ "incomeSourceType").read[IncomeSourceType].map(_.toTypeOfBusiness) and
+      (JsPath \ "incomeSourceId").read[String] and
+      (JsPath \ "incomeSourceName").readNullable[String] and
+      (JsPath \ "accountingPeriodStartDate").read[String] and
+      (JsPath \ "accountingPeriodEndDate").read[String] and
+      (JsPath \ "source").read[Source] and
+      (JsPath \ "submissionPeriods").read[Seq[SubmissionPeriod]]
+    ) (Inputs.apply _)
+
+  implicit val writes: OWrites[Inputs] = Json.writes[Inputs]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/Metadata.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/Metadata.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import shared.models.domain.{Status, TaxYear}
+
+case class Metadata(
+    calculationId: String,
+    requestedDateTime: String,
+    adjustedDateTime: Option[String],
+    nino: String,
+    taxYear: String,
+    summaryStatus: Status
+)
+
+object Metadata {
+
+  implicit val reads: Reads[Metadata] = (
+    (JsPath \ "calculationId").read[String] and
+      (JsPath \ "requestedDateTime").read[String] and
+      (JsPath \ "adjustedDateTime").readNullable[String] and
+      (JsPath \ "taxableEntityId").read[String] and
+      (JsPath \ "taxYear").read[Int].map(taxYear => TaxYear.fromDownstreamInt(taxYear).asMtd) and
+      (JsPath \ "status").read[Status]
+  )(Metadata.apply _)
+
+  implicit val writes: OWrites[Metadata] = Json.writes[Metadata]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/SubmissionPeriod.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/SubmissionPeriod.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.json._
+
+case class SubmissionPeriod(
+                             periodId: Option[String],
+                             submissionId: Option[String],
+                             startDate: String,
+                             endDate: String,
+                             receivedDateTime: String,
+                           )
+
+object SubmissionPeriod {
+
+  private val periodIdRegex = "^[0-9]{16}$"
+
+  implicit val reads: Reads[SubmissionPeriod] = (json: JsValue) => {
+    for {
+      startDate <- (json \ "startDate").validate[String]
+      endDate <- (json \ "endDate").validate[String]
+      receivedDateTime <- (json \ "receivedDateTime").validate[String]
+      id <- (json \ "periodId").validate[String]
+      (periodId, submissionId) = {
+        if (id.matches(periodIdRegex)) {
+          (Some(id), None)
+        } else {
+          (None, Some(s"${startDate}_$endDate"))
+        }
+      }
+    } yield {
+      SubmissionPeriod(periodId = periodId,
+        submissionId = submissionId,
+        startDate = startDate,
+        endDate = endDate,
+        receivedDateTime = receivedDateTime)
+    }
+  }
+
+  implicit val writes: OWrites[SubmissionPeriod] = Json.writes[SubmissionPeriod]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationAdditions.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationAdditions.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class SummaryCalculationAdditions(
+                                        privateUseAdjustment: Option[BigDecimal],
+                                        balancingCharge: Option[BigDecimal],
+                                        bpraBalancingCharge: Option[BigDecimal],
+                                      )
+
+object SummaryCalculationAdditions {
+  implicit val reads: Reads[SummaryCalculationAdditions] = (
+    (JsPath \ "privateUseAdjustment").readNullable[BigDecimal] and
+      (JsPath \ "balancingCharge").readNullable[BigDecimal] and
+      (JsPath \ "bpraBalancingCharge").readNullable[BigDecimal]
+    ) (SummaryCalculationAdditions.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationAdditions] = Json.writes[SummaryCalculationAdditions]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationDeductions.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationDeductions.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class SummaryCalculationDeductions(
+                                         zeroEmissionGoods: Option[BigDecimal],
+                                         annualInvestmentAllowance: Option[BigDecimal],
+                                         costOfReplacingDomesticItems: Option[BigDecimal],
+                                         businessPremisesRenovationAllowance: Option[BigDecimal],
+                                         propertyAllowance: Option[BigDecimal],
+                                         otherCapitalAllowance: Option[BigDecimal],
+                                         rarReliefClaimed: Option[BigDecimal],
+                                         electricChargePointAllowance: Option[BigDecimal],
+                                         structuredBuildingAllowance: Option[BigDecimal],
+                                         enhancedStructuredBuildingAllowance: Option[BigDecimal],
+                                         zeroEmissionsCarAllowance: Option[BigDecimal],
+                                       )
+
+object SummaryCalculationDeductions {
+
+  val readsFhl: Reads[SummaryCalculationDeductions] = (
+    Reads.pure(None) and
+      (JsPath \ "annualInvestmentAllowance").readNullable[BigDecimal] and
+      Reads.pure(None) and
+      (JsPath \ "businessPremisesRenovationAllowance").readNullable[BigDecimal] and
+      (JsPath \ "propertyAllowance").readNullable[BigDecimal] and
+      (JsPath \ "otherCapitalAllowance").readNullable[BigDecimal] and
+      (JsPath \ "rarReliefClaimed").readNullable[BigDecimal] and
+      (JsPath \ "electricChargePointAllowance").readNullable[BigDecimal] and
+      Reads.pure(None) and
+      Reads.pure(None) and
+      (JsPath \ "zeroEmissionsCarAllowance").readNullable[BigDecimal]
+    ) (SummaryCalculationDeductions.apply _)
+
+  val readsNonFhl: Reads[SummaryCalculationDeductions] = (
+    (JsPath \ "zeroEmissionsGoodsVehicleAllowance").readNullable[BigDecimal] and
+      (JsPath \ "annualInvestmentAllowance").readNullable[BigDecimal] and
+      (JsPath \ "costOfReplacingDomesticItems").readNullable[BigDecimal] and
+      (JsPath \ "businessPremisesRenovationAllowance").readNullable[BigDecimal] and
+      (JsPath \ "propertyAllowance").readNullable[BigDecimal] and
+      (JsPath \ "otherCapitalAllowance").readNullable[BigDecimal] and
+      (JsPath \ "rarReliefClaimed").readNullable[BigDecimal] and
+      (JsPath \ "electricChargePointAllowance").readNullable[BigDecimal] and
+      (JsPath \ "structuredBuildingAllowance").readNullable[BigDecimal] and
+      (JsPath \ "enhancedStructuredBuildingAllowance").readNullable[BigDecimal] and
+      (JsPath \ "zeroEmissionsCarAllowance").readNullable[BigDecimal]
+    ) (SummaryCalculationDeductions.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationDeductions] = Json.writes[SummaryCalculationDeductions]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationExpenses.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationExpenses.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class SummaryCalculationExpenses(
+                                       consolidatedExpenses: Option[BigDecimal],
+                                       premisesRunningCosts: Option[BigDecimal],
+                                       repairsAndMaintenance: Option[BigDecimal],
+                                       financialCosts: Option[BigDecimal],
+                                       professionalFees: Option[BigDecimal],
+                                       costOfServices: Option[BigDecimal],
+                                       residentialFinancialCost: Option[BigDecimal],
+                                       broughtFwdResidentialFinancialCost: Option[BigDecimal],
+                                       other: Option[BigDecimal],
+                                       travelCosts: Option[BigDecimal],
+                                     )
+
+object SummaryCalculationExpenses {
+
+  val readsFhl: Reads[SummaryCalculationExpenses] = (
+    (JsPath \ "consolidatedExpenses").readNullable[BigDecimal] and
+      (JsPath \ "premisesRunningCosts").readNullable[BigDecimal] and
+      (JsPath \ "repairsAndMaintenance").readNullable[BigDecimal] and
+      (JsPath \ "financialCosts").readNullable[BigDecimal] and
+      (JsPath \ "professionalFees").readNullable[BigDecimal] and
+      (JsPath \ "costOfServices").readNullable[BigDecimal] and
+      Reads.pure(None) and
+      Reads.pure(None) and
+      (JsPath \ "other").readNullable[BigDecimal] and
+      (JsPath \ "travelCosts").readNullable[BigDecimal]
+    ) (SummaryCalculationExpenses.apply _)
+
+  val readsNonFhl: Reads[SummaryCalculationExpenses] = (
+    (JsPath \ "consolidatedExpenses").readNullable[BigDecimal] and
+      (JsPath \ "premisesRunningCosts").readNullable[BigDecimal] and
+      (JsPath \ "repairsAndMaintenance").readNullable[BigDecimal] and
+      (JsPath \ "financialCosts").readNullable[BigDecimal] and
+      (JsPath \ "professionalFees").readNullable[BigDecimal] and
+      (JsPath \ "costOfServices").readNullable[BigDecimal] and
+      (JsPath \ "residentialFinancialCost").readNullable[BigDecimal] and
+      (JsPath \ "broughtFwdResidentialFinancialCost").readNullable[BigDecimal] and
+      (JsPath \ "other").readNullable[BigDecimal] and
+      (JsPath \ "travelCosts").readNullable[BigDecimal]
+    ) (SummaryCalculationExpenses.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationExpenses] = Json.writes[SummaryCalculationExpenses]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationIncome.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationIncome.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class SummaryCalculationIncome(
+                                     totalRentsReceived: Option[BigDecimal],
+                                     premiumsOfLeaseGrant: Option[BigDecimal],
+                                     reversePremiums: Option[BigDecimal],
+                                     otherPropertyIncome: Option[BigDecimal],
+                                     rarRentReceived: Option[BigDecimal]
+                                   )
+
+object SummaryCalculationIncome {
+
+  val readsFhl: Reads[SummaryCalculationIncome] = (
+    (JsPath \ "rentReceived").readNullable[BigDecimal] and
+      Reads.pure(None) and
+      Reads.pure(None) and
+      Reads.pure(None) and
+      (JsPath \ "rarRentReceived").readNullable[BigDecimal]
+    ) (SummaryCalculationIncome.apply _)
+
+  val readsNonFhl: Reads[SummaryCalculationIncome] = (
+    (JsPath \ "totalRentsReceived").readNullable[BigDecimal] and
+      (JsPath \ "premiumsOfLeaseGrant").readNullable[BigDecimal] and
+      (JsPath \ "reversePremiums").readNullable[BigDecimal] and
+      (JsPath \ "otherPropertyIncome").readNullable[BigDecimal] and
+      (JsPath \ "rarRentReceived").readNullable[BigDecimal]
+    ) (SummaryCalculationIncome.apply _)
+
+  implicit val writes: OWrites[SummaryCalculationIncome] = Json.writes[SummaryCalculationIncome]
+}

--- a/app/v5/retrieveUkPropertyBsas/models/def1/package.scala
+++ b/app/v5/retrieveUkPropertyBsas/models/def1/package.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models
+
+import play.api.libs.functional.FunctionalBuilder
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+package object def1 {
+
+  private type SummaryCalculationReads = FunctionalBuilder[Reads]#CanBuild12[Option[BigDecimal],
+    Option[SummaryCalculationIncome],
+    Option[BigDecimal],
+    Option[SummaryCalculationExpenses],
+    Option[BigDecimal],
+    Option[BigDecimal],
+    Option[BigDecimal],
+    Option[SummaryCalculationAdditions],
+    Option[BigDecimal],
+    Option[SummaryCalculationDeductions],
+    Option[BigDecimal],
+    Option[BigDecimal]]
+
+  val summaryCalculationReadsFhl: SummaryCalculationReads =
+    (JsPath \ "totalIncome").readNullable[BigDecimal] and
+      (JsPath \ "income").readNullable[SummaryCalculationIncome](SummaryCalculationIncome.readsFhl) and
+      (JsPath \ "totalExpenses").readNullable[BigDecimal] and
+      (JsPath \ "expenses").readNullable[SummaryCalculationExpenses](SummaryCalculationExpenses.readsFhl) and
+      (JsPath \ "netProfit").readNullable[BigDecimal] and
+      (JsPath \ "netLoss").readNullable[BigDecimal] and
+      (JsPath \ "totalAdditions").readNullable[BigDecimal] and
+      (JsPath \ "additions").readNullable[SummaryCalculationAdditions] and
+      (JsPath \ "totalDeductions").readNullable[BigDecimal] and
+      (JsPath \ "deductions").readNullable[SummaryCalculationDeductions](SummaryCalculationDeductions.readsFhl) and
+      (JsPath \ "taxableProfit").readNullable[BigDecimal] and
+      (JsPath \ "adjustedIncomeTaxLoss").readNullable[BigDecimal]
+
+  val summaryCalculationReadsNonFhl: SummaryCalculationReads =
+    (JsPath \ "totalIncome").readNullable[BigDecimal] and
+      (JsPath \ "income").readNullable[SummaryCalculationIncome](SummaryCalculationIncome.readsNonFhl) and
+      (JsPath \ "totalExpenses").readNullable[BigDecimal] and
+      (JsPath \ "expenses").readNullable[SummaryCalculationExpenses](SummaryCalculationExpenses.readsNonFhl) and
+      (JsPath \ "netProfit").readNullable[BigDecimal] and
+      (JsPath \ "netLoss").readNullable[BigDecimal] and
+      (JsPath \ "totalAdditions").readNullable[BigDecimal] and
+      (JsPath \ "additions").readNullable[SummaryCalculationAdditions] and
+      (JsPath \ "totalDeductions").readNullable[BigDecimal] and
+      (JsPath \ "deductions").readNullable[SummaryCalculationDeductions](SummaryCalculationDeductions.readsNonFhl) and
+      (JsPath \ "taxableProfit").readNullable[BigDecimal] and
+      (JsPath \ "adjustedIncomeTaxLoss").readNullable[BigDecimal]
+}

--- a/app/v5/retrieveUkPropertyBsas/schema/RetrieveUkPropertyBsasSchema.scala
+++ b/app/v5/retrieveUkPropertyBsas/schema/RetrieveUkPropertyBsasSchema.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.schema
+
+import play.api.libs.json.Reads
+import shared.controllers.validators.resolvers.ResolveTaxYear
+import shared.models.domain.TaxYear
+import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyBsasResponse
+import v5.retrieveUkPropertyBsas.models.def1.Def1_RetrieveUkPropertyBsasResponse
+import v5.schema.DownstreamReadable
+
+import scala.math.Ordered.orderingToOrdered
+
+sealed trait RetrieveUkPropertyBsasSchema extends DownstreamReadable[RetrieveUkPropertyBsasResponse]
+
+object RetrieveUkPropertyBsasSchema {
+
+  case object Def1 extends RetrieveUkPropertyBsasSchema {
+    type DownstreamResp = Def1_RetrieveUkPropertyBsasResponse
+    val connectorReads: Reads[DownstreamResp] = Def1_RetrieveUkPropertyBsasResponse.reads
+  }
+
+  private val defaultSchema = Def1
+
+  def schemaFor(maybeTaxYear: Option[String]): RetrieveUkPropertyBsasSchema = {
+    maybeTaxYear
+      .map(ResolveTaxYear.resolver)
+      .flatMap(_.toOption.map(schemaFor))
+      .getOrElse(defaultSchema)
+  }
+
+  def schemaFor(taxYear: TaxYear): RetrieveUkPropertyBsasSchema = {
+    if (TaxYear.starting(2023) <= taxYear) {
+      Def1
+    } else {
+      defaultSchema
+    }
+  }
+
+}

--- a/app/v5/retrieveUkPropertyBsas/services/RetrieveUkPropertyBsasService.scala
+++ b/app/v5/retrieveUkPropertyBsas/services/RetrieveUkPropertyBsasService.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.services
+
+import cats.data.EitherT
+import cats.implicits._
+import shared.controllers.RequestContext
+import shared.models
+import shared.models.errors._
+import shared.services.ServiceOutcome
+import v5.models.domain.TypeOfBusiness
+import v5.retrieveUkPropertyBsas.connectors.RetrieveUkPropertyBsasConnector
+import v5.retrieveUkPropertyBsas.models.{RetrieveUkPropertyBsasRequestData, RetrieveUkPropertyBsasResponse}
+import v5.services.BaseRetrieveBsasService
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class RetrieveUkPropertyBsasService @Inject()(connector: RetrieveUkPropertyBsasConnector) extends BaseRetrieveBsasService {
+
+  protected val supportedTypesOfBusiness: Set[TypeOfBusiness] = Set(TypeOfBusiness.`uk-property-fhl`, TypeOfBusiness.`uk-property-non-fhl`)
+  private val errorMap: Map[String, MtdError] = {
+
+    val errors = Map(
+      "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+      "INVALID_CALCULATION_ID" -> CalculationIdFormatError,
+      "INVALID_CORRELATIONID" -> models.errors.InternalError,
+      "INVALID_RETURN" -> models.errors.InternalError,
+      "UNPROCESSABLE_ENTITY" -> models.errors.InternalError,
+      "NO_DATA_FOUND" -> NotFoundError,
+      "SERVER_ERROR" -> models.errors.InternalError,
+      "SERVICE_UNAVAILABLE" -> models.errors.InternalError
+    )
+
+    val extraTysErrors: Map[String, MtdError] = Map(
+      "INVALID_TAX_YEAR" -> TaxYearFormatError,
+      "NOT_FOUND" -> NotFoundError,
+      "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError
+    )
+
+    errors ++ extraTysErrors
+  }
+
+  def retrieve(request: RetrieveUkPropertyBsasRequestData)(implicit ctx: RequestContext,
+                                                           ec: ExecutionContext): Future[ServiceOutcome[RetrieveUkPropertyBsasResponse]] = {
+
+    val result = for {
+      desResponseWrapper <- EitherT(connector.retrieve(request)).leftMap(mapDownstreamErrors(errorMap))
+      mtdResponseWrapper <- EitherT.fromEither[Future](validateTypeOfBusiness(desResponseWrapper))
+
+    } yield mtdResponseWrapper
+
+    result.value
+  }
+
+}

--- a/app/v5/retrieveUkPropertyBsas/validators/RetrieveUkPropertyBsasValidatorFactory.scala
+++ b/app/v5/retrieveUkPropertyBsas/validators/RetrieveUkPropertyBsasValidatorFactory.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.validators
+
+import shared.controllers.validators.Validator
+import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyBsasRequestData
+import v5.retrieveUkPropertyBsas.schema.RetrieveUkPropertyBsasSchema
+import v5.retrieveUkPropertyBsas.schema.RetrieveUkPropertyBsasSchema._
+import v5.retrieveUkPropertyBsas.validators.def1.Def1_RetrieveUkPropertyBsasValidator
+
+import javax.inject.Singleton
+
+@Singleton
+class RetrieveUkPropertyBsasValidatorFactory {
+
+  def validator(nino: String,
+                calculationId: String,
+                taxYear: Option[String],
+                schema: RetrieveUkPropertyBsasSchema): Validator[RetrieveUkPropertyBsasRequestData] =
+    schema match {
+      case Def1 => new Def1_RetrieveUkPropertyBsasValidator(nino, calculationId, taxYear)
+    }
+
+}

--- a/app/v5/retrieveUkPropertyBsas/validators/def1/Def1_RetrieveUkPropertyBsasValidator.scala
+++ b/app/v5/retrieveUkPropertyBsas/validators/def1/Def1_RetrieveUkPropertyBsasValidator.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.validators.def1
+
+import cats.data.Validated
+import cats.implicits._
+import shared.controllers.validators.Validator
+import shared.controllers.validators.resolvers.{ResolveCalculationId, ResolveNino, ResolveTysTaxYear, ResolverSupport}
+import shared.models.errors.MtdError
+import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyBsasRequestData
+import v5.retrieveUkPropertyBsas.models.def1.Def1_RetrieveUkPropertyBsasRequestData
+
+class Def1_RetrieveUkPropertyBsasValidator(nino: String, calculationId: String, taxYear: Option[String])
+    extends Validator[RetrieveUkPropertyBsasRequestData]
+    with ResolverSupport {
+
+  private val resolveTysTaxYear = ResolveTysTaxYear.resolver.resolveOptionally
+
+  def validate: Validated[Seq[MtdError], RetrieveUkPropertyBsasRequestData] =
+    (
+      ResolveNino(nino),
+      ResolveCalculationId(calculationId),
+      resolveTysTaxYear(taxYear)
+    ).mapN(Def1_RetrieveUkPropertyBsasRequestData)
+
+}

--- a/app/v5/retrieveUkPropertyBsas/validators/def1/Def1_RetrieveUkPropertyBsasValidator.scala
+++ b/app/v5/retrieveUkPropertyBsas/validators/def1/Def1_RetrieveUkPropertyBsasValidator.scala
@@ -24,11 +24,13 @@ import shared.models.errors.MtdError
 import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyBsasRequestData
 import v5.retrieveUkPropertyBsas.models.def1.Def1_RetrieveUkPropertyBsasRequestData
 
-class Def1_RetrieveUkPropertyBsasValidator(nino: String, calculationId: String, taxYear: Option[String])
-    extends Validator[RetrieveUkPropertyBsasRequestData]
-    with ResolverSupport {
-
+object Def1_RetrieveUkPropertyBsasValidator extends ResolverSupport {
   private val resolveTysTaxYear = ResolveTysTaxYear.resolver.resolveOptionally
+}
+
+class Def1_RetrieveUkPropertyBsasValidator(nino: String, calculationId: String, taxYear: Option[String])
+    extends Validator[RetrieveUkPropertyBsasRequestData] {
+  import Def1_RetrieveUkPropertyBsasValidator._
 
   def validate: Validated[Seq[MtdError], RetrieveUkPropertyBsasRequestData] =
     (

--- a/app/v5/schema/DownstreamReadable.scala
+++ b/app/v5/schema/DownstreamReadable.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.schema
+
+import play.api.libs.json.Reads
+
+trait DownstreamReadable[Base] {
+
+  /** This is the type of response returned by the connector.
+   *
+   * It is not necessarily the same as the response type returned by the service to the controller.
+   */
+  type DownstreamResp <: Base
+
+  implicit def connectorReads: Reads[DownstreamResp]
+}

--- a/app/v5/services/BaseRetrieveBsasService.scala
+++ b/app/v5/services/BaseRetrieveBsasService.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.services
+
+import shared.models.errors.ErrorWrapper
+import shared.models.outcomes.ResponseWrapper
+import shared.services.{BaseService, ServiceOutcome}
+import v5.models.domain.{HasTypeOfBusiness, TypeOfBusiness}
+import v5.models.errors._
+
+trait BaseRetrieveBsasService extends BaseService {
+  protected val supportedTypesOfBusiness: Set[TypeOfBusiness]
+
+  final protected def validateTypeOfBusiness[T <: HasTypeOfBusiness](responseWrapper: ResponseWrapper[T]): ServiceOutcome[T] =
+    if (supportedTypesOfBusiness.contains(responseWrapper.responseData.typeOfBusiness)) {
+      Right(responseWrapper)
+    } else {
+      Left(ErrorWrapper(responseWrapper.correlationId, RuleTypeOfBusinessIncorrectError, None))
+    }
+
+}

--- a/app/v5/submitForeignPropertyBsas/connectors/SubmitForeignPropertyBsasConnector.scala
+++ b/app/v5/submitForeignPropertyBsas/connectors/SubmitForeignPropertyBsasConnector.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.connectors
+
+import play.api.http.Status
+import shared.config.AppConfig
+import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.httpparsers.StandardDownstreamHttpParser._
+import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import v5.submitForeignPropertyBsas.models.SubmitForeignPropertyBsasRequestData
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubmitForeignPropertyBsasConnector @Inject()(val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+
+  def submitForeignPropertyBsas(request: SubmitForeignPropertyBsasRequestData)(implicit hc: HeaderCarrier,
+                                                                               ec: ExecutionContext,
+                                                                               correlationId: String): Future[DownstreamOutcome[Unit]] = {
+
+    implicit val successCode: SuccessCode = SuccessCode(Status.OK)
+
+    import request._
+
+    val downstreamUri = taxYear match {
+      case Some(ty) if ty.useTaxYearSpecificApi =>
+        TaxYearSpecificIfsUri[Unit](s"income-tax/adjustable-summary-calculation/${ty.asTysDownstream}/$nino/$calculationId")
+      case _ =>
+        IfsUri[Unit](s"income-tax/adjustable-summary-calculation/$nino/$calculationId")
+    }
+
+    put(body, downstreamUri)
+  }
+}

--- a/app/v5/submitForeignPropertyBsas/controllers/SubmitForeignPropertyBsasController.scala
+++ b/app/v5/submitForeignPropertyBsas/controllers/SubmitForeignPropertyBsasController.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.controllers
+
+import play.api.libs.json.JsValue
+import play.api.mvc.{Action, ControllerComponents}
+import shared.config.AppConfig
+import shared.controllers._
+import shared.hateoas.HateoasFactory
+import shared.routing.Version
+import shared.services.{AuditService, EnrolmentsAuthService, MtdIdLookupService}
+import shared.utils.IdGenerator
+import v5.submitForeignPropertyBsas.models.SubmitForeignPropertyBsasHateoasData
+import v5.submitForeignPropertyBsas.schema.SubmitForeignPropertyBsasSchema
+import v5.submitForeignPropertyBsas.services.SubmitForeignPropertyBsasService
+import v5.submitForeignPropertyBsas.validators.SubmitForeignPropertyBsasValidatorFactory
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class SubmitForeignPropertyBsasController @Inject() (val authService: EnrolmentsAuthService,
+                                                     val lookupService: MtdIdLookupService,
+                                                     validatorFactory: SubmitForeignPropertyBsasValidatorFactory,
+                                                     service: SubmitForeignPropertyBsasService,
+                                                     hateoasFactory: HateoasFactory,
+                                                     auditService: AuditService,
+                                                     cc: ControllerComponents,
+                                                     val idGenerator: IdGenerator)(implicit ec: ExecutionContext, appConfig: AppConfig)
+    extends AuthorisedController(cc) {
+
+  implicit val endpointLogContext: EndpointLogContext =
+    EndpointLogContext(controllerName = "SubmitForeignPropertyBsasController", endpointName = "SubmitForeignPropertyBsas")
+
+  def handleRequest(nino: String, calculationId: String, taxYear: Option[String]): Action[JsValue] =
+    authorisedAction(nino).async(parse.json) { implicit request =>
+      implicit val ctx: RequestContext = RequestContext.from(idGenerator, endpointLogContext)
+
+      val validator = validatorFactory.validator(nino, calculationId, taxYear, request.body, SubmitForeignPropertyBsasSchema.schemaFor(taxYear))
+
+      val requestHandler =
+        RequestHandler
+          .withValidator(validator)
+          .withService(service.submitForeignPropertyBsas)
+          .withHateoasResultFrom(hateoasFactory) { (parsedRequest, _) =>
+            SubmitForeignPropertyBsasHateoasData(nino, calculationId, parsedRequest.taxYear)
+          }
+          .withAuditing(AuditHandler(
+            auditService,
+            auditType = "SubmitForeignPropertyAccountingAdjustments",
+            transactionName = "submit-foreign-property-accounting-adjustments",
+            apiVersion = Version(request),
+            params = Map("nino" -> nino, "calculationId" -> calculationId),
+            requestBody = Some(request.body),
+            includeResponse = true
+          ))
+
+      requestHandler.handleRequest()
+    }
+
+}

--- a/app/v5/submitForeignPropertyBsas/models/SubmitForeignPropertyBsasHateoasData.scala
+++ b/app/v5/submitForeignPropertyBsas/models/SubmitForeignPropertyBsasHateoasData.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models
+
+import shared.config.AppConfig
+import shared.hateoas.{HateoasData, HateoasLinksFactory, Link}
+import shared.models.domain.TaxYear
+import v5.hateoas.HateoasLinks
+
+object SubmitForeignPropertyBsasHateoasData extends HateoasLinks {
+
+  implicit object SubmitForeignPropertyAdjustmentHateoasFactory extends HateoasLinksFactory[Unit, SubmitForeignPropertyBsasHateoasData] {
+    override def links(appConfig: AppConfig, data: SubmitForeignPropertyBsasHateoasData): Seq[Link] = {
+      import data._
+
+      Seq(
+        getForeignPropertyBsas(appConfig, nino, bsasId, taxYear)
+      )
+    }
+  }
+}
+
+case class SubmitForeignPropertyBsasHateoasData(nino: String, bsasId: String, taxYear: Option[TaxYear]) extends HateoasData

--- a/app/v5/submitForeignPropertyBsas/models/SubmitForeignPropertyBsasRequestBody.scala
+++ b/app/v5/submitForeignPropertyBsas/models/SubmitForeignPropertyBsasRequestBody.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models
+
+import play.api.libs.json._
+import v5.submitForeignPropertyBsas.models.def1.Def1_SubmitForeignPropertyBsasRequestBody
+
+trait SubmitForeignPropertyBsasRequestBody
+
+object SubmitForeignPropertyBsasRequestBody {
+
+  implicit val writes: OWrites[SubmitForeignPropertyBsasRequestBody] = OWrites.apply[SubmitForeignPropertyBsasRequestBody] {
+    case a: Def1_SubmitForeignPropertyBsasRequestBody => implicitly[OWrites[Def1_SubmitForeignPropertyBsasRequestBody]].writes(a)
+
+    case a: SubmitForeignPropertyBsasRequestBody => throw new RuntimeException(s"No writes defined for type ${a.getClass.getName}")
+  }
+
+}

--- a/app/v5/submitForeignPropertyBsas/models/SubmitForeignPropertyBsasRequestData.scala
+++ b/app/v5/submitForeignPropertyBsas/models/SubmitForeignPropertyBsasRequestData.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.retrieveForeignPropertyBsas.schema.RetrieveForeignPropertyBsasSchema
+
+trait SubmitForeignPropertyBsasRequestData {
+  def nino: Nino
+  def calculationId: CalculationId
+  def taxYear: Option[TaxYear]
+  def body: SubmitForeignPropertyBsasRequestBody
+
+  val schema: RetrieveForeignPropertyBsasSchema
+}

--- a/app/v5/submitForeignPropertyBsas/models/def1/Def1_SubmitForeignPropertyBsasRequestBody.scala
+++ b/app/v5/submitForeignPropertyBsas/models/def1/Def1_SubmitForeignPropertyBsasRequestBody.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json._
+import shared.utils.JsonWritesUtil
+import v5.submitForeignPropertyBsas.models.SubmitForeignPropertyBsasRequestBody
+
+case class Def1_SubmitForeignPropertyBsasRequestBody(nonFurnishedHolidayLet: Option[Seq[ForeignProperty]], foreignFhlEea: Option[FhlEea])
+    extends SubmitForeignPropertyBsasRequestBody
+
+object Def1_SubmitForeignPropertyBsasRequestBody extends JsonWritesUtil {
+  implicit val reads: Reads[Def1_SubmitForeignPropertyBsasRequestBody] = Json.reads
+
+  implicit val writes: OWrites[Def1_SubmitForeignPropertyBsasRequestBody] = new OWrites[Def1_SubmitForeignPropertyBsasRequestBody] {
+
+    override def writes(o: Def1_SubmitForeignPropertyBsasRequestBody): JsObject = {
+      writeIfPresent(o.nonFurnishedHolidayLet, incomeSourceType = "15")
+        .orElse(writeIfPresent(o.foreignFhlEea, incomeSourceType = "03"))
+        .getOrElse(JsObject.empty)
+    }
+
+    private def writeIfPresent[A: Writes](oa: Option[A], incomeSourceType: String): Option[JsObject] =
+      oa.map { a =>
+        Json.obj("incomeSourceType" -> incomeSourceType, "adjustments" -> a)
+      }
+
+  }
+
+}

--- a/app/v5/submitForeignPropertyBsas/models/def1/Def1_SubmitForeignPropertyBsasRequestData.scala
+++ b/app/v5/submitForeignPropertyBsas/models/def1/Def1_SubmitForeignPropertyBsasRequestData.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.retrieveForeignPropertyBsas.schema.RetrieveForeignPropertyBsasSchema
+import v5.submitForeignPropertyBsas.models.SubmitForeignPropertyBsasRequestData
+
+case class Def1_SubmitForeignPropertyBsasRequestData(nino: Nino,
+                                                     calculationId: CalculationId,
+                                                     taxYear: Option[TaxYear],
+                                                     body: Def1_SubmitForeignPropertyBsasRequestBody)
+    extends SubmitForeignPropertyBsasRequestData {
+  override val schema: RetrieveForeignPropertyBsasSchema = RetrieveForeignPropertyBsasSchema.Def1
+}

--- a/app/v5/submitForeignPropertyBsas/models/def1/FhlEea.scala
+++ b/app/v5/submitForeignPropertyBsas/models/def1/FhlEea.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{Json, OFormat}
+
+case class FhlEea(income: Option[FhlIncome], expenses: Option[FhlEeaExpenses])
+
+object FhlEea {
+  implicit val format: OFormat[FhlEea] = Json.format[FhlEea]
+}

--- a/app/v5/submitForeignPropertyBsas/models/def1/FhlEeaExpenses.scala
+++ b/app/v5/submitForeignPropertyBsas/models/def1/FhlEeaExpenses.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{Json, OFormat}
+
+case class FhlEeaExpenses(premisesRunningCosts: Option[BigDecimal],
+                          repairsAndMaintenance: Option[BigDecimal],
+                          financialCosts: Option[BigDecimal],
+                          professionalFees: Option[BigDecimal],
+                          costOfServices: Option[BigDecimal],
+                          other: Option[BigDecimal],
+                          travelCosts: Option[BigDecimal],
+                          consolidatedExpenses: Option[BigDecimal])
+
+object FhlEeaExpenses {
+  implicit val format: OFormat[FhlEeaExpenses] = Json.format[FhlEeaExpenses]
+}

--- a/app/v5/submitForeignPropertyBsas/models/def1/FhlIncome.scala
+++ b/app/v5/submitForeignPropertyBsas/models/def1/FhlIncome.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class FhlIncome(totalRentsReceived: Option[BigDecimal])
+
+object FhlIncome {
+  implicit val reads: Reads[FhlIncome] = Json.reads[FhlIncome]
+
+  implicit val writes: OWrites[FhlIncome] =
+    (JsPath \ "rentAmount").writeNullable[BigDecimal].contramap((o: FhlIncome) => o.totalRentsReceived)
+}

--- a/app/v5/submitForeignPropertyBsas/models/def1/ForeignProperty.scala
+++ b/app/v5/submitForeignPropertyBsas/models/def1/ForeignProperty.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{Format, Json}
+import shapeless.HNil
+import shared.utils.EmptinessChecker
+
+case class ForeignProperty(countryCode: String, income: Option[ForeignPropertyIncome], expenses: Option[ForeignPropertyExpenses])
+
+object ForeignProperty {
+
+  implicit val emptinessChecker: EmptinessChecker[ForeignProperty] = EmptinessChecker.use { body =>
+    "income" -> body.income ::
+      "expenses" -> body.expenses :: HNil
+  }
+
+  implicit val format: Format[ForeignProperty] = Json.format[ForeignProperty]
+}

--- a/app/v5/submitForeignPropertyBsas/models/def1/ForeignPropertyExpenses.scala
+++ b/app/v5/submitForeignPropertyBsas/models/def1/ForeignPropertyExpenses.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class ForeignPropertyExpenses(premisesRunningCosts: Option[BigDecimal],
+                                   repairsAndMaintenance: Option[BigDecimal],
+                                   financialCosts: Option[BigDecimal],
+                                   professionalFees: Option[BigDecimal],
+                                   travelCosts: Option[BigDecimal],
+                                   costOfServices: Option[BigDecimal],
+                                   residentialFinancialCost: Option[BigDecimal],
+                                   other: Option[BigDecimal],
+                                   consolidatedExpenses: Option[BigDecimal])
+
+object ForeignPropertyExpenses {
+  implicit val reads: Reads[ForeignPropertyExpenses] = Json.reads[ForeignPropertyExpenses]
+
+  implicit val writes: OWrites[ForeignPropertyExpenses] = (
+    (JsPath \ "premisesRunningCosts").writeNullable[BigDecimal] and
+      (JsPath \ "repairsAndMaintenance").writeNullable[BigDecimal] and
+      (JsPath \ "financialCosts").writeNullable[BigDecimal] and
+      (JsPath \ "professionalFees").writeNullable[BigDecimal] and
+      (JsPath \ "travelCosts").writeNullable[BigDecimal] and
+      (JsPath \ "costOfServices").writeNullable[BigDecimal] and
+      (JsPath \ "residentialFinancialCost").writeNullable[BigDecimal] and
+      (JsPath \ "other").writeNullable[BigDecimal] and
+      (JsPath \ "consolidatedExpenses").writeNullable[BigDecimal]
+    ) (unlift(ForeignPropertyExpenses.unapply))
+}

--- a/app/v5/submitForeignPropertyBsas/models/def1/ForeignPropertyIncome.scala
+++ b/app/v5/submitForeignPropertyBsas/models/def1/ForeignPropertyIncome.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class ForeignPropertyIncome(totalRentsReceived: Option[BigDecimal],
+                                 premiumsOfLeaseGrant: Option[BigDecimal],
+                                 otherPropertyIncome: Option[BigDecimal])
+
+object ForeignPropertyIncome {
+  implicit val reads: Reads[ForeignPropertyIncome] = Json.reads[ForeignPropertyIncome]
+
+  implicit val writes: OWrites[ForeignPropertyIncome] = (
+    (JsPath \ "rent").writeNullable[BigDecimal] and
+      (JsPath \ "premiumsOfLeaseGrant").writeNullable[BigDecimal] and
+      (JsPath \ "otherPropertyIncome").writeNullable[BigDecimal]
+    ) (unlift(ForeignPropertyIncome.unapply))
+}

--- a/app/v5/submitForeignPropertyBsas/schema/SubmitForeignPropertyBsasSchema.scala
+++ b/app/v5/submitForeignPropertyBsas/schema/SubmitForeignPropertyBsasSchema.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.schema
+
+import shared.controllers.validators.resolvers.ResolveTaxYear
+import shared.models.domain.TaxYear
+
+import scala.math.Ordered.orderingToOrdered
+
+sealed trait SubmitForeignPropertyBsasSchema
+
+object SubmitForeignPropertyBsasSchema {
+
+  case object Def1 extends SubmitForeignPropertyBsasSchema
+
+  private val defaultSchema = Def1
+
+  def schemaFor(maybeTaxYear: Option[String]): SubmitForeignPropertyBsasSchema = {
+    maybeTaxYear
+      .map(ResolveTaxYear.resolver)
+      .flatMap(_.toOption.map(schemaFor))
+      .getOrElse(defaultSchema)
+  }
+
+  def schemaFor(taxYear: TaxYear): SubmitForeignPropertyBsasSchema = {
+    if (TaxYear.starting(2023) <= taxYear) {
+      Def1
+    } else {
+      defaultSchema
+    }
+  }
+
+}

--- a/app/v5/submitForeignPropertyBsas/services/SubmitForeignPropertyBsasService.scala
+++ b/app/v5/submitForeignPropertyBsas/services/SubmitForeignPropertyBsasService.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.services
+
+import cats.implicits._
+import shared.controllers.RequestContext
+import shared.models
+import shared.models.errors._
+import shared.services.{BaseService, ServiceOutcome}
+import v5.models.errors._
+import v5.submitForeignPropertyBsas.connectors.SubmitForeignPropertyBsasConnector
+import v5.submitForeignPropertyBsas.models.SubmitForeignPropertyBsasRequestData
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubmitForeignPropertyBsasService @Inject()(connector: SubmitForeignPropertyBsasConnector) extends BaseService {
+
+  private val errorMap: Map[String, MtdError] = {
+    val errors = Map(
+      "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+      "INVALID_CALCULATION_ID" -> CalculationIdFormatError,
+      "INVALID_CORRELATIONID" -> models.errors.InternalError,
+      "INVALID_PAYLOAD" -> models.errors.InternalError,
+      "BVR_FAILURE_C15320" -> models.errors.InternalError,
+      "BVR_FAILURE_C55508" -> models.errors.InternalError,
+      "BVR_FAILURE_C55509" -> models.errors.InternalError,
+      "BVR_FAILURE_C559107" -> RulePropertyIncomeAllowanceClaimed,
+      "BVR_FAILURE_C559103" -> RulePropertyIncomeAllowanceClaimed,
+      "BVR_FAILURE_C559099" -> RuleOverConsolidatedExpensesThreshold,
+      "BVR_FAILURE_C55503" -> models.errors.InternalError,
+      "BVR_FAILURE_C55316" -> models.errors.InternalError,
+      "NO_DATA_FOUND" -> NotFoundError,
+      "ASC_ALREADY_SUPERSEDED" -> RuleSummaryStatusSuperseded,
+      "ASC_ALREADY_ADJUSTED" -> RuleAlreadyAdjusted,
+      "UNALLOWABLE_VALUE" -> RuleResultingValueNotPermitted,
+      "ASC_ID_INVALID" -> RuleSummaryStatusInvalid,
+      "INCOMESOURCE_TYPE_NOT_MATCHED" -> RuleTypeOfBusinessIncorrectError,
+      "SERVER_ERROR" -> models.errors.InternalError,
+      "SERVICE_UNAVAILABLE" -> models.errors.InternalError,
+    )
+
+    val extraTysErrors =
+      Map(
+        "INVALID_TAX_YEAR" -> TaxYearFormatError,
+        "NOT_FOUND" -> NotFoundError,
+        "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError,
+        "INCOME_SOURCE_TYPE_NOT_MATCHED" -> RuleTypeOfBusinessIncorrectError
+      )
+
+    errors ++ extraTysErrors
+  }
+
+  def submitForeignPropertyBsas(request: SubmitForeignPropertyBsasRequestData)(implicit ctx: RequestContext,
+                                                                               ec: ExecutionContext): Future[ServiceOutcome[Unit]] = {
+
+    connector
+      .submitForeignPropertyBsas(request)
+      .map(_.leftMap(mapDownstreamErrors(errorMap)))
+  }
+}

--- a/app/v5/submitForeignPropertyBsas/validators/SubmitForeignPropertyBsasValidatorFactory.scala
+++ b/app/v5/submitForeignPropertyBsas/validators/SubmitForeignPropertyBsasValidatorFactory.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.validators
+
+import play.api.libs.json.JsValue
+import shared.controllers.validators.Validator
+import v5.submitForeignPropertyBsas.models.SubmitForeignPropertyBsasRequestData
+import v5.submitForeignPropertyBsas.schema.SubmitForeignPropertyBsasSchema
+import v5.submitForeignPropertyBsas.schema.SubmitForeignPropertyBsasSchema._
+import v5.submitForeignPropertyBsas.validators.def1.Def1_SubmitForeignPropertyBsasValidator
+
+import javax.inject.Singleton
+
+@Singleton
+class SubmitForeignPropertyBsasValidatorFactory {
+
+  def validator(nino: String,
+                calculationId: String,
+                taxYear: Option[String],
+                body: JsValue,
+                schema: SubmitForeignPropertyBsasSchema): Validator[SubmitForeignPropertyBsasRequestData] =
+    schema match {
+      case Def1 => new Def1_SubmitForeignPropertyBsasValidator(nino, calculationId, taxYear, body)
+    }
+
+}
+
+

--- a/app/v5/submitForeignPropertyBsas/validators/def1/Def1_SubmitForeignPropertyBsasRulesValidator.scala
+++ b/app/v5/submitForeignPropertyBsas/validators/def1/Def1_SubmitForeignPropertyBsasRulesValidator.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.validators.def1
+
+import cats.data.Validated
+import cats.data.Validated._
+import cats.implicits._
+import shared.controllers.validators.RulesValidator
+import shared.controllers.validators.resolvers.{ResolveParsedCountryCode, ResolveParsedNumber}
+import shared.models.errors.MtdError
+import v5.models.errors.{RuleBothExpensesError, RuleDuplicateCountryCodeError}
+import v5.submitForeignPropertyBsas.models.def1._
+
+object Def1_SubmitForeignPropertyBsasRulesValidator extends RulesValidator[Def1_SubmitForeignPropertyBsasRequestData] {
+
+  def validateBusinessRules(parsed: Def1_SubmitForeignPropertyBsasRequestData): Validated[Seq[MtdError], Def1_SubmitForeignPropertyBsasRequestData] = {
+    import parsed.body
+
+    val (validatedForeignFhlEea, validatedForeignFhlEeaConsolidated) = body.foreignFhlEea match {
+      case Some(fhlEea) =>
+        (
+          validateForeignFhlEea(fhlEea),
+          validateForeignFhlEeaConsolidatedExpenses(fhlEea)
+        )
+
+      case None =>
+        (valid, valid)
+    }
+
+    val (validatedNonFurnishedHolidayLets, validatedDuplicateCountryCode) = body.nonFurnishedHolidayLet match {
+      case Some(foreignProperties) =>
+        val foreignPropertiesWithIndex = foreignProperties.zipWithIndex.toList
+        (
+          validateNonFurnishedHolidayLets(foreignPropertiesWithIndex),
+          duplicateCountryCodeValidation(foreignPropertiesWithIndex)
+        )
+
+      case None =>
+        (valid, valid)
+    }
+
+    combine(
+      validatedForeignFhlEea,
+      validatedForeignFhlEeaConsolidated,
+      validatedNonFurnishedHolidayLets,
+      validatedDuplicateCountryCode
+    ).onSuccess(parsed)
+  }
+
+  private val resolveAdjustment = ResolveParsedNumber(min = -99999999999.99, disallowZero = true)
+
+  private def resolveAdjusted(path: String, value: Option[BigDecimal]) =
+    resolveAdjustment(value, path)
+
+  private def validateForeignFhlEea(foreignFhlEea: FhlEea): Validated[Seq[MtdError], Unit] =
+    combine(
+      resolveAdjusted("/foreignFhlEea/income/totalRentsReceived", foreignFhlEea.income.flatMap(_.totalRentsReceived)),
+      resolveAdjusted("/foreignFhlEea/expenses/premisesRunningCosts", foreignFhlEea.expenses.flatMap(_.premisesRunningCosts)),
+      resolveAdjusted("/foreignFhlEea/expenses/repairsAndMaintenance", foreignFhlEea.expenses.flatMap(_.repairsAndMaintenance)),
+      resolveAdjusted("/foreignFhlEea/expenses/financialCosts", foreignFhlEea.expenses.flatMap(_.financialCosts)),
+      resolveAdjusted("/foreignFhlEea/expenses/professionalFees", foreignFhlEea.expenses.flatMap(_.professionalFees)),
+      resolveAdjusted("/foreignFhlEea/expenses/travelCosts", foreignFhlEea.expenses.flatMap(_.travelCosts)),
+      resolveAdjusted("/foreignFhlEea/expenses/costOfServices", foreignFhlEea.expenses.flatMap(_.costOfServices)),
+      resolveAdjusted("/foreignFhlEea/expenses/other", foreignFhlEea.expenses.flatMap(_.other)),
+      resolveAdjusted("/foreignFhlEea/expenses/consolidatedExpenses", foreignFhlEea.expenses.flatMap(_.consolidatedExpenses))
+    )
+
+  private def validateForeignFhlEeaConsolidatedExpenses(foreignFhlEea: FhlEea): Validated[Seq[MtdError], Unit] = {
+    foreignFhlEea.expenses
+      .collect {
+        case expenses if expenses.consolidatedExpenses.isDefined =>
+          expenses match {
+            case FhlEeaExpenses(None, None, None, None, None, None, None, Some(_)) =>
+              valid
+            case _ =>
+              Invalid(List(RuleBothExpensesError.copy(paths = Some(List("/foreignFhlEea/expenses")))))
+          }
+      }
+      .getOrElse(valid)
+  }
+
+  private def validateNonFurnishedHolidayLets(foreignProperties: Seq[(ForeignProperty, Int)]): Validated[Seq[MtdError], Unit] = {
+    foreignProperties.traverse_ { case (foreignProperty, i) =>
+      validateForeignProperty(foreignProperty, i)
+        .combine(validateForeignPropertyConsolidatedExpenses(foreignProperty, i))
+    }
+  }
+
+  private def duplicateCountryCodeValidation(foreignProperties: Seq[(ForeignProperty, Int)]): Validated[Seq[MtdError], Unit] = {
+    val duplicateErrors = {
+      foreignProperties
+        .map { case (entry, idx) =>
+          (entry.countryCode, s"/nonFurnishedHolidayLet/$idx/countryCode")
+        }
+        .groupBy(_._1)
+        .collect {
+          case (code, codeAndPaths) if codeAndPaths.size >= 2 =>
+            RuleDuplicateCountryCodeError.forDuplicatedCodesAndPaths(code, codeAndPaths.map(_._2))
+        }
+    }
+
+    if (duplicateErrors.nonEmpty)
+      Invalid(duplicateErrors.toList)
+    else
+      valid
+  }
+
+  private def validateForeignProperty(foreignProperty: ForeignProperty, index: Int): Validated[Seq[MtdError], Unit] = {
+
+    def path(suffix: String) = s"/nonFurnishedHolidayLet/$index/$suffix"
+
+    combine(
+      ResolveParsedCountryCode(foreignProperty.countryCode, path("countryCode")),
+      resolveAdjusted(path("income/totalRentsReceived"), foreignProperty.income.flatMap(_.totalRentsReceived)),
+      resolveAdjusted(path("income/premiumsOfLeaseGrant"), foreignProperty.income.flatMap(_.premiumsOfLeaseGrant)),
+      resolveAdjusted(path("income/otherPropertyIncome"), foreignProperty.income.flatMap(_.otherPropertyIncome)),
+      resolveAdjusted(path("expenses/premisesRunningCosts"), foreignProperty.expenses.flatMap(_.premisesRunningCosts)),
+      resolveAdjusted(path("expenses/repairsAndMaintenance"), foreignProperty.expenses.flatMap(_.repairsAndMaintenance)),
+      resolveAdjusted(path("expenses/financialCosts"), foreignProperty.expenses.flatMap(_.financialCosts)),
+      resolveAdjusted(path("expenses/professionalFees"), foreignProperty.expenses.flatMap(_.professionalFees)),
+      resolveAdjusted(path("expenses/travelCosts"), foreignProperty.expenses.flatMap(_.travelCosts)),
+      resolveAdjusted(path("expenses/costOfServices"), foreignProperty.expenses.flatMap(_.costOfServices)),
+      resolveAdjusted(path("expenses/residentialFinancialCost"), foreignProperty.expenses.flatMap(_.residentialFinancialCost)),
+      resolveAdjusted(path("expenses/other"), foreignProperty.expenses.flatMap(_.other)),
+      resolveAdjusted(path("expenses/consolidatedExpenses"), foreignProperty.expenses.flatMap(_.consolidatedExpenses))
+    )
+  }
+
+  private def validateForeignPropertyConsolidatedExpenses(foreignProperty: ForeignProperty, index: Int): Validated[Seq[MtdError], Unit] = {
+
+    foreignProperty.expenses
+      .collect {
+        case expenses if expenses.consolidatedExpenses.isDefined =>
+          expenses match {
+            case ForeignPropertyExpenses(None, None, None, None, None, None, _, None, Some(_)) =>
+              valid
+            case _ =>
+              Invalid(List(RuleBothExpensesError.copy(paths = Some(List(s"/nonFurnishedHolidayLet/$index/expenses")))))
+          }
+      }
+      .getOrElse(valid)
+  }
+
+}

--- a/app/v5/submitForeignPropertyBsas/validators/def1/Def1_SubmitForeignPropertyBsasValidator.scala
+++ b/app/v5/submitForeignPropertyBsas/validators/def1/Def1_SubmitForeignPropertyBsasValidator.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.validators.def1
+
+import cats.data.Validated
+import cats.implicits._
+import play.api.libs.json.JsValue
+import shared.controllers.validators.Validator
+import shared.controllers.validators.resolvers.{ResolveCalculationId, ResolveNino, ResolveNonEmptyJsonObject, ResolveTysTaxYear, ResolverSupport}
+import shared.models.errors.MtdError
+import v5.controllers.validators.resolvers.ResolveOnlyOneJsonProperty
+import v5.submitForeignPropertyBsas.models.SubmitForeignPropertyBsasRequestData
+import v5.submitForeignPropertyBsas.models.def1.{Def1_SubmitForeignPropertyBsasRequestBody, Def1_SubmitForeignPropertyBsasRequestData}
+
+class Def1_SubmitForeignPropertyBsasValidator(nino: String, calculationId: String, taxYear: Option[String], body: JsValue)
+    extends Validator[SubmitForeignPropertyBsasRequestData]
+    with ResolverSupport {
+
+  private val resolveJson = new ResolveNonEmptyJsonObject[Def1_SubmitForeignPropertyBsasRequestBody]()
+
+  private val resolveOnlyOneJsonProperty = new ResolveOnlyOneJsonProperty("foreignFhlEea", "nonFurnishedHolidayLet")
+
+  private val resolveTysTaxYear = ResolveTysTaxYear.resolver.resolveOptionally
+
+  def validate: Validated[Seq[MtdError], SubmitForeignPropertyBsasRequestData] =
+    resolveOnlyOneJsonProperty(body).productR(
+      (
+        ResolveNino(nino),
+        ResolveCalculationId(calculationId),
+        resolveTysTaxYear(taxYear),
+        resolveJson(body)
+      ).mapN(Def1_SubmitForeignPropertyBsasRequestData)
+    ) andThen Def1_SubmitForeignPropertyBsasRulesValidator.validateBusinessRules
+
+}

--- a/app/v5/submitSelfEmploymentBsas/connectors/SubmitSelfEmploymentBsasConnector.scala
+++ b/app/v5/submitSelfEmploymentBsas/connectors/SubmitSelfEmploymentBsasConnector.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.connectors
+
+import play.api.http.Status
+import shared.config.AppConfig
+import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestData
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubmitSelfEmploymentBsasConnector @Inject()(val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+
+  def submitSelfEmploymentBsas(request: SubmitSelfEmploymentBsasRequestData)(implicit hc: HeaderCarrier,
+                                                                             ec: ExecutionContext,
+                                                                             correlationId: String): Future[DownstreamOutcome[Unit]] = {
+
+    import shared.connectors.httpparsers.StandardDownstreamHttpParser._
+
+    implicit val successCode: SuccessCode = SuccessCode(Status.OK)
+
+    import request._
+
+    val downstreamUri = taxYear match {
+      case Some(taxYearValue) if taxYearValue.useTaxYearSpecificApi =>
+        TaxYearSpecificIfsUri[Unit](s"income-tax/adjustable-summary-calculation/${taxYearValue.asTysDownstream}/$nino/$calculationId")
+      case _ => IfsUri[Unit](s"income-tax/adjustable-summary-calculation/$nino/$calculationId")
+    }
+
+    put(body, downstreamUri)
+  }
+}

--- a/app/v5/submitSelfEmploymentBsas/controllers/SubmitSelfEmploymentBsasController.scala
+++ b/app/v5/submitSelfEmploymentBsas/controllers/SubmitSelfEmploymentBsasController.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.controllers
+
+import play.api.libs.json.JsValue
+import play.api.mvc.{Action, ControllerComponents}
+import shared.config.AppConfig
+import shared.controllers._
+import shared.hateoas.HateoasFactory
+import shared.routing.Version
+import shared.services.{AuditService, EnrolmentsAuthService, MtdIdLookupService}
+import shared.utils.IdGenerator
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasHateoasData
+import v5.submitSelfEmploymentBsas.schema.SubmitSelfEmploymentBsasSchema
+import v5.submitSelfEmploymentBsas.services.SubmitSelfEmploymentBsasService
+import v5.submitSelfEmploymentBsas.validators.SubmitSelfEmploymentBsasValidatorFactory
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class SubmitSelfEmploymentBsasController @Inject() (val authService: EnrolmentsAuthService,
+                                                    val lookupService: MtdIdLookupService,
+                                                    validatorFactory: SubmitSelfEmploymentBsasValidatorFactory,
+                                                    service: SubmitSelfEmploymentBsasService,
+                                                    hateoasFactory: HateoasFactory,
+                                                    auditService: AuditService,
+                                                    cc: ControllerComponents,
+                                                    val idGenerator: IdGenerator)(implicit ec: ExecutionContext, appConfig: AppConfig)
+    extends AuthorisedController(cc) {
+
+  implicit val endpointLogContext: EndpointLogContext =
+    EndpointLogContext(
+      controllerName = "SubmitSelfEmploymentBsasController",
+      endpointName = "submitSelfEmploymentBsas"
+    )
+
+  def submitSelfEmploymentBsas(nino: String, calculationId: String, taxYear: Option[String]): Action[JsValue] =
+    authorisedAction(nino).async(parse.json) { implicit request =>
+      implicit val ctx: RequestContext = RequestContext.from(idGenerator, endpointLogContext)
+
+      val validator = validatorFactory.validator(nino, calculationId, taxYear, request.body, SubmitSelfEmploymentBsasSchema.schemaFor(taxYear))
+
+      val requestHandler =
+        RequestHandler
+          .withValidator(validator)
+          .withService(service.submitSelfEmploymentBsas)
+          .withHateoasResultFrom(hateoasFactory) { (parsedRequest, _) =>
+            SubmitSelfEmploymentBsasHateoasData(nino, calculationId, parsedRequest.taxYear)
+          }
+          .withAuditing(AuditHandler(
+            auditService,
+            auditType = "SubmitSelfEmploymentAccountingAdjustments",
+            transactionName = "submit-self-employment-accounting-adjustments",
+            apiVersion = Version(request),
+            params = Map("nino" -> nino, "calculationId" -> calculationId),
+            requestBody = Some(request.body),
+            includeResponse = true
+          ))
+
+      requestHandler.handleRequest()
+    }
+
+}

--- a/app/v5/submitSelfEmploymentBsas/models/SubmitSelfEmploymentBsasHateoasData.scala
+++ b/app/v5/submitSelfEmploymentBsas/models/SubmitSelfEmploymentBsasHateoasData.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models
+
+import shared.config.AppConfig
+import shared.hateoas.{HateoasData, HateoasLinksFactory, Link}
+import shared.models.domain.TaxYear
+import v5.hateoas.HateoasLinks
+
+object SubmitSelfEmploymentBsasHateoasData extends HateoasLinks {
+
+  implicit object SubmitSelfEmploymentAdjustmentHateoasFactory extends HateoasLinksFactory[Unit, SubmitSelfEmploymentBsasHateoasData] {
+    override def links(appConfig: AppConfig, data: SubmitSelfEmploymentBsasHateoasData): Seq[Link] = {
+      import data._
+      Seq(getSelfEmploymentBsas(appConfig, nino, calculationId, taxYear))
+    }
+  }
+}
+
+case class SubmitSelfEmploymentBsasHateoasData(nino: String, calculationId: String, taxYear: Option[TaxYear]) extends HateoasData

--- a/app/v5/submitSelfEmploymentBsas/models/SubmitSelfEmploymentBsasRequestBody.scala
+++ b/app/v5/submitSelfEmploymentBsas/models/SubmitSelfEmploymentBsasRequestBody.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models
+
+import play.api.libs.json.OWrites
+import v5.submitSelfEmploymentBsas.models.def1.Def1_SubmitSelfEmploymentBsasRequestBody
+
+trait SubmitSelfEmploymentBsasRequestBody
+
+object SubmitSelfEmploymentBsasRequestBody {
+
+  implicit val writes: OWrites[SubmitSelfEmploymentBsasRequestBody] = OWrites.apply[SubmitSelfEmploymentBsasRequestBody] {
+    case a: Def1_SubmitSelfEmploymentBsasRequestBody => implicitly[OWrites[Def1_SubmitSelfEmploymentBsasRequestBody]].writes(a)
+
+    case a: SubmitSelfEmploymentBsasRequestBody => throw new RuntimeException(s"No writes defined for type ${a.getClass.getName}")
+  }
+
+}

--- a/app/v5/submitSelfEmploymentBsas/models/SubmitSelfEmploymentBsasRequestData.scala
+++ b/app/v5/submitSelfEmploymentBsas/models/SubmitSelfEmploymentBsasRequestData.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.submitSelfEmploymentBsas.schema.SubmitSelfEmploymentBsasSchema
+
+trait SubmitSelfEmploymentBsasRequestData {
+  def nino: Nino
+  def calculationId: CalculationId
+  def taxYear: Option[TaxYear]
+  def body: SubmitSelfEmploymentBsasRequestBody
+
+  val schema: SubmitSelfEmploymentBsasSchema
+}

--- a/app/v5/submitSelfEmploymentBsas/models/def1/Additions.scala
+++ b/app/v5/submitSelfEmploymentBsas/models/def1/Additions.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.{Json, OFormat}
+
+case class Additions(costOfGoodsDisallowable: Option[BigDecimal],
+                     paymentsToSubcontractorsDisallowable: Option[BigDecimal],
+                     wagesAndStaffCostsDisallowable: Option[BigDecimal],
+                     carVanTravelExpensesDisallowable: Option[BigDecimal],
+                     premisesRunningCostsDisallowable: Option[BigDecimal],
+                     maintenanceCostsDisallowable: Option[BigDecimal],
+                     adminCostsDisallowable: Option[BigDecimal],
+                     interestOnBankOtherLoansDisallowable: Option[BigDecimal],
+                     financeChargesDisallowable: Option[BigDecimal],
+                     irrecoverableDebtsDisallowable: Option[BigDecimal],
+                     professionalFeesDisallowable: Option[BigDecimal],
+                     depreciationDisallowable: Option[BigDecimal],
+                     otherExpensesDisallowable: Option[BigDecimal],
+                     advertisingCostsDisallowable: Option[BigDecimal],
+                     businessEntertainmentCostsDisallowable: Option[BigDecimal]) {
+
+  val nonEmpty: Boolean = this match {
+    case Additions(None, None, None, None, None, None, None, None, None, None, None, None, None, None, None) => false
+    case _ => true
+  }
+}
+
+object Additions {
+  implicit val format: OFormat[Additions] = Json.format[Additions]
+}

--- a/app/v5/submitSelfEmploymentBsas/models/def1/Def1_SubmitSelfEmploymentBsasRequestBody.scala
+++ b/app/v5/submitSelfEmploymentBsas/models/def1/Def1_SubmitSelfEmploymentBsasRequestBody.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.{JsObject, Json, OWrites, Reads}
+import shared.utils.JsonWritesUtil
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestBody
+
+case class Def1_SubmitSelfEmploymentBsasRequestBody(income: Option[Income], expenses: Option[Expenses], additions: Option[Additions])
+    extends SubmitSelfEmploymentBsasRequestBody {
+
+  def isEmpty: Boolean = !(income.isDefined || expenses.isDefined || additions.isDefined)
+}
+
+object Def1_SubmitSelfEmploymentBsasRequestBody extends JsonWritesUtil {
+
+  implicit val reads: Reads[Def1_SubmitSelfEmploymentBsasRequestBody] = Json.reads
+
+  implicit val writes: OWrites[Def1_SubmitSelfEmploymentBsasRequestBody] = (o: Def1_SubmitSelfEmploymentBsasRequestBody) =>
+    if (o.isEmpty) JsObject.empty
+    else
+      filterNull(
+        Json.obj(
+          "incomeSourceType" -> "01",
+          "adjustments" -> filterNull(
+            Json.obj(
+              "income"    -> o.income,
+              "expenses"  -> o.expenses,
+              "additions" -> o.additions
+            ))
+        ))
+
+}

--- a/app/v5/submitSelfEmploymentBsas/models/def1/Def1_SubmitSelfEmploymentBsasRequestData.scala
+++ b/app/v5/submitSelfEmploymentBsas/models/def1/Def1_SubmitSelfEmploymentBsasRequestData.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models.def1
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestData
+import v5.submitSelfEmploymentBsas.schema.SubmitSelfEmploymentBsasSchema
+
+case class Def1_SubmitSelfEmploymentBsasRequestData(nino: Nino,
+                                                    calculationId: CalculationId,
+                                                    taxYear: Option[TaxYear],
+                                                    body: Def1_SubmitSelfEmploymentBsasRequestBody)
+    extends SubmitSelfEmploymentBsasRequestData {
+  override val schema: SubmitSelfEmploymentBsasSchema = SubmitSelfEmploymentBsasSchema.Def1
+}

--- a/app/v5/submitSelfEmploymentBsas/models/def1/Expenses.scala
+++ b/app/v5/submitSelfEmploymentBsas/models/def1/Expenses.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.{Json, OFormat}
+
+case class Expenses(costOfGoodsAllowable: Option[BigDecimal],
+                    paymentsToSubcontractorsAllowable: Option[BigDecimal],
+                    wagesAndStaffCostsAllowable: Option[BigDecimal],
+                    carVanTravelExpensesAllowable: Option[BigDecimal],
+                    premisesRunningCostsAllowable: Option[BigDecimal],
+                    maintenanceCostsAllowable: Option[BigDecimal],
+                    adminCostsAllowable: Option[BigDecimal],
+                    interestOnBankOtherLoansAllowable: Option[BigDecimal],
+                    financeChargesAllowable: Option[BigDecimal],
+                    irrecoverableDebtsAllowable: Option[BigDecimal],
+                    professionalFeesAllowable: Option[BigDecimal],
+                    depreciationAllowable: Option[BigDecimal],
+                    otherExpensesAllowable: Option[BigDecimal],
+                    advertisingCostsAllowable: Option[BigDecimal],
+                    businessEntertainmentCostsAllowable: Option[BigDecimal],
+                    consolidatedExpenses: Option[BigDecimal]) {
+
+  val hasOnlyConsolidatedExpenses = this match {
+    case Expenses(None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, Some(_)) => true
+    case _ => false
+  }
+}
+
+object Expenses {
+  implicit val format: OFormat[Expenses] = Json.format[Expenses]
+}

--- a/app/v5/submitSelfEmploymentBsas/models/def1/Income.scala
+++ b/app/v5/submitSelfEmploymentBsas/models/def1/Income.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.{Json, OFormat}
+
+case class Income(turnover: Option[BigDecimal], other: Option[BigDecimal])
+
+object Income {
+  implicit val format: OFormat[Income] = Json.format[Income]
+}

--- a/app/v5/submitSelfEmploymentBsas/schema/SubmitSelfEmploymentBsasSchema.scala
+++ b/app/v5/submitSelfEmploymentBsas/schema/SubmitSelfEmploymentBsasSchema.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.schema
+
+import shared.controllers.validators.resolvers.ResolveTaxYear
+import shared.models.domain.TaxYear
+
+import scala.math.Ordered.orderingToOrdered
+
+sealed trait SubmitSelfEmploymentBsasSchema
+
+object SubmitSelfEmploymentBsasSchema {
+
+  case object Def1 extends SubmitSelfEmploymentBsasSchema
+
+  private val defaultSchema = Def1
+
+  def schemaFor(maybeTaxYear: Option[String]): SubmitSelfEmploymentBsasSchema = {
+    maybeTaxYear
+      .map(ResolveTaxYear.resolver)
+      .flatMap(_.toOption.map(schemaFor))
+      .getOrElse(defaultSchema)
+  }
+
+  def schemaFor(taxYear: TaxYear): SubmitSelfEmploymentBsasSchema = {
+    if (TaxYear.starting(2023) <= taxYear) {
+      Def1
+    } else {
+      defaultSchema
+    }
+  }
+
+}

--- a/app/v5/submitSelfEmploymentBsas/services/SubmitSelfEmploymentBsasService.scala
+++ b/app/v5/submitSelfEmploymentBsas/services/SubmitSelfEmploymentBsasService.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.services
+
+import cats.implicits._
+import shared.controllers.RequestContext
+import shared.models
+import shared.models.errors._
+import shared.services.{BaseService, ServiceOutcome}
+import v5.models.errors._
+import v5.submitSelfEmploymentBsas.connectors.SubmitSelfEmploymentBsasConnector
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestData
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubmitSelfEmploymentBsasService @Inject()(connector: SubmitSelfEmploymentBsasConnector) extends BaseService {
+
+  private val errorMap: Map[String, MtdError] = {
+    val errors: Map[String, MtdError] = Map(
+      "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+      "INVALID_CALCULATION_ID" -> CalculationIdFormatError,
+      "INVALID_PAYLOAD" -> models.errors.InternalError,
+      "ASC_ID_INVALID" -> RuleSummaryStatusInvalid,
+      "ASC_ALREADY_SUPERSEDED" -> RuleSummaryStatusSuperseded,
+      "ASC_ALREADY_ADJUSTED" -> RuleAlreadyAdjusted,
+      "UNALLOWABLE_VALUE" -> RuleResultingValueNotPermitted,
+      "INCOMESOURCE_TYPE_NOT_MATCHED" -> RuleTypeOfBusinessIncorrectError,
+      "BVR_FAILURE_C55316" -> RuleOverConsolidatedExpensesThreshold,
+      "BVR_FAILURE_C15320" -> RuleTradingIncomeAllowanceClaimed,
+      "BVR_FAILURE_C55503" -> models.errors.InternalError,
+      "BVR_FAILURE_C55508" -> models.errors.InternalError,
+      "BVR_FAILURE_C55509" -> models.errors.InternalError,
+      "BVR_FAILURE_C559107" -> models.errors.InternalError,
+      "BVR_FAILURE_C559103" -> models.errors.InternalError,
+      "BVR_FAILURE_C559099" -> models.errors.InternalError,
+      "NO_DATA_FOUND" -> NotFoundError,
+      "INVALID_CORRELATIONID" -> models.errors.InternalError,
+      "SERVER_ERROR" -> models.errors.InternalError,
+      "SERVICE_UNAVAILABLE" -> models.errors.InternalError,
+      "RULE_TAX_YEAR_RANGE_INVALID" -> RuleTaxYearRangeInvalidError
+    )
+
+    val extraTysErrors =
+      Map(
+        "INCOME_SOURCE_TYPE_NOT_MATCHED" -> RuleTypeOfBusinessIncorrectError,
+        "INVALID_TAX_YEAR" -> TaxYearFormatError,
+        "NOT_FOUND" -> NotFoundError,
+        "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError
+      )
+
+    errors ++ extraTysErrors
+  }
+
+  def submitSelfEmploymentBsas(request: SubmitSelfEmploymentBsasRequestData)(implicit ctx: RequestContext,
+                                                                             ec: ExecutionContext): Future[ServiceOutcome[Unit]] = {
+
+    connector
+      .submitSelfEmploymentBsas(request)
+      .map(_.leftMap(mapDownstreamErrors(errorMap)))
+  }
+}

--- a/app/v5/submitSelfEmploymentBsas/validators/SubmitSelfEmploymentBsasRulesValidator.scala
+++ b/app/v5/submitSelfEmploymentBsas/validators/SubmitSelfEmploymentBsasRulesValidator.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.validators
+
+import cats.data.Validated
+import cats.data.Validated.Invalid
+import shared.controllers.validators.RulesValidator
+import shared.controllers.validators.resolvers.ResolveParsedNumber
+import shared.models.errors.MtdError
+import v5.models.errors.RuleBothExpensesError
+import v5.submitSelfEmploymentBsas.models.def1.{Additions, Def1_SubmitSelfEmploymentBsasRequestData, Expenses, Income}
+
+object SubmitSelfEmploymentBsasRulesValidator extends RulesValidator[Def1_SubmitSelfEmploymentBsasRequestData] {
+
+  def validateBusinessRules(parsed: Def1_SubmitSelfEmploymentBsasRequestData): Validated[Seq[MtdError], Def1_SubmitSelfEmploymentBsasRequestData] = {
+    import parsed.body
+
+    val validatedIncome = body.income.map(validateIncome).getOrElse(valid)
+
+    val (validatedExpenses, validatedBothExpenses) = body.expenses
+      .map(expenses => (validateExpenses(expenses), validateBothExpenses(expenses, body.additions)))
+      .getOrElse((valid, valid))
+
+    val validatedAdditions = body.additions.map(validateAdditions).getOrElse(valid)
+
+    combine(
+      validatedIncome,
+      validatedExpenses,
+      validatedBothExpenses,
+      validatedAdditions
+    ).onSuccess(parsed)
+  }
+
+  private val resolveAdjustment = ResolveParsedNumber(min = -99999999999.99, disallowZero = true)
+
+  private def resolveAdjusted(path: String, value: Option[BigDecimal]) =
+    resolveAdjustment(value, path)
+
+  private def validateIncome(income: Income): Validated[Seq[MtdError], Unit] = {
+    combine(
+      resolveAdjusted("/income/turnover", income.turnover),
+      resolveAdjusted("/income/other", income.other)
+    )
+  }
+
+  private def validateExpenses(expenses: Expenses): Validated[Seq[MtdError], Unit] =
+    combine(
+      resolveAdjusted("/expenses/costOfGoodsAllowable", expenses.costOfGoodsAllowable),
+      resolveAdjusted("/expenses/paymentsToSubcontractorsAllowable", expenses.paymentsToSubcontractorsAllowable),
+      resolveAdjusted("/expenses/wagesAndStaffCostsAllowable", expenses.wagesAndStaffCostsAllowable),
+      resolveAdjusted("/expenses/carVanTravelExpensesAllowable", expenses.carVanTravelExpensesAllowable),
+      resolveAdjusted("/expenses/premisesRunningCostsAllowable", expenses.premisesRunningCostsAllowable),
+      resolveAdjusted("/expenses/maintenanceCostsAllowable", expenses.maintenanceCostsAllowable),
+      resolveAdjusted("/expenses/adminCostsAllowable", expenses.adminCostsAllowable),
+      resolveAdjusted("/expenses/interestOnBankOtherLoansAllowable", expenses.interestOnBankOtherLoansAllowable),
+      resolveAdjusted("/expenses/financeChargesAllowable", expenses.financeChargesAllowable),
+      resolveAdjusted("/expenses/irrecoverableDebtsAllowable", expenses.irrecoverableDebtsAllowable),
+      resolveAdjusted("/expenses/professionalFeesAllowable", expenses.professionalFeesAllowable),
+      resolveAdjusted("/expenses/depreciationAllowable", expenses.depreciationAllowable),
+      resolveAdjusted("/expenses/otherExpensesAllowable", expenses.otherExpensesAllowable),
+      resolveAdjusted("/expenses/advertisingCostsAllowable", expenses.advertisingCostsAllowable),
+      resolveAdjusted("/expenses/businessEntertainmentCostsAllowable", expenses.businessEntertainmentCostsAllowable),
+      resolveAdjusted("/expenses/consolidatedExpenses", expenses.consolidatedExpenses)
+    )
+
+  private def validateAdditions(additions: Additions): Validated[Seq[MtdError], Unit] =
+    combine(
+      resolveAdjusted("/additions/costOfGoodsDisallowable", additions.costOfGoodsDisallowable),
+      resolveAdjusted("/additions/paymentsToSubcontractorsDisallowable", additions.paymentsToSubcontractorsDisallowable),
+      resolveAdjusted("/additions/wagesAndStaffCostsDisallowable", additions.wagesAndStaffCostsDisallowable),
+      resolveAdjusted("/additions/carVanTravelExpensesDisallowable", additions.carVanTravelExpensesDisallowable),
+      resolveAdjusted("/additions/premisesRunningCostsDisallowable", additions.premisesRunningCostsDisallowable),
+      resolveAdjusted("/additions/maintenanceCostsDisallowable", additions.maintenanceCostsDisallowable),
+      resolveAdjusted("/additions/adminCostsDisallowable", additions.adminCostsDisallowable),
+      resolveAdjusted("/additions/interestOnBankOtherLoansDisallowable", additions.interestOnBankOtherLoansDisallowable),
+      resolveAdjusted("/additions/financeChargesDisallowable", additions.financeChargesDisallowable),
+      resolveAdjusted("/additions/irrecoverableDebtsDisallowable", additions.irrecoverableDebtsDisallowable),
+      resolveAdjusted("/additions/professionalFeesDisallowable", additions.professionalFeesDisallowable),
+      resolveAdjusted("/additions/depreciationDisallowable", additions.depreciationDisallowable),
+      resolveAdjusted("/additions/otherExpensesDisallowable", additions.otherExpensesDisallowable),
+      resolveAdjusted("/additions/advertisingCostsDisallowable", additions.advertisingCostsDisallowable),
+      resolveAdjusted("/additions/businessEntertainmentCostsDisallowable", additions.businessEntertainmentCostsDisallowable)
+    )
+
+  private def validateBothExpenses(expenses: Expenses, additions: Option[Additions]): Validated[Seq[MtdError], Unit] = {
+
+    def bothExpensesError = List(RuleBothExpensesError.withPath("/expenses"))
+
+    (expenses.consolidatedExpenses, additions) match {
+      case (None, _)                                                                       => valid
+      case (Some(_), None) if expenses.hasOnlyConsolidatedExpenses                         => valid
+      case (Some(_), None)                                                                 => Invalid(bothExpensesError)
+      case (Some(_), Some(adds)) if !expenses.hasOnlyConsolidatedExpenses || adds.nonEmpty => Invalid(bothExpensesError)
+      case (Some(_), Some(_))                                                              => valid
+    }
+  }
+
+}

--- a/app/v5/submitSelfEmploymentBsas/validators/SubmitSelfEmploymentBsasValidatorFactory.scala
+++ b/app/v5/submitSelfEmploymentBsas/validators/SubmitSelfEmploymentBsasValidatorFactory.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.validators
+
+import play.api.libs.json.JsValue
+import shared.controllers.validators.Validator
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestData
+import v5.submitSelfEmploymentBsas.schema.SubmitSelfEmploymentBsasSchema
+import v5.submitSelfEmploymentBsas.schema.SubmitSelfEmploymentBsasSchema._
+import v5.submitSelfEmploymentBsas.validators.def1.Def1_SubmitSelfEmploymentBsasValidator
+
+import javax.inject.Singleton
+
+@Singleton
+class SubmitSelfEmploymentBsasValidatorFactory {
+
+  def validator(nino: String,
+                calculationId: String,
+                taxYear: Option[String],
+                body: JsValue,
+                schema: SubmitSelfEmploymentBsasSchema): Validator[SubmitSelfEmploymentBsasRequestData] =
+    schema match {
+      case Def1 => new Def1_SubmitSelfEmploymentBsasValidator(nino, calculationId, taxYear, body)
+    }
+
+}
+
+

--- a/app/v5/submitSelfEmploymentBsas/validators/def1/Def1_SubmitSelfEmploymentBsasValidator.scala
+++ b/app/v5/submitSelfEmploymentBsas/validators/def1/Def1_SubmitSelfEmploymentBsasValidator.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.validators.def1
+
+import cats.implicits._
+import cats.data.Validated
+import play.api.libs.json.JsValue
+import shared.controllers.validators.Validator
+import shared.controllers.validators.resolvers._
+import shared.models.errors.MtdError
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestData
+import v5.submitSelfEmploymentBsas.models.def1.{Def1_SubmitSelfEmploymentBsasRequestBody, Def1_SubmitSelfEmploymentBsasRequestData}
+import v5.submitSelfEmploymentBsas.validators.SubmitSelfEmploymentBsasRulesValidator
+
+class Def1_SubmitSelfEmploymentBsasValidator(nino: String, calculationId: String, taxYear: Option[String], body: JsValue)
+    extends Validator[SubmitSelfEmploymentBsasRequestData]
+    with ResolverSupport {
+
+  private val resolveJson = new ResolveNonEmptyJsonObject[Def1_SubmitSelfEmploymentBsasRequestBody]()
+
+  private val resolveTysTaxYear = ResolveTysTaxYear.resolver.resolveOptionally
+
+  def validate: Validated[Seq[MtdError], SubmitSelfEmploymentBsasRequestData] =
+    (
+      ResolveNino(nino),
+      ResolveCalculationId(calculationId),
+      resolveTysTaxYear(taxYear),
+      resolveJson(body)
+    ).mapN(Def1_SubmitSelfEmploymentBsasRequestData) andThen SubmitSelfEmploymentBsasRulesValidator.validateBusinessRules
+
+}

--- a/app/v5/submitSelfEmploymentBsas/validators/def1/Def1_SubmitSelfEmploymentBsasValidator.scala
+++ b/app/v5/submitSelfEmploymentBsas/validators/def1/Def1_SubmitSelfEmploymentBsasValidator.scala
@@ -26,13 +26,15 @@ import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestData
 import v5.submitSelfEmploymentBsas.models.def1.{Def1_SubmitSelfEmploymentBsasRequestBody, Def1_SubmitSelfEmploymentBsasRequestData}
 import v5.submitSelfEmploymentBsas.validators.SubmitSelfEmploymentBsasRulesValidator
 
-class Def1_SubmitSelfEmploymentBsasValidator(nino: String, calculationId: String, taxYear: Option[String], body: JsValue)
-    extends Validator[SubmitSelfEmploymentBsasRequestData]
-    with ResolverSupport {
-
-  private val resolveJson = new ResolveNonEmptyJsonObject[Def1_SubmitSelfEmploymentBsasRequestBody]()
+object Def1_SubmitSelfEmploymentBsasValidator extends ResolverSupport {
+  private val resolveJson = ResolveNonEmptyJsonObject.resolver[Def1_SubmitSelfEmploymentBsasRequestBody]
 
   private val resolveTysTaxYear = ResolveTysTaxYear.resolver.resolveOptionally
+}
+
+class Def1_SubmitSelfEmploymentBsasValidator(nino: String, calculationId: String, taxYear: Option[String], body: JsValue)
+    extends Validator[SubmitSelfEmploymentBsasRequestData] {
+  import Def1_SubmitSelfEmploymentBsasValidator._
 
   def validate: Validated[Seq[MtdError], SubmitSelfEmploymentBsasRequestData] =
     (

--- a/app/v5/submitUkPropertyBsas/connectors/SubmitUkPropertyBsasConnector.scala
+++ b/app/v5/submitUkPropertyBsas/connectors/SubmitUkPropertyBsasConnector.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.connectors
+
+import play.api.http.Status.OK
+import shared.config.AppConfig
+import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.httpparsers.StandardDownstreamHttpParser._
+import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasRequestData
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubmitUkPropertyBsasConnector @Inject()(val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+
+  def submitPropertyBsas(request: SubmitUkPropertyBsasRequestData)(implicit
+                                                                   hc: HeaderCarrier,
+                                                                   ec: ExecutionContext,
+                                                                   correlationId: String): Future[DownstreamOutcome[Unit]] = {
+
+    import request._
+
+    implicit val successCode: SuccessCode = SuccessCode(OK)
+
+    val downstreamUri =
+      taxYear match {
+        case Some(taxYear) if taxYear.useTaxYearSpecificApi =>
+          TaxYearSpecificIfsUri[Unit](s"income-tax/adjustable-summary-calculation/${taxYear.asTysDownstream}/$nino/$calculationId")
+
+        case _ =>
+          IfsUri[Unit](s"income-tax/adjustable-summary-calculation/$nino/$calculationId")
+      }
+
+    put(
+      body = request.body,
+      uri = downstreamUri
+    )
+  }
+}

--- a/app/v5/submitUkPropertyBsas/controllers/SubmitUkPropertyBsasController.scala
+++ b/app/v5/submitUkPropertyBsas/controllers/SubmitUkPropertyBsasController.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.controllers
+
+import play.api.libs.json.JsValue
+import play.api.mvc.{Action, ControllerComponents}
+import shared.config.AppConfig
+import shared.controllers._
+import shared.hateoas.HateoasFactory
+import shared.routing.Version
+import shared.services.{AuditService, EnrolmentsAuthService, MtdIdLookupService}
+import shared.utils.IdGenerator
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasHateoasData
+import v5.submitUkPropertyBsas.schema.SubmitUkPropertyBsasSchema
+import v5.submitUkPropertyBsas.services.SubmitUkPropertyBsasService
+import v5.submitUkPropertyBsas.validators.SubmitUkPropertyBsasValidatorFactory
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class SubmitUkPropertyBsasController @Inject() (val authService: EnrolmentsAuthService,
+                                                val lookupService: MtdIdLookupService,
+                                                validatorFactory: SubmitUkPropertyBsasValidatorFactory,
+                                                service: SubmitUkPropertyBsasService,
+                                                hateoasFactory: HateoasFactory,
+                                                auditService: AuditService,
+                                                cc: ControllerComponents,
+                                                val idGenerator: IdGenerator)(implicit ec: ExecutionContext, appConfig: AppConfig)
+    extends AuthorisedController(cc) {
+
+  implicit val endpointLogContext: EndpointLogContext =
+    EndpointLogContext(controllerName = "SubmitUkPropertyBsasController", endpointName = "submitUkPropertyBsas")
+
+  def handleRequest(nino: String, calculationId: String, taxYear: Option[String]): Action[JsValue] =
+    authorisedAction(nino).async(parse.json) { implicit request =>
+      implicit val ctx: RequestContext = RequestContext.from(idGenerator, endpointLogContext)
+
+      val validator = validatorFactory.validator(nino, calculationId, taxYear, request.body, SubmitUkPropertyBsasSchema.schemaFor(taxYear))
+
+      val requestHandler =
+        RequestHandler
+          .withValidator(validator)
+          .withService(service.submitPropertyBsas)
+          .withHateoasResultFrom(hateoasFactory) { (parsedRequest, _) =>
+            SubmitUkPropertyBsasHateoasData(nino, calculationId, parsedRequest.taxYear)
+          }
+          .withAuditing(AuditHandler(
+            auditService,
+            auditType = "SubmitUKPropertyAccountingAdjustments",
+            transactionName = "submit-uk-property-accounting-adjustments",
+            apiVersion = Version(request),
+            params = Map("nino" -> nino, "calculationId" -> calculationId),
+            requestBody = Some(request.body),
+            includeResponse = true
+          ))
+
+      requestHandler.handleRequest()
+    }
+
+}

--- a/app/v5/submitUkPropertyBsas/models/SubmitUkPropertyBsasHateoasData.scala
+++ b/app/v5/submitUkPropertyBsas/models/SubmitUkPropertyBsasHateoasData.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models
+
+import shared.config.AppConfig
+import shared.hateoas.{HateoasData, HateoasLinksFactory, Link}
+import shared.models.domain.TaxYear
+import v5.hateoas.HateoasLinks
+
+object SubmitUkPropertyBsasHateoasData extends HateoasLinks {
+
+  implicit object SubmitPropertyAdjustmentHateoasFactory extends HateoasLinksFactory[Unit, SubmitUkPropertyBsasHateoasData] {
+
+    override def links(appConfig: AppConfig, data: SubmitUkPropertyBsasHateoasData): Seq[Link] = {
+
+      import data._
+
+      Seq(getUkPropertyBsas(appConfig, nino, calculationId, taxYear))
+    }
+  }
+}
+
+case class SubmitUkPropertyBsasHateoasData(nino: String, calculationId: String, taxYear: Option[TaxYear]) extends HateoasData

--- a/app/v5/submitUkPropertyBsas/models/SubmitUkPropertyBsasRequestBody.scala
+++ b/app/v5/submitUkPropertyBsas/models/SubmitUkPropertyBsasRequestBody.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models
+
+import play.api.libs.json._
+import v5.submitUkPropertyBsas.models.def1.Def1_SubmitUkPropertyBsasRequestBody
+
+trait SubmitUkPropertyBsasRequestBody
+
+object SubmitUkPropertyBsasRequestBody {
+
+  implicit val writes: OWrites[SubmitUkPropertyBsasRequestBody] = OWrites.apply[SubmitUkPropertyBsasRequestBody] {
+    case a: Def1_SubmitUkPropertyBsasRequestBody => implicitly[OWrites[Def1_SubmitUkPropertyBsasRequestBody]].writes(a)
+
+    case a: SubmitUkPropertyBsasRequestBody => throw new RuntimeException(s"No writes defined for type ${a.getClass.getName}")
+  }
+
+}

--- a/app/v5/submitUkPropertyBsas/models/SubmitUkPropertyBsasRequestData.scala
+++ b/app/v5/submitUkPropertyBsas/models/SubmitUkPropertyBsasRequestData.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.retrieveUkPropertyBsas.schema.RetrieveUkPropertyBsasSchema
+
+trait SubmitUkPropertyBsasRequestData {
+  def nino: Nino
+  def calculationId: CalculationId
+  def taxYear: Option[TaxYear]
+  def body: SubmitUkPropertyBsasRequestBody
+
+  val schema: RetrieveUkPropertyBsasSchema
+}

--- a/app/v5/submitUkPropertyBsas/models/def1/Def1_SubmitUkPropertyBsasRequestBody.scala
+++ b/app/v5/submitUkPropertyBsas/models/def1/Def1_SubmitUkPropertyBsasRequestBody.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json._
+import shared.utils.JsonWritesUtil
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasRequestBody
+
+case class Def1_SubmitUkPropertyBsasRequestBody(nonFurnishedHolidayLet: Option[NonFurnishedHolidayLet],
+                                                furnishedHolidayLet: Option[FurnishedHolidayLet])
+    extends SubmitUkPropertyBsasRequestBody
+
+object Def1_SubmitUkPropertyBsasRequestBody extends JsonWritesUtil {
+  implicit val reads: Reads[Def1_SubmitUkPropertyBsasRequestBody] = Json.reads
+
+  implicit val writes: OWrites[Def1_SubmitUkPropertyBsasRequestBody] = new OWrites[Def1_SubmitUkPropertyBsasRequestBody] {
+
+    override def writes(o: Def1_SubmitUkPropertyBsasRequestBody): JsObject = {
+      writeIfPresent(o.nonFurnishedHolidayLet, incomeSourceType = "02")
+        .orElse(writeIfPresent(o.furnishedHolidayLet, incomeSourceType = "04"))
+        .getOrElse(JsObject.empty)
+    }
+
+    private def writeIfPresent[A: Writes](oa: Option[A], incomeSourceType: String): Option[JsObject] =
+      oa.map { a =>
+        Json.obj("incomeSourceType" -> incomeSourceType, "adjustments" -> a)
+      }
+
+  }
+
+}

--- a/app/v5/submitUkPropertyBsas/models/def1/Def1_SubmitUkPropertyBsasRequestData.scala
+++ b/app/v5/submitUkPropertyBsas/models/def1/Def1_SubmitUkPropertyBsasRequestData.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import v5.retrieveUkPropertyBsas.schema.RetrieveUkPropertyBsasSchema
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasRequestData
+
+case class Def1_SubmitUkPropertyBsasRequestData(nino: Nino,
+                                                calculationId: CalculationId,
+                                                taxYear: Option[TaxYear],
+                                                body: Def1_SubmitUkPropertyBsasRequestBody)
+    extends SubmitUkPropertyBsasRequestData {
+  override val schema: RetrieveUkPropertyBsasSchema = RetrieveUkPropertyBsasSchema.Def1
+}

--- a/app/v5/submitUkPropertyBsas/models/def1/FHLExpenses.scala
+++ b/app/v5/submitUkPropertyBsas/models/def1/FHLExpenses.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json.{Json, OFormat}
+
+case class FHLExpenses(premisesRunningCosts: Option[BigDecimal],
+                       repairsAndMaintenance: Option[BigDecimal],
+                       financialCosts: Option[BigDecimal],
+                       professionalFees: Option[BigDecimal],
+                       costOfServices: Option[BigDecimal],
+                       other: Option[BigDecimal],
+                       travelCosts: Option[BigDecimal],
+                       consolidatedExpenses: Option[BigDecimal])
+
+object FHLExpenses {
+  implicit val format: OFormat[FHLExpenses] = Json.format[FHLExpenses]
+}

--- a/app/v5/submitUkPropertyBsas/models/def1/FHLIncome.scala
+++ b/app/v5/submitUkPropertyBsas/models/def1/FHLIncome.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json._
+
+case class FHLIncome(totalRentsReceived: Option[BigDecimal])
+
+object FHLIncome {
+  implicit val reads: Reads[FHLIncome] = Json.reads[FHLIncome]
+
+  implicit val writes: OWrites[FHLIncome] =
+    (JsPath \ "rentReceived").writeNullable[BigDecimal].contramap((o: FHLIncome) => o.totalRentsReceived)
+}

--- a/app/v5/submitUkPropertyBsas/models/def1/FurnishedHolidayLet.scala
+++ b/app/v5/submitUkPropertyBsas/models/def1/FurnishedHolidayLet.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json.{Json, OFormat}
+
+case class FurnishedHolidayLet(income: Option[FHLIncome], expenses: Option[FHLExpenses])
+
+object FurnishedHolidayLet {
+  implicit val format: OFormat[FurnishedHolidayLet] = Json.format[FurnishedHolidayLet]
+}

--- a/app/v5/submitUkPropertyBsas/models/def1/NonFHLExpenses.scala
+++ b/app/v5/submitUkPropertyBsas/models/def1/NonFHLExpenses.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json.{Json, OFormat}
+
+case class NonFHLExpenses(premisesRunningCosts: Option[BigDecimal],
+                          repairsAndMaintenance: Option[BigDecimal],
+                          financialCosts: Option[BigDecimal],
+                          professionalFees: Option[BigDecimal],
+                          travelCosts: Option[BigDecimal],
+                          costOfServices: Option[BigDecimal],
+                          residentialFinancialCost: Option[BigDecimal],
+                          other: Option[BigDecimal],
+                          consolidatedExpenses: Option[BigDecimal])
+
+object NonFHLExpenses {
+  implicit val format: OFormat[NonFHLExpenses] = Json.format[NonFHLExpenses]
+}

--- a/app/v5/submitUkPropertyBsas/models/def1/NonFHLIncome.scala
+++ b/app/v5/submitUkPropertyBsas/models/def1/NonFHLIncome.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json._
+
+case class NonFHLIncome(totalRentsReceived: Option[BigDecimal],
+                        premiumsOfLeaseGrant: Option[BigDecimal],
+                        reversePremiums: Option[BigDecimal],
+                        otherPropertyIncome: Option[BigDecimal])
+
+object NonFHLIncome {
+  implicit val format: OFormat[NonFHLIncome] = Json.format[NonFHLIncome]
+}

--- a/app/v5/submitUkPropertyBsas/models/def1/NonFurnishedHolidayLet.scala
+++ b/app/v5/submitUkPropertyBsas/models/def1/NonFurnishedHolidayLet.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Json, OWrites, Reads}
+
+case class NonFurnishedHolidayLet(income: Option[NonFHLIncome], expenses: Option[NonFHLExpenses])
+
+object NonFurnishedHolidayLet {
+  implicit val reads: Reads[NonFurnishedHolidayLet] = (
+    (JsPath \ "income").readNullable[NonFHLIncome] and
+      (JsPath \ "expenses").readNullable[NonFHLExpenses]
+    ) (NonFurnishedHolidayLet.apply _)
+
+  implicit val writes: OWrites[NonFurnishedHolidayLet] = Json.writes[NonFurnishedHolidayLet]
+}

--- a/app/v5/submitUkPropertyBsas/schema/SubmitUkPropertyBsasSchema.scala
+++ b/app/v5/submitUkPropertyBsas/schema/SubmitUkPropertyBsasSchema.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.schema
+
+import shared.controllers.validators.resolvers.ResolveTaxYear
+import shared.models.domain.TaxYear
+
+import scala.math.Ordered.orderingToOrdered
+
+sealed trait SubmitUkPropertyBsasSchema
+
+object SubmitUkPropertyBsasSchema {
+
+  case object Def1 extends SubmitUkPropertyBsasSchema
+
+  private val defaultSchema = Def1
+
+  def schemaFor(maybeTaxYear: Option[String]): SubmitUkPropertyBsasSchema = {
+    maybeTaxYear
+      .map(ResolveTaxYear.resolver)
+      .flatMap(_.toOption.map(schemaFor))
+      .getOrElse(defaultSchema)
+  }
+
+  def schemaFor(taxYear: TaxYear): SubmitUkPropertyBsasSchema = {
+    if (TaxYear.starting(2023) <= taxYear) {
+      Def1
+    } else {
+      defaultSchema
+    }
+  }
+
+}

--- a/app/v5/submitUkPropertyBsas/services/SubmitUkPropertyBsasService.scala
+++ b/app/v5/submitUkPropertyBsas/services/SubmitUkPropertyBsasService.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.services
+
+import cats.implicits._
+import shared.controllers.RequestContext
+import shared.models
+import shared.models.errors._
+import shared.services.{BaseService, ServiceOutcome}
+import v5.models.errors._
+import v5.submitUkPropertyBsas.connectors.SubmitUkPropertyBsasConnector
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasRequestData
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubmitUkPropertyBsasService @Inject()(connector: SubmitUkPropertyBsasConnector) extends BaseService {
+
+  private val errorMap: Map[String, MtdError] = {
+    val errors = Map(
+      "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+      "INVALID_CALCULATION_ID" -> CalculationIdFormatError,
+      "INVALID_CORRELATIONID" -> models.errors.InternalError,
+      "INVALID_PAYLOAD" -> models.errors.InternalError,
+      "BVR_FAILURE_C55316" -> models.errors.InternalError,
+      "BVR_FAILURE_C15320" -> models.errors.InternalError,
+      "BVR_FAILURE_C55508" -> RulePropertyIncomeAllowanceClaimed,
+      "BVR_FAILURE_C55509" -> RulePropertyIncomeAllowanceClaimed,
+      "BVR_FAILURE_C55503" -> RuleOverConsolidatedExpensesThreshold,
+      "BVR_FAILURE_C559107" -> models.errors.InternalError,
+      "BVR_FAILURE_C559103" -> models.errors.InternalError,
+      "BVR_FAILURE_C559099" -> models.errors.InternalError,
+      "NO_DATA_FOUND" -> NotFoundError,
+      "ASC_ALREADY_SUPERSEDED" -> RuleSummaryStatusSuperseded,
+      "ASC_ALREADY_ADJUSTED" -> RuleAlreadyAdjusted,
+      "UNALLOWABLE_VALUE" -> RuleResultingValueNotPermitted,
+      "ASC_ID_INVALID" -> RuleSummaryStatusInvalid,
+      "INCOMESOURCE_TYPE_NOT_MATCHED" -> RuleTypeOfBusinessIncorrectError,
+      "SERVER_ERROR" -> models.errors.InternalError,
+      "SERVICE_UNAVAILABLE" -> models.errors.InternalError
+    )
+    val extraTysErrors = Map(
+      "INVALID_TAX_YEAR" -> TaxYearFormatError,
+      "NOT_FOUND" -> NotFoundError,
+      "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError,
+      "INCOME_SOURCE_TYPE_NOT_MATCHED" -> RuleTypeOfBusinessIncorrectError
+    )
+
+    errors ++ extraTysErrors
+  }
+
+  def submitPropertyBsas(request: SubmitUkPropertyBsasRequestData)(implicit ctx: RequestContext, ec: ExecutionContext): Future[ServiceOutcome[Unit]] =
+    connector
+      .submitPropertyBsas(request)
+      .map(_.leftMap(mapDownstreamErrors(errorMap)))
+
+}

--- a/app/v5/submitUkPropertyBsas/validators/SubmitUkPropertyBsasValidatorFactory.scala
+++ b/app/v5/submitUkPropertyBsas/validators/SubmitUkPropertyBsasValidatorFactory.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.validators
+
+import play.api.libs.json.JsValue
+import shared.controllers.validators.Validator
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasRequestData
+import v5.submitUkPropertyBsas.schema.SubmitUkPropertyBsasSchema
+import v5.submitUkPropertyBsas.schema.SubmitUkPropertyBsasSchema._
+import v5.submitUkPropertyBsas.validators.def1.Def1_SubmitUkPropertyBsasValidator
+
+import javax.inject.Singleton
+
+@Singleton
+class SubmitUkPropertyBsasValidatorFactory {
+
+  def validator(nino: String,
+                calculationId: String,
+                taxYear: Option[String],
+                body: JsValue,
+                schema: SubmitUkPropertyBsasSchema): Validator[SubmitUkPropertyBsasRequestData] =
+    schema match {
+      case Def1 => new Def1_SubmitUkPropertyBsasValidator(nino, calculationId, taxYear, body)
+    }
+
+}
+
+

--- a/app/v5/submitUkPropertyBsas/validators/def1/Def1_SubmitUkPropertyBsasRulesValidator.scala
+++ b/app/v5/submitUkPropertyBsas/validators/def1/Def1_SubmitUkPropertyBsasRulesValidator.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.validators.def1
+
+import cats.data.Validated
+import cats.data.Validated.Invalid
+import shared.controllers.validators.RulesValidator
+import shared.controllers.validators.resolvers.ResolveParsedNumber
+import shared.models.errors.MtdError
+import v5.models.errors.RuleBothExpensesError
+import v5.submitUkPropertyBsas.models.def1._
+
+object Def1_SubmitUkPropertyBsasRulesValidator extends RulesValidator[Def1_SubmitUkPropertyBsasRequestData] {
+
+  def validateBusinessRules(parsed: Def1_SubmitUkPropertyBsasRequestData): Validated[Seq[MtdError], Def1_SubmitUkPropertyBsasRequestData] = {
+    import parsed.body
+
+    val (validatedFhl, validatedFhlConsolidated) = body.furnishedHolidayLet match {
+      case Some(fhl) =>
+        (
+          validateFhl(fhl),
+          validateFhlConsolidatedExpenses(fhl)
+        )
+      case None =>
+        (valid, valid)
+    }
+
+    val (validatedNonFhl, validatedNonFhlConsolidated) = body.nonFurnishedHolidayLet match {
+      case Some(ukProperty) =>
+        (
+          validateNonFhl(ukProperty),
+          validateNonFhlConsolidatedExpenses(ukProperty)
+        )
+      case None =>
+        (valid, valid)
+    }
+
+    combine(
+      validatedFhl,
+      validatedFhlConsolidated,
+      validatedNonFhl,
+      validatedNonFhlConsolidated
+    ).onSuccess(parsed)
+  }
+
+  private val resolveAdjustment = ResolveParsedNumber(min = -99999999999.99, disallowZero = true)
+
+  private def resolveAdjusted(path: String, value: Option[BigDecimal]) =
+    resolveAdjustment(value, path)
+
+  private def validateFhl(fhl: FurnishedHolidayLet): Validated[Seq[MtdError], Unit] = {
+    combine(
+      resolveAdjusted("/furnishedHolidayLet/income/totalRentsReceived", fhl.income.flatMap(_.totalRentsReceived)),
+      resolveAdjusted("/furnishedHolidayLet/expenses/premisesRunningCosts", fhl.expenses.flatMap(_.premisesRunningCosts)),
+      resolveAdjusted("/furnishedHolidayLet/expenses/repairsAndMaintenance", fhl.expenses.flatMap(_.repairsAndMaintenance)),
+      resolveAdjusted("/furnishedHolidayLet/expenses/financialCosts", fhl.expenses.flatMap(_.financialCosts)),
+      resolveAdjusted("/furnishedHolidayLet/expenses/professionalFees", fhl.expenses.flatMap(_.professionalFees)),
+      resolveAdjusted("/furnishedHolidayLet/expenses/travelCosts", fhl.expenses.flatMap(_.travelCosts)),
+      resolveAdjusted("/furnishedHolidayLet/expenses/costOfServices", fhl.expenses.flatMap(_.costOfServices)),
+      resolveAdjusted("/furnishedHolidayLet/expenses/other", fhl.expenses.flatMap(_.other)),
+      resolveAdjusted("/furnishedHolidayLet/expenses/consolidatedExpenses", fhl.expenses.flatMap(_.consolidatedExpenses))
+    )
+  }
+
+  private def validateNonFhl(nonFhl: NonFurnishedHolidayLet): Validated[Seq[MtdError], Unit] = {
+    combine(
+      resolveAdjusted("/nonFurnishedHolidayLet/income/totalRentsReceived", nonFhl.income.flatMap(_.totalRentsReceived)),
+      resolveAdjusted("/nonFurnishedHolidayLet/income/premiumsOfLeaseGrant", nonFhl.income.flatMap(_.premiumsOfLeaseGrant)),
+      resolveAdjusted("/nonFurnishedHolidayLet/income/reversePremiums", nonFhl.income.flatMap(_.reversePremiums)),
+      resolveAdjusted("/nonFurnishedHolidayLet/income/otherPropertyIncome", nonFhl.income.flatMap(_.otherPropertyIncome)),
+      resolveAdjusted("/nonFurnishedHolidayLet/expenses/premisesRunningCosts", nonFhl.expenses.flatMap(_.premisesRunningCosts)),
+      resolveAdjusted("/nonFurnishedHolidayLet/expenses/repairsAndMaintenance", nonFhl.expenses.flatMap(_.repairsAndMaintenance)),
+      resolveAdjusted("/nonFurnishedHolidayLet/expenses/financialCosts", nonFhl.expenses.flatMap(_.financialCosts)),
+      resolveAdjusted("/nonFurnishedHolidayLet/expenses/professionalFees", nonFhl.expenses.flatMap(_.professionalFees)),
+      resolveAdjusted("/nonFurnishedHolidayLet/expenses/travelCosts", nonFhl.expenses.flatMap(_.travelCosts)),
+      resolveAdjusted("/nonFurnishedHolidayLet/expenses/costOfServices", nonFhl.expenses.flatMap(_.costOfServices)),
+      resolveAdjusted("/nonFurnishedHolidayLet/expenses/residentialFinancialCost", nonFhl.expenses.flatMap(_.residentialFinancialCost)),
+      resolveAdjusted("/nonFurnishedHolidayLet/expenses/other", nonFhl.expenses.flatMap(_.other)),
+      resolveAdjusted("/nonFurnishedHolidayLet/expenses/consolidatedExpenses", nonFhl.expenses.flatMap(_.consolidatedExpenses))
+    )
+  }
+
+  private def validateFhlConsolidatedExpenses(fhl: FurnishedHolidayLet): Validated[Seq[MtdError], Unit] = {
+    fhl.expenses
+      .collect {
+        case expenses if expenses.consolidatedExpenses.isDefined =>
+          expenses match {
+            case FHLExpenses(None, None, None, None, None, None, None, Some(_)) =>
+              valid
+            case _ =>
+              Invalid(List(RuleBothExpensesError.withPath("/furnishedHolidayLet/expenses")))
+          }
+      }
+      .getOrElse(valid)
+  }
+
+  private def validateNonFhlConsolidatedExpenses(nonFhl: NonFurnishedHolidayLet): Validated[Seq[MtdError], Unit] = {
+    nonFhl.expenses
+      .collect {
+        case expenses if expenses.consolidatedExpenses.isDefined =>
+          expenses match {
+            case NonFHLExpenses(None, None, None, None, None, None, None, None, Some(_)) =>
+              valid
+            case _ =>
+              Invalid(List(RuleBothExpensesError.withPath("/nonFurnishedHolidayLet/expenses")))
+          }
+      }
+      .getOrElse(valid)
+  }
+
+}

--- a/app/v5/submitUkPropertyBsas/validators/def1/Def1_SubmitUkPropertyBsasValidator.scala
+++ b/app/v5/submitUkPropertyBsas/validators/def1/Def1_SubmitUkPropertyBsasValidator.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.validators.def1
+
+import cats.data.Validated
+import cats.implicits._
+import play.api.libs.json.JsValue
+import shared.controllers.validators.Validator
+import shared.controllers.validators.resolvers._
+import shared.models.errors.MtdError
+import v5.controllers.validators.resolvers.ResolveOnlyOneJsonProperty
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasRequestData
+import v5.submitUkPropertyBsas.models.def1.{Def1_SubmitUkPropertyBsasRequestBody, Def1_SubmitUkPropertyBsasRequestData}
+
+class Def1_SubmitUkPropertyBsasValidator(nino: String, calculationId: String, taxYear: Option[String], body: JsValue)
+    extends Validator[SubmitUkPropertyBsasRequestData]
+    with ResolverSupport {
+
+  private val resolveJson = new ResolveNonEmptyJsonObject[Def1_SubmitUkPropertyBsasRequestBody]()
+
+  private val resolveOnlyOneJsonProperty = new ResolveOnlyOneJsonProperty("furnishedHolidayLet", "nonFurnishedHolidayLet")
+
+  private val resolveTysTaxYear = ResolveTysTaxYear.resolver.resolveOptionally
+
+  def validate: Validated[Seq[MtdError], SubmitUkPropertyBsasRequestData] =
+    resolveOnlyOneJsonProperty(body).productR(
+      (
+        ResolveNino(nino),
+        ResolveCalculationId(calculationId),
+        resolveTysTaxYear(taxYear),
+        resolveJson(body)
+      ).mapN(Def1_SubmitUkPropertyBsasRequestData)
+    ) andThen Def1_SubmitUkPropertyBsasRulesValidator.validateBusinessRules
+
+}

--- a/app/v5/triggerBsas/connectors/TriggerBsasConnector.scala
+++ b/app/v5/triggerBsas/connectors/TriggerBsasConnector.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.connectors
+
+import shared.config.AppConfig
+import shared.connectors.DownstreamUri.{IfsUri, TaxYearSpecificIfsUri}
+import shared.connectors.httpparsers.StandardDownstreamHttpParser._
+import shared.connectors.{BaseDownstreamConnector, DownstreamOutcome, DownstreamUri}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import v5.triggerBsas.models.{TriggerBsasRequestData, TriggerBsasResponse}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class TriggerBsasConnector @Inject() (val http: HttpClient, val appConfig: AppConfig) extends BaseDownstreamConnector {
+
+  def triggerBsas(request: TriggerBsasRequestData)(implicit
+      hc: HeaderCarrier,
+      ec: ExecutionContext,
+      correlationId: String): Future[DownstreamOutcome[TriggerBsasResponse]] = {
+
+    import request._
+    import schema._
+
+    val downstreamUri: DownstreamUri[DownstreamResp] =
+      if (taxYear.useTaxYearSpecificApi) {
+        TaxYearSpecificIfsUri(s"income-tax/adjustable-summary-calculation/${taxYear.asTysDownstream}/$nino")
+      } else {
+        IfsUri(s"income-tax/adjustable-summary-calculation/$nino")
+      }
+
+    post(body, downstreamUri)
+
+  }
+
+}

--- a/app/v5/triggerBsas/controllers/TriggerBsasController.scala
+++ b/app/v5/triggerBsas/controllers/TriggerBsasController.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.controllers
+
+import play.api.libs.json.JsValue
+import play.api.mvc.{Action, ControllerComponents}
+import shared.config.AppConfig
+import shared.controllers._
+import shared.hateoas.HateoasFactory
+import shared.routing.Version
+import shared.services.{AuditService, EnrolmentsAuthService, MtdIdLookupService}
+import shared.utils.{IdGenerator, Logging}
+import v5.models.domain.TypeOfBusiness
+import v5.triggerBsas.models.TriggerBsasHateoasData
+import v5.triggerBsas.schema.TriggerSchema
+import v5.triggerBsas.services.TriggerBsasService
+import v5.triggerBsas.validators.TriggerBsasValidatorFactory
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class TriggerBsasController @Inject() (val authService: EnrolmentsAuthService,
+                                       val lookupService: MtdIdLookupService,
+                                       validatorFactory: TriggerBsasValidatorFactory,
+                                       service: TriggerBsasService,
+                                       hateoasFactory: HateoasFactory,
+                                       auditService: AuditService,
+                                       cc: ControllerComponents,
+                                       val idGenerator: IdGenerator)(implicit ec: ExecutionContext, appConfig: AppConfig)
+    extends AuthorisedController(cc)
+    with Logging {
+
+  implicit val endpointLogContext: EndpointLogContext =
+    EndpointLogContext(controllerName = "TriggerBsasController", endpointName = "triggerBsas")
+
+  def triggerBsas(nino: String): Action[JsValue] =
+    authorisedAction(nino).async(parse.json) { implicit request =>
+      implicit val ctx: RequestContext = RequestContext.from(idGenerator, endpointLogContext)
+
+      val validator = validatorFactory.validator(nino, request.body, TriggerSchema.schemaFor(request.body))
+
+      val requestHandler =
+        RequestHandler
+          .withValidator(validator)
+          .withService(service.triggerBsas)
+          .withHateoasResultFrom(hateoasFactory) { (parsedRequest, responseData) =>
+            val typeOfBusiness = TypeOfBusiness.parser(parsedRequest.body.typeOfBusiness)
+            TriggerBsasHateoasData(nino, typeOfBusiness, responseData.calculationId, Some(parsedRequest.taxYear))
+          }
+          .withAuditing(AuditHandler(
+            auditService,
+            auditType = "TriggerBusinessSourceAdjustableSummary",
+            transactionName = "trigger-business-source-adjustable-summary",
+            apiVersion = Version(request),
+            params = Map("nino" -> nino),
+            requestBody = Some(request.body),
+            includeResponse = true
+          ))
+
+      requestHandler.handleRequest()
+    }
+
+}

--- a/app/v5/triggerBsas/models/TriggerBsasRequestBody.scala
+++ b/app/v5/triggerBsas/models/TriggerBsasRequestBody.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models
+
+import play.api.libs.json.OWrites
+import v5.triggerBsas.models.def1.Def1_TriggerBsasRequestBody
+
+trait TriggerBsasRequestBody
+
+object TriggerBsasRequestBody {
+
+  implicit val writes: OWrites[TriggerBsasRequestBody] = OWrites{
+    case a: Def1_TriggerBsasRequestBody => implicitly[OWrites[Def1_TriggerBsasRequestBody]].writes(a)
+    case a: TriggerBsasRequestBody => throw new RuntimeException(s"No writes defined for type ${a.getClass.getName}")
+  }
+
+}

--- a/app/v5/triggerBsas/models/TriggerBsasRequestData.scala
+++ b/app/v5/triggerBsas/models/TriggerBsasRequestData.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models
+
+import shared.models.domain.{Nino, TaxYear}
+import v5.triggerBsas.models.def1.Def1_TriggerBsasRequestBody
+import v5.triggerBsas.schema.TriggerSchema
+
+trait TriggerBsasRequestData {
+  val nino: Nino
+  val body: Def1_TriggerBsasRequestBody
+  val schema: TriggerSchema
+
+  def taxYear: TaxYear
+}

--- a/app/v5/triggerBsas/models/TriggerBsasResponse.scala
+++ b/app/v5/triggerBsas/models/TriggerBsasResponse.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models
+
+import play.api.libs.json.OWrites
+import shared.config.AppConfig
+import shared.hateoas.{HateoasData, HateoasLinksFactory, Link}
+import shared.models.domain.TaxYear
+import v5.hateoas.HateoasLinks
+import v5.models.domain.TypeOfBusiness
+import v5.triggerBsas.models.def1.Def1_TriggerBsasResponse
+
+trait TriggerBsasResponse {
+  val calculationId: String
+}
+
+object TriggerBsasResponse extends HateoasLinks {
+
+  implicit val writes: OWrites[TriggerBsasResponse] = OWrites.apply[TriggerBsasResponse] {
+    case a: Def1_TriggerBsasResponse =>
+      implicitly[OWrites[Def1_TriggerBsasResponse]].writes(a)
+
+    case a: TriggerBsasResponse => throw new RuntimeException(s"No writes defined for type ${a.getClass.getName}")
+  }
+
+  implicit object TriggerHateoasFactory extends HateoasLinksFactory[TriggerBsasResponse, TriggerBsasHateoasData] {
+
+    override def links(appConfig: AppConfig, data: TriggerBsasHateoasData): Seq[Link] = {
+      import data._
+      import v5.models.domain.TypeOfBusiness._
+
+      data.typeOfBusiness match {
+        case `self-employment`                               => Seq(getSelfEmploymentBsas(appConfig, nino, bsasId, taxYear))
+        case `uk-property-fhl` | `uk-property-non-fhl`       => Seq(getUkPropertyBsas(appConfig, nino, bsasId, taxYear))
+        case `foreign-property` | `foreign-property-fhl-eea` => Seq(getForeignPropertyBsas(appConfig, nino, bsasId, taxYear))
+      }
+    }
+
+  }
+
+}
+
+case class TriggerBsasHateoasData(nino: String, typeOfBusiness: TypeOfBusiness, bsasId: String, taxYear: Option[TaxYear]) extends HateoasData

--- a/app/v5/triggerBsas/models/def1/AccountingPeriod.scala
+++ b/app/v5/triggerBsas/models/def1/AccountingPeriod.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models.def1
+
+import play.api.libs.json.{Json, OFormat}
+
+case class AccountingPeriod(startDate: String, endDate: String)
+
+object AccountingPeriod {
+  implicit val format: OFormat[AccountingPeriod] = Json.format[AccountingPeriod]
+}

--- a/app/v5/triggerBsas/models/def1/Def1_TriggerBsasRequestBody.scala
+++ b/app/v5/triggerBsas/models/def1/Def1_TriggerBsasRequestBody.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models.def1
+
+import play.api.libs.json.{Json, OWrites, Reads}
+import v5.models.domain.TypeOfBusiness
+
+/** @param typeOfBusiness
+  *   reads "self-employment" etc from the vendor request, writes "01" etc to the downstream request.
+  */
+case class Def1_TriggerBsasRequestBody(accountingPeriod: AccountingPeriod, typeOfBusiness: String, businessId: String)
+
+object Def1_TriggerBsasRequestBody {
+
+  implicit val reads: Reads[Def1_TriggerBsasRequestBody] = Json.reads[Def1_TriggerBsasRequestBody]
+
+  implicit val writes: OWrites[Def1_TriggerBsasRequestBody] = (requestBody: Def1_TriggerBsasRequestBody) => {
+    val typeOfBusiness = TypeOfBusiness.parser(requestBody.typeOfBusiness)
+    Json.obj(
+      "incomeSourceType"          -> typeOfBusiness.asDownstreamValue,
+      "incomeSourceId"            -> requestBody.businessId,
+      "accountingPeriodStartDate" -> requestBody.accountingPeriod.startDate,
+      "accountingPeriodEndDate"   -> requestBody.accountingPeriod.endDate
+    )
+  }
+
+}

--- a/app/v5/triggerBsas/models/def1/Def1_TriggerBsasRequestData.scala
+++ b/app/v5/triggerBsas/models/def1/Def1_TriggerBsasRequestData.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models.def1
+
+import shared.models.domain.{Nino, TaxYear}
+import v5.triggerBsas.models.TriggerBsasRequestData
+import v5.triggerBsas.schema.TriggerSchema
+
+case class Def1_TriggerBsasRequestData(nino: Nino, body: Def1_TriggerBsasRequestBody) extends TriggerBsasRequestData {
+  lazy val taxYear: TaxYear = TaxYear.fromIso(body.accountingPeriod.endDate)
+
+  override val schema: TriggerSchema = TriggerSchema.Def1
+}

--- a/app/v5/triggerBsas/models/def1/Def1_TriggerBsasResponse.scala
+++ b/app/v5/triggerBsas/models/def1/Def1_TriggerBsasResponse.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models.def1
+
+import play.api.libs.json._
+import v5.triggerBsas.models.TriggerBsasResponse
+
+
+case class Def1_TriggerBsasResponse(calculationId: String) extends TriggerBsasResponse
+
+object Def1_TriggerBsasResponse {
+
+  implicit val writes: OWrites[Def1_TriggerBsasResponse] = Json.writes[Def1_TriggerBsasResponse]
+
+  implicit val reads: Reads[Def1_TriggerBsasResponse] =
+    (JsPath \ "metadata" \ "calculationId").read[String].map(Def1_TriggerBsasResponse.apply)
+
+}

--- a/app/v5/triggerBsas/schema/TriggerSchema.scala
+++ b/app/v5/triggerBsas/schema/TriggerSchema.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.schema
+
+import play.api.libs.json.{JsValue, Reads}
+import shared.models.domain.TaxYear
+import v5.schema.DownstreamReadable
+import v5.triggerBsas.models.TriggerBsasResponse
+import v5.triggerBsas.models.def1.Def1_TriggerBsasResponse
+
+import java.time.LocalDate
+import scala.math.Ordered.orderingToOrdered
+
+sealed trait TriggerSchema extends DownstreamReadable[TriggerBsasResponse]
+
+object TriggerSchema {
+
+  case object Def1 extends TriggerSchema {
+    type DownstreamResp = Def1_TriggerBsasResponse
+    val connectorReads: Reads[DownstreamResp] = Def1_TriggerBsasResponse.reads
+  }
+
+  private val defaultSchema = Def1
+
+  def schemaFor(request: JsValue): TriggerSchema =
+    (request \ "accountingPeriod" \ "endDate")
+      .asOpt[LocalDate]
+      .map(TaxYear.containing)
+      .map(schemaFor)
+      .getOrElse(defaultSchema)
+
+  def schemaFor(taxYear: TaxYear): TriggerSchema = {
+    if (TaxYear.starting(2023) <= taxYear) {
+      Def1
+    } else {
+      defaultSchema
+    }
+  }
+
+}

--- a/app/v5/triggerBsas/services/TriggerBsasService.scala
+++ b/app/v5/triggerBsas/services/TriggerBsasService.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.services
+
+import cats.implicits._
+import shared.controllers.RequestContext
+import shared.models.errors._
+import shared.services.{BaseService, ServiceOutcome}
+import v5.models.errors._
+import v5.triggerBsas.connectors.TriggerBsasConnector
+import v5.triggerBsas.models.{TriggerBsasRequestData, TriggerBsasResponse}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class TriggerBsasService @Inject() (connector: TriggerBsasConnector) extends BaseService {
+
+  def triggerBsas(
+      request: TriggerBsasRequestData)(implicit ctx: RequestContext, ec: ExecutionContext): Future[ServiceOutcome[TriggerBsasResponse]] = {
+    connector
+      .triggerBsas(request)
+      .map(_.leftMap(mapDownstreamErrors(errorMap)))
+  }
+
+  private val errorMap: Map[String, MtdError] = {
+    val errors = Map(
+      "INVALID_TAXABLE_ENTITY_ID"   -> NinoFormatError,
+      "INVALID_CORRELATIONID"       -> InternalError,
+      "INVALID_PAYLOAD"             -> InternalError,
+      "NO_DATA_FOUND"               -> TriggerNotFoundError,
+      "ACCOUNTING_PERIOD_NOT_ENDED" -> RuleAccountingPeriodNotEndedError,
+      "OBLIGATIONS_NOT_MET"         -> RulePeriodicDataIncompleteError,
+      "NO_ACCOUNTING_PERIOD"        -> RuleNoAccountingPeriodError,
+      "SERVER_ERROR"                -> InternalError,
+      "SERVICE_UNAVAILABLE"         -> InternalError
+    )
+    val extraTysErrors =
+      Map(
+        "INVALID_TAX_YEAR"       -> InternalError,
+        "INVALID_CORRELATION_ID" -> InternalError,
+        "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError
+      )
+
+    errors ++ extraTysErrors
+  }
+
+}

--- a/app/v5/triggerBsas/validators/TriggerBsasValidatorFactory.scala
+++ b/app/v5/triggerBsas/validators/TriggerBsasValidatorFactory.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.validators
+
+import play.api.libs.json.JsValue
+import shared.controllers.validators.Validator
+import v5.triggerBsas.models.TriggerBsasRequestData
+import v5.triggerBsas.schema.TriggerSchema
+import v5.triggerBsas.schema.TriggerSchema._
+import v5.triggerBsas.validators.def1.{Def1_TriggerBsasRulesValidator, Def1_TriggerBsasValidator}
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class TriggerBsasValidatorFactory @Inject() (def1_TriggerBsasRulesValidator: Def1_TriggerBsasRulesValidator) {
+
+  def validator(nino: String, body: JsValue, schema: TriggerSchema): Validator[TriggerBsasRequestData] =
+    schema match {
+      case Def1 => new Def1_TriggerBsasValidator(def1_TriggerBsasRulesValidator)(nino, body)
+    }
+
+}

--- a/app/v5/triggerBsas/validators/def1/Def1_TriggerBsasRulesValidator.scala
+++ b/app/v5/triggerBsas/validators/def1/Def1_TriggerBsasRulesValidator.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.validators.def1
+
+import cats.data.Validated
+import cats.data.Validated.Invalid
+import cats.implicits._
+import config.BsasConfig
+import shared.controllers.validators.RulesValidator
+import shared.controllers.validators.resolvers.{ResolveBusinessId, ResolveDateRange}
+import shared.models.errors.MtdError
+import v5.controllers.validators.resolvers.ResolveTypeOfBusiness
+import v5.models.domain.TypeOfBusiness
+import v5.models.domain.TypeOfBusiness.{`foreign-property-fhl-eea`, `foreign-property`, `self-employment`, `uk-property-fhl`, `uk-property-non-fhl`}
+import v5.models.errors.RuleAccountingPeriodNotSupportedError
+import v5.triggerBsas.models.TriggerBsasRequestData
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class Def1_TriggerBsasRulesValidator @Inject()(bsasConfig: BsasConfig) extends RulesValidator[TriggerBsasRequestData] {
+
+  private val minYear: Int = 1900
+  private val maxYear: Int = 2099
+
+  private val resolveDateRange = ResolveDateRange().withYearsLimitedTo(minYear, maxYear)
+
+  private lazy val foreignPropertyEarliestEndDate: LocalDate = LocalDate.parse(
+    s"${bsasConfig.v3TriggerForeignBsasMinimumTaxYear.dropRight(3)}-04-06",
+    DateTimeFormatter.ISO_LOCAL_DATE
+  )
+
+  private lazy val selfEmploymentAndUkPropertyEarliestEndDate: LocalDate = LocalDate.parse(
+    s"${bsasConfig.v3TriggerNonForeignBsasMinimumTaxYear.dropRight(3)}-04-06",
+    DateTimeFormatter.ISO_LOCAL_DATE
+  )
+
+  def validateBusinessRules(parsed: TriggerBsasRequestData): Validated[Seq[MtdError], TriggerBsasRequestData] = {
+    import parsed.body
+    import parsed.body.accountingPeriod._
+
+    val (validatedBusinessId, validatedDateRange, validatedTypeOfBusiness) = (
+      ResolveBusinessId(body.businessId),
+      resolveDateRange(startDate -> endDate),
+      ResolveTypeOfBusiness(body.typeOfBusiness)
+    )
+
+    (
+      validatedBusinessId,
+      validatedDateRange,
+      validatedTypeOfBusiness
+    ).mapN((_, _, _))
+      .andThen { case (_, dateRange, typeOfBusiness) => validateAccountingPeriodNotSupported(dateRange.endDate, typeOfBusiness) }
+      .onSuccess(parsed)
+  }
+
+  private def validateAccountingPeriodNotSupported(endDate: LocalDate, typeOfBusiness: TypeOfBusiness): Validated[Seq[MtdError], Unit] = {
+
+    val earliestDate: LocalDate = typeOfBusiness match {
+      case `self-employment` | `uk-property-fhl` | `uk-property-non-fhl` =>
+        selfEmploymentAndUkPropertyEarliestEndDate
+      case `foreign-property-fhl-eea` | `foreign-property` =>
+        foreignPropertyEarliestEndDate
+    }
+
+    if (endDate.isBefore(earliestDate))
+      Invalid(List(RuleAccountingPeriodNotSupportedError))
+    else
+      valid
+  }
+
+}

--- a/app/v5/triggerBsas/validators/def1/Def1_TriggerBsasValidator.scala
+++ b/app/v5/triggerBsas/validators/def1/Def1_TriggerBsasValidator.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.validators.def1
+
+import cats.data.Validated
+import cats.implicits._
+import play.api.libs.json.JsValue
+import shared.controllers.validators.Validator
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveNonEmptyJsonObject}
+import shared.models.errors.MtdError
+import v5.triggerBsas.models.TriggerBsasRequestData
+import v5.triggerBsas.models.def1.{Def1_TriggerBsasRequestBody, Def1_TriggerBsasRequestData}
+
+class Def1_TriggerBsasValidator(rulesValidator: Def1_TriggerBsasRulesValidator)(nino: String, body: JsValue)
+    extends Validator[TriggerBsasRequestData] {
+  private val resolveJson = new ResolveNonEmptyJsonObject[Def1_TriggerBsasRequestBody]()
+
+  def validate: Validated[Seq[MtdError], TriggerBsasRequestData] = {
+    (
+      ResolveNino(nino),
+      resolveJson(body)
+    ).mapN(Def1_TriggerBsasRequestData) andThen rulesValidator.validateBusinessRules
+  }
+
+}

--- a/app/v5/triggerBsas/validators/def1/Def1_TriggerBsasValidator.scala
+++ b/app/v5/triggerBsas/validators/def1/Def1_TriggerBsasValidator.scala
@@ -20,14 +20,18 @@ import cats.data.Validated
 import cats.implicits._
 import play.api.libs.json.JsValue
 import shared.controllers.validators.Validator
-import shared.controllers.validators.resolvers.{ResolveNino, ResolveNonEmptyJsonObject}
+import shared.controllers.validators.resolvers.{ResolveNino, ResolveNonEmptyJsonObject, ResolverSupport}
 import shared.models.errors.MtdError
 import v5.triggerBsas.models.TriggerBsasRequestData
 import v5.triggerBsas.models.def1.{Def1_TriggerBsasRequestBody, Def1_TriggerBsasRequestData}
 
+object Def1_TriggerBsasValidator extends ResolverSupport {
+  private val resolveJson = ResolveNonEmptyJsonObject.resolver[Def1_TriggerBsasRequestBody]
+}
+
 class Def1_TriggerBsasValidator(rulesValidator: Def1_TriggerBsasRulesValidator)(nino: String, body: JsValue)
     extends Validator[TriggerBsasRequestData] {
-  private val resolveJson = new ResolveNonEmptyJsonObject[Def1_TriggerBsasRequestBody]()
+  import Def1_TriggerBsasValidator._
 
   def validate: Validated[Seq[MtdError], TriggerBsasRequestData] = {
     (

--- a/conf/v5.routes
+++ b/conf/v5.routes
@@ -1,15 +1,13 @@
-GET         /:nino                                        v3.controllers.ListBsasController.listBsas(nino: String, taxYear: Option[String], typeOfBusiness: Option[String], businessId: Option[String])
+GET         /:nino                                        v5.listBsas.controllers.ListBsasController.listBsas(nino: String, taxYear: Option[String], typeOfBusiness: Option[String], businessId: Option[String])
 
-POST        /:nino/trigger                                v4.controllers.TriggerBsasController.triggerBsas(nino: String)
+POST        /:nino/trigger                                v5.triggerBsas.controllers.TriggerBsasController.triggerBsas(nino: String)
 
-GET         /:nino/uk-property/:calculationId             v3.controllers.RetrieveUkPropertyBsasController.retrieve(nino: String, calculationId: String, taxYear: Option[String])
+GET         /:nino/self-employment/:calculationId         v5.retrieveSelfEmploymentBsas.controllers.RetrieveSelfEmploymentBsasController.handleRequest(nino:String, calculationId: String, taxYear: Option[String])
+POST        /:nino/self-employment/:calculationId/adjust  v5.submitSelfEmploymentBsas.controllers.SubmitSelfEmploymentBsasController.submitSelfEmploymentBsas(nino: String, calculationId: String, taxYear: Option[String])
 
-POST        /:nino/uk-property/:calculationId/adjust      v3.controllers.SubmitUkPropertyBsasController.handleRequest(nino: String, calculationId: String, taxYear: Option[String])
+GET         /:nino/uk-property/:calculationId             v5.retrieveUkPropertyBsas.controllers.RetrieveUkPropertyBsasController.retrieve(nino: String, calculationId: String, taxYear: Option[String])
+POST        /:nino/uk-property/:calculationId/adjust      v5.submitUkPropertyBsas.controllers.SubmitUkPropertyBsasController.handleRequest(nino: String, calculationId: String, taxYear: Option[String])
 
-GET         /:nino/self-employment/:calculationId         v4.controllers.RetrieveSelfEmploymentBsasController.handleRequest(nino:String, calculationId: String, taxYear: Option[String])
+GET         /:nino/foreign-property/:calculationId        v5.retrieveForeignPropertyBsas.controllers.RetrieveForeignPropertyBsasController.retrieve(nino: String, calculationId: String, taxYear: Option[String])
+POST        /:nino/foreign-property/:calculationId/adjust v5.submitForeignPropertyBsas.controllers.SubmitForeignPropertyBsasController.handleRequest(nino: String, calculationId: String, taxYear:Option[String])
 
-POST        /:nino/self-employment/:calculationId/adjust  v3.controllers.SubmitSelfEmploymentBsasController.submitSelfEmploymentBsas(nino: String, calculationId: String, taxYear: Option[String])
-
-POST        /:nino/foreign-property/:calculationId/adjust v3.controllers.SubmitForeignPropertyBsasController.handleRequest(nino: String, calculationId: String, taxYear:Option[String])
-
-GET         /:nino/foreign-property/:calculationId        v3.controllers.RetrieveForeignPropertyBsasController.retrieve(nino: String, calculationId: String, taxYear: Option[String])

--- a/it/v3/endpoints/ListBsasControllerISpec.scala
+++ b/it/v3/endpoints/ListBsasControllerISpec.scala
@@ -158,7 +158,6 @@ class ListBsasControllerISpec extends IntegrationBaseSpec with ListBsasFixture {
         private val currentTaxYear = TaxYear.now()
 
         override val taxYear: Option[String]   = None
-        override def downstreamTaxYear: String = currentTaxYear.asTysDownstream
 
         override def setupStubs(): StubMapping = {
           AuditStub.audit()

--- a/it/v5/endpoints/AuthISpec.scala
+++ b/it/v5/endpoints/AuthISpec.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIED OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status
+import play.api.http.Status.OK
+import play.api.libs.json.{JsObject, Json}
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.stubs.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
+import support.IntegrationBaseSpec
+import v5.triggerBsas.fixtures.def1.TriggerBsasRequestBodyFixtures.downstreamResponse
+import v5.models.domain.TypeOfBusiness
+
+class AuthISpec extends IntegrationBaseSpec {
+
+  private trait Test {
+    val nino = "AA123456A"
+
+    val requestJson: JsObject = Json.obj(
+      "accountingPeriod" -> Json.obj("startDate" -> "2019-01-01", "endDate" -> "2019-10-31"),
+      "typeOfBusiness"   -> TypeOfBusiness.`self-employment`.toString,
+      "businessId"       -> "XAIS12345678901"
+    )
+
+    def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/$nino"
+
+    def setupStubs(): StubMapping
+
+    def request(): WSRequest = {
+      setupStubs()
+      buildRequest(uri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.5.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    def uri: String = s"/$nino/trigger"
+  }
+
+  "Calling the sample endpoint" when {
+
+    "the NINO cannot be converted to a MTD ID" should {
+
+      "return 500" in new Test {
+        override val nino: String = "AA123456A"
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          MtdIdLookupStub.internalServerError(nino)
+        }
+
+        val response: WSResponse = await(request().post(requestJson))
+        response.status shouldBe Status.INTERNAL_SERVER_ERROR
+      }
+    }
+
+    "an MTD ID is successfully retrieve from the NINO and the user is authorised" should {
+
+      "return 200" in new Test {
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.POST, downstreamUri, OK, Json.parse(downstreamResponse))
+        }
+
+        val response: WSResponse = await(request().post(requestJson))
+        response.status shouldBe Status.OK
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+    }
+
+    "an MTD ID is successfully retrieve from the NINO and the user is NOT logged in" should {
+
+      "return 403" in new Test {
+        override val nino: String = "AA123456A"
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          MtdIdLookupStub.ninoFound(nino)
+          AuthStub.unauthorisedNotLoggedIn()
+        }
+
+        val response: WSResponse = await(request().post(requestJson))
+        response.status shouldBe Status.FORBIDDEN
+      }
+    }
+
+    "an MTD ID is successfully retrieve from the NINO and the user is NOT authorised" should {
+
+      "return 403" in new Test {
+        override val nino: String = "AA123456A"
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          MtdIdLookupStub.ninoFound(nino)
+          AuthStub.unauthorisedOther()
+        }
+
+        val response: WSResponse = await(request().post(requestJson))
+        response.status shouldBe Status.FORBIDDEN
+      }
+    }
+  }
+
+}

--- a/it/v5/endpoints/ListBsasControllerISpec.scala
+++ b/it/v5/endpoints/ListBsasControllerISpec.scala
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status._
+import play.api.libs.json.Json
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.domain.{Nino, TaxYear}
+import shared.models.errors.{BusinessIdFormatError, InternalError, MtdError, NinoFormatError, NotFoundError, RuleTaxYearNotSupportedError, RuleTaxYearRangeInvalidError, TaxYearFormatError}
+import shared.stubs.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
+import support.IntegrationBaseSpec
+import v5.listBsas.fixtures.def1.ListBsasFixture
+import v5.models.errors.TypeOfBusinessFormatError
+
+class ListBsasControllerISpec extends IntegrationBaseSpec with ListBsasFixture {
+
+  private trait Test {
+    // common
+    val nino                           = "AA123456B"
+    val typeOfBusiness: Option[String] = Some("self-employment")
+    val businessId: Option[String]     = Some("XAIS12345678910")
+
+    def taxYear: Option[String]
+
+    // downstream
+    def downstreamUri: String
+
+    def setupStubs(): StubMapping
+
+    def request: WSRequest = {
+      setupStubs()
+      buildRequest(mtdUri)
+        .addQueryStringParameters(mtdQueryParams: _*)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.5.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    // mtd
+    def mtdUri: String = s"/$nino"
+
+    def mtdQueryParams: Seq[(String, String)] =
+      Seq("typeOfBusiness" -> typeOfBusiness, "businessId" -> businessId, "taxYear" -> taxYear)
+        .collect { case (k, Some(v)) =>
+          (k, v)
+        }
+
+    def errorBody(code: String): String =
+      s"""{
+         |  "code": "$code",
+         |  "reason": "error message"
+         |}""".stripMargin
+
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear: Option[String] = Some("2019-20")
+
+    override def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/$nino"
+  }
+
+  private trait TysIfsTest extends Test {
+    def taxYear: Option[String] = Some("2023-24")
+
+    def downstreamTaxYear: String = "23-24"
+
+    override def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/$downstreamTaxYear/$nino"
+  }
+
+  "Calling the list Bsas endpoint" should {
+    "return a valid response with status OK" when {
+      "valid request is made" in new NonTysTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, listBsasDownstreamJsonMultiple)
+        }
+
+        val response: WSResponse = await(request.get())
+
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+        response.json shouldBe summariesJSONWithHateoas(Nino(nino))
+
+      }
+
+      "valid request is made with a Tax Year Specific (TYS) tax year" in new TysIfsTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, listBsasDownstreamJsonMultiple)
+        }
+
+        val response: WSResponse = await(request.get())
+
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+        response.json shouldBe summariesJSONWithHateoas(Nino(nino), Some("2023-24"))
+      }
+
+      "valid request is made with foreign property" in new NonTysTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, listBsasResponseDownstreamJsonForeign)
+        }
+
+        val response: WSResponse = await(request.get())
+
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+        response.json shouldBe summariesJSONForeignWithHateoas(Nino(nino))
+      }
+
+      "valid request is made with foreign property and a Tax Year Specific (TYS) tax year" in new TysIfsTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, listBsasResponseDownstreamJsonForeign)
+        }
+
+        val response: WSResponse = await(request.get())
+
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+        response.json shouldBe summariesJSONForeignWithHateoas(Nino(nino), Some("2023-24"))
+      }
+
+      "valid request is made without a tax year so that he current tax year is used" in new TysIfsTest {
+        private val currentTaxYear = TaxYear.now()
+
+        override val taxYear: Option[String]   = None
+        override def downstreamTaxYear: String = currentTaxYear.asTysDownstream
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, listBsasDownstreamJsonMultiple)
+        }
+
+        val response: WSResponse = await(request.get())
+
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+        response.json shouldBe summariesJSONWithHateoas(Nino(nino), Some(currentTaxYear.asMtd))
+      }
+    }
+
+    "return error according to spec" when {
+
+      def validationErrorTest(requestNino: String,
+                              requestTaxYear: String,
+                              requestTypeOfBusiness: Option[String],
+                              requestBusinessId: Option[String],
+                              expectedStatus: Int,
+                              expectedBody: MtdError): Unit = {
+        s"validation fails with ${expectedBody.code} error" in new NonTysTest {
+
+          override val nino: String                   = requestNino
+          override val taxYear: Option[String]        = Some(requestTaxYear)
+          override val typeOfBusiness: Option[String] = requestTypeOfBusiness
+          override val businessId: Option[String]     = requestBusinessId
+
+          override def setupStubs(): StubMapping = {
+            AuditStub.audit()
+            AuthStub.authorised()
+            MtdIdLookupStub.ninoFound(nino)
+          }
+
+          val response: WSResponse = await(request.get())
+          response.status shouldBe expectedStatus
+          response.json shouldBe Json.toJson(expectedBody)
+          response.header("Content-Type") shouldBe Some("application/json")
+        }
+      }
+
+      val input = Seq(
+        ("AA1123A", "2019-20", Some("self-employment"), Some("X0IS00000000210"), BAD_REQUEST, NinoFormatError),
+        ("AA123456A", "20177", Some("self-employment"), Some("X0IS00000000210"), BAD_REQUEST, TaxYearFormatError),
+        ("AA123456A", "2018-19", Some("self-employment"), Some("X0IS00000000210"), BAD_REQUEST, RuleTaxYearNotSupportedError),
+        ("AA123456A", "2019-20", Some("self-employment"), Some("X0IS00"), BAD_REQUEST, BusinessIdFormatError),
+        ("AA123456A", "2019-20", Some("self-employments-or-not"), Some("X0IS00000000210"), BAD_REQUEST, TypeOfBusinessFormatError),
+        ("AA123456A", "2019-21", Some("self-employment"), Some("X0IS00000000210"), BAD_REQUEST, RuleTaxYearRangeInvalidError)
+      )
+      input.foreach(args => (validationErrorTest _).tupled(args))
+    }
+
+    "downstream service error" when {
+
+      def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+        s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+
+          override def setupStubs(): StubMapping = {
+            AuditStub.audit()
+            AuthStub.authorised()
+            MtdIdLookupStub.ninoFound(nino)
+            DownstreamStub.onError(DownstreamStub.GET, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+          }
+
+          val response: WSResponse = await(request.get())
+          response.status shouldBe expectedStatus
+          response.json shouldBe Json.toJson(expectedBody)
+          response.header("Content-Type") shouldBe Some("application/json")
+        }
+      }
+
+      val errors = List(
+        (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+        (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+        (BAD_REQUEST, "INVALID_TAXYEAR", BAD_REQUEST, TaxYearFormatError),
+        (BAD_REQUEST, "INVALID_INCOMESOURCEID", BAD_REQUEST, BusinessIdFormatError),
+        (BAD_REQUEST, "INVALID_INCOMESOURCE_TYPE", INTERNAL_SERVER_ERROR, InternalError),
+        (BAD_REQUEST, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+        (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+        (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError),
+        (BAD_REQUEST, "INVALID_REQUEST", INTERNAL_SERVER_ERROR, InternalError)
+      )
+
+      val extraTysErrors = List(
+        (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+        (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+        (BAD_REQUEST, "INVALID_INCOMESOURCE_ID", BAD_REQUEST, BusinessIdFormatError),
+        (BAD_REQUEST, "NOT_FOUND", NOT_FOUND, NotFoundError),
+        (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+      )
+
+      (errors ++ extraTysErrors).foreach(args => (serviceErrorTest _).tupled(args))
+    }
+  }
+
+}

--- a/it/v5/endpoints/RetrieveForeignPropertyBsasControllerISpec.scala
+++ b/it/v5/endpoints/RetrieveForeignPropertyBsasControllerISpec.scala
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.endpoints
+
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status._
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors._
+import shared.stubs.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
+import support.IntegrationBaseSpec
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+import v5.models.errors._
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures
+
+class RetrieveForeignPropertyBsasControllerISpec extends IntegrationBaseSpec {
+
+  private trait Test {
+    val nino          = "AA123456B"
+    val calculationId = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c"
+
+    def taxYear: Option[String]
+
+    def mtdUrl: String
+
+    def downstreamUrl: String
+
+    def retrieveHateoasLink: String
+
+    def submitHateoasLink: String
+
+    def request: WSRequest = {
+      AuditStub.audit()
+      AuthStub.authorised()
+      MtdIdLookupStub.ninoFound(nino)
+      buildRequest(s"/$nino/foreign-property/$calculationId")
+        .withQueryStringParameters(taxYear.map(ty => Seq("taxYear" -> ty)).getOrElse(Nil): _*)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.5.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    def responseWithHateoas(response: JsValue): JsValue =
+      response.as[JsObject] ++ Json
+        .parse(s"""
+           |{
+           |  "links": [
+           |    {
+           |      "href": "$retrieveHateoasLink",
+           |      "method": "GET",
+           |      "rel": "self"
+           |    }, {
+           |      "href": "$submitHateoasLink",
+           |      "method": "POST",
+           |      "rel": "submit-foreign-property-accounting-adjustments"
+           |    }
+           |  ]
+           |}
+           |""".stripMargin)
+        .as[JsObject]
+
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear: Option[String] = None
+
+    def mtdUrl: String = s"/$nino/foreign-property/$calculationId"
+
+    def downstreamUrl: String = s"/income-tax/adjustable-summary-calculation/$nino/$calculationId"
+
+    def retrieveHateoasLink: String = s"/individuals/self-assessment/adjustable-summary/$nino/foreign-property/$calculationId"
+
+    def submitHateoasLink: String = s"/individuals/self-assessment/adjustable-summary/$nino/foreign-property/$calculationId/adjust"
+  }
+
+  private trait TysTest extends Test {
+    def taxYear: Option[String] = Some("2023-24")
+
+    def mtdUrl: String = s"/$nino/foreign-property/$calculationId"
+
+    def downstreamUrl: String = s"/income-tax/adjustable-summary-calculation/23-24/$nino/$calculationId"
+
+    def retrieveHateoasLink: String = s"/individuals/self-assessment/adjustable-summary/$nino/foreign-property/$calculationId?taxYear=2023-24"
+
+    def submitHateoasLink: String = s"/individuals/self-assessment/adjustable-summary/$nino/foreign-property/$calculationId/adjust?taxYear=2023-24"
+  }
+
+  "Calling the retrieve Foreign Property Bsas endpoint" should {
+    "return a valid response with status OK" when {
+      "valid request is made and Non-fhl is returned" in new NonTysTest {
+        DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUrl, OK, retrieveForeignPropertyBsasDesNonFhlJson)
+
+        val response: WSResponse = await(request.get())
+
+        response.json shouldBe responseWithHateoas(retrieveForeignPropertyBsasMtdNonFhlJson)
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+
+      }
+
+      "valid request is made and fhl is returned" in new NonTysTest {
+        DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUrl, OK, retrieveForeignPropertyBsasDesFhlJson)
+
+        val response: WSResponse = await(request.get())
+
+        response.json shouldBe responseWithHateoas(retrieveForeignPropertyBsasMtdFhlJson)
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+
+      }
+
+      "valid request is made for a Tax Year Specific (TYS) tax year" in new TysTest {
+        DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUrl, OK, retrieveForeignPropertyBsasDesNonFhlJson)
+
+        val response: WSResponse = await(request.get())
+
+        response.json shouldBe responseWithHateoas(retrieveForeignPropertyBsasMtdNonFhlJson)
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+
+      }
+    }
+
+    "return error response with status BAD_REQUEST" when {
+      "Downstream response is UK property" in {
+        checkTypeOfBusinessIncorrectWith(RetrieveUkPropertyBsasFixtures.downstreamRetrieveBsasFhlResponseJson)
+      }
+
+      "Downstream response is self employment" in {
+        checkTypeOfBusinessIncorrectWith(RetrieveSelfEmploymentBsasFixtures.downstreamRetrieveBsasResponseJson)
+      }
+
+      def checkTypeOfBusinessIncorrectWith(downstreamResponse: JsValue): Unit =
+        new NonTysTest {
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUrl, OK, downstreamResponse)
+
+          val response: WSResponse = await(request.get())
+
+          response.json shouldBe RuleTypeOfBusinessIncorrectError.asJson
+          response.status shouldBe BAD_REQUEST
+          response.header("Content-Type") shouldBe Some("application/json")
+        }
+    }
+
+    "return error according to spec" when {
+      def validationErrorTest(requestNino: String,
+                              requestBsasId: String,
+                              requestTaxYear: Option[String],
+                              expectedStatus: Int,
+                              expectedBody: MtdError): Unit =
+        s"validation fails with ${expectedBody.code} error" in new TysTest {
+          override val nino: String          = requestNino
+          override val calculationId: String = requestBsasId
+
+          val response: WSResponse = requestTaxYear match {
+            case Some(year) => await(request.withQueryStringParameters("taxYear" -> year).get())
+            case _          => await(request.get())
+          }
+
+          response.json shouldBe Json.toJson(expectedBody)
+          response.status shouldBe expectedStatus
+          response.header("Content-Type") shouldBe Some("application/json")
+        }
+
+      val input = Seq(
+        ("BAD_NINO", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", None, BAD_REQUEST, NinoFormatError),
+        ("AA123456A", "bad_calc_id", None, BAD_REQUEST, CalculationIdFormatError),
+        ("AA123456A", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", Some("2023"), BAD_REQUEST, TaxYearFormatError),
+        ("AA123456A", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", Some("2023-25"), BAD_REQUEST, RuleTaxYearRangeInvalidError),
+        ("AA123456A", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", Some("2022-23"), BAD_REQUEST, InvalidTaxYearParameterError)
+      )
+      input.foreach(args => (validationErrorTest _).tupled(args))
+    }
+
+    "downstream service error" when {
+      def errorBody(code: String): String =
+        s"""{
+           |  "code": "$code",
+           |  "reason": "message"
+           |}""".stripMargin
+
+      def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit =
+        s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+          DownstreamStub.onError(DownstreamStub.GET, downstreamUrl, downstreamStatus, errorBody(downstreamCode))
+
+          val response: WSResponse = await(request.get())
+
+          response.json shouldBe Json.toJson(expectedBody)
+          response.status shouldBe expectedStatus
+          response.header("Content-Type") shouldBe Some("application/json")
+        }
+
+      val errors = Seq(
+        (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+        (BAD_REQUEST, "INVALID_CALCULATION_ID", BAD_REQUEST, CalculationIdFormatError),
+        (BAD_REQUEST, "INVALID_RETURN", INTERNAL_SERVER_ERROR, InternalError),
+        (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+        (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+        (UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY", INTERNAL_SERVER_ERROR, InternalError),
+        (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+        (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+      )
+
+      val extraTysErrors = Seq(
+        (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+        (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+        (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+      )
+
+      (errors ++ extraTysErrors).foreach(args => (serviceErrorTest _).tupled(args))
+    }
+  }
+
+}

--- a/it/v5/endpoints/RetrieveSelfEmploymentBsasControllerISpec.scala
+++ b/it/v5/endpoints/RetrieveSelfEmploymentBsasControllerISpec.scala
@@ -24,9 +24,9 @@ import play.api.test.Helpers.AUTHORIZATION
 import shared.models.errors._
 import shared.stubs.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
 import support.IntegrationBaseSpec
-import v4.fixtures.selfEmployment.RetrieveSelfEmploymentBsasFixtures._
-import v4.models.domain.IncomeSourceType
-import v4.models.errors._
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+import v5.models.domain.IncomeSourceType
+import v5.models.errors._
 
 class RetrieveSelfEmploymentBsasControllerISpec extends IntegrationBaseSpec {
 

--- a/it/v5/endpoints/RetrieveUkPropertyBsasControllerISpec.scala
+++ b/it/v5/endpoints/RetrieveUkPropertyBsasControllerISpec.scala
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.endpoints
+
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status._
+import play.api.libs.json.Json
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors._
+import shared.stubs.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
+import support.IntegrationBaseSpec
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+import v5.models.domain.IncomeSourceType
+import v5.models.errors._
+
+class RetrieveUkPropertyBsasControllerISpec extends IntegrationBaseSpec {
+
+  private trait Test {
+    val nino          = "AA123456B"
+    val calculationId = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c"
+
+    def downstreamUri: String
+
+    def setupStubs(): Unit
+
+    def request: WSRequest = {
+      AuditStub.audit()
+      AuthStub.authorised()
+      MtdIdLookupStub.ninoFound(nino)
+      setupStubs()
+      buildRequest(uri)
+        .withQueryStringParameters(taxYear.map(ty => Seq("taxYear" -> ty)).getOrElse(Nil): _*)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.5.0+json"),
+          (AUTHORIZATION, "Bearer 123")
+        )
+    }
+
+    def taxYear: Option[String] = None
+
+    def uri: String = s"/$nino/uk-property/$calculationId"
+  }
+
+  private trait NonTysTest extends Test {
+
+    def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/$nino/$calculationId"
+  }
+
+  private trait TysIfsTest extends Test {
+
+    override def taxYear: Option[String] = Some("2023-24")
+
+    def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/23-24/$nino/$calculationId"
+  }
+
+  "Calling the retrieve UK Property Bsas endpoint" should {
+    "return a valid response with status OK" when {
+      "valid request is made and FHL is returned" in new NonTysTest {
+
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, downstreamRetrieveBsasFhlResponseJson)
+        }
+
+        val response: WSResponse = await(request.get())
+
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+        response.json shouldBe mtdRetrieveBsasReponseFhlJsonWithHateoas(nino, calculationId)
+
+      }
+
+      "valid request is made and Non-FHL is returned" in new NonTysTest {
+
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, downstreamRetrieveBsasNonFhlResponseJson)
+        }
+
+        val response: WSResponse = await(request.get())
+
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+        response.json shouldBe mtdRetrieveBsasReponseNonFhlJsonWithHateoas(nino, calculationId)
+
+      }
+
+      "any valid Tax Year Specific request is made and FHL is returned" in new TysIfsTest {
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, downstreamRetrieveBsasFhlResponseJson)
+        }
+
+        val response: WSResponse = await(request.get())
+
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+        response.json shouldBe mtdRetrieveBsasReponseFhlJsonWithHateoas(nino, calculationId, taxYear)
+
+      }
+
+      "any valid Tax Year Specific request is made and Non-FHL is returned" in new TysIfsTest {
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(DownstreamStub.GET, downstreamUri, OK, downstreamRetrieveBsasNonFhlResponseJson)
+        }
+
+        val response: WSResponse = await(request.get())
+
+        response.status shouldBe OK
+        response.header("Content-Type") shouldBe Some("application/json")
+
+        response.json shouldBe mtdRetrieveBsasReponseNonFhlJsonWithHateoas(nino, calculationId, taxYear)
+      }
+    }
+
+    "return error response with status BAD_REQUEST" when {
+      "valid request is made but DES response has invalid type of business" in new NonTysTest {
+
+        override def setupStubs(): Unit = {
+          DownstreamStub.onSuccess(
+            DownstreamStub.GET,
+            downstreamUri,
+            OK,
+            downstreamRetrieveBsasResponseJsonInvalidIncomeSourceType(IncomeSourceType.`01`))
+        }
+
+        val response: WSResponse = await(request.get())
+
+        response.status shouldBe BAD_REQUEST
+        response.header("Content-Type") shouldBe Some("application/json")
+        response.json shouldBe RuleTypeOfBusinessIncorrectError.asJson
+      }
+    }
+
+    "return error according to spec" when {
+      def validationErrorTest(requestNino: String,
+                              requestCalculationId: String,
+                              taxYearString: Option[String],
+                              expectedStatus: Int,
+                              expectedBody: MtdError): Unit = {
+        s"validation fails with ${expectedBody.code} error" in new TysIfsTest {
+
+          override val nino: String          = requestNino
+          override val calculationId: String = requestCalculationId
+
+          override def taxYear: Option[String] = taxYearString
+
+          override def setupStubs(): Unit = {}
+
+          val response: WSResponse = await(request.get())
+          response.status shouldBe expectedStatus
+          response.json shouldBe Json.toJson(expectedBody)
+          response.header("Content-Type") shouldBe Some("application/json")
+        }
+      }
+
+      val input = Seq(
+        ("AA1123A", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", Some("2023-24"), BAD_REQUEST, NinoFormatError),
+        ("AA123456A", "f2fb30e5-4ab6-4a29-b3c1-beans", Some("2023-24"), BAD_REQUEST, CalculationIdFormatError),
+        ("AA123456A", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", Some("2023-2024"), BAD_REQUEST, TaxYearFormatError),
+        ("AA123456A", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", Some("2019-20"), BAD_REQUEST, InvalidTaxYearParameterError)
+      )
+      input.foreach(args => (validationErrorTest _).tupled(args))
+    }
+
+    "des service error" when {
+
+      def errorBody(code: String): String =
+        s"""{
+           |  "code": "$code",
+           |  "reason": "des message"
+           |}""".stripMargin
+
+      def serviceErrorTest(desStatus: Int, desCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+        s"des returns an $desCode error and status $desStatus" in new NonTysTest {
+
+          override def setupStubs(): Unit = {
+            AuditStub.audit()
+            AuthStub.authorised()
+            MtdIdLookupStub.ninoFound(nino)
+            DownstreamStub.onError(DownstreamStub.GET, downstreamUri, desStatus, errorBody(desCode))
+          }
+
+          val response: WSResponse = await(request.get())
+          response.status shouldBe expectedStatus
+          response.json shouldBe Json.toJson(expectedBody)
+          response.header("Content-Type") shouldBe Some("application/json")
+        }
+      }
+
+      val errors = Seq(
+        (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+        (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+        (BAD_REQUEST, "INVALID_CALCULATION_ID", BAD_REQUEST, CalculationIdFormatError),
+        (BAD_REQUEST, "INVALID_RETURN", INTERNAL_SERVER_ERROR, InternalError),
+        (UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY", INTERNAL_SERVER_ERROR, InternalError),
+        (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+        (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+        (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+      )
+      val extraTysErrors = Seq(
+        (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+        (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+        (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+      )
+
+      (errors ++ extraTysErrors).foreach(args => (serviceErrorTest _).tupled(args))
+    }
+  }
+
+}

--- a/it/v5/endpoints/SubmitForeignPropertyBsasControllerISpec.scala
+++ b/it/v5/endpoints/SubmitForeignPropertyBsasControllerISpec.scala
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIED OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.endpoints
+
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status._
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors._
+import shared.stubs._
+import support.IntegrationBaseSpec
+import v5.submitForeignPropertyBsas.fixtures.def1.SubmitForeignPropertyBsasFixtures._
+import v5.models.errors._
+
+class SubmitForeignPropertyBsasControllerISpec extends IntegrationBaseSpec {
+
+  private trait Test {
+
+    val nino: String          = "AA123456A"
+    val calculationId: String = "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4"
+    // Downstream returns the adjustments and adjusted calculation - we ignore whatever we get back...
+    val ignoredDownstreamResponse: JsValue = Json.parse("""{"ignored": "doesn't matter"}""")
+
+    val responseBody: JsValue = Json.parse(s"""
+         |{
+         |  "links":[
+         |    {
+         |      "href":"$retrieveHateoasLink",
+         |      "rel":"self",
+         |      "method":"GET"
+         |    }
+         |  ]
+         |}
+         |""".stripMargin)
+
+    def retrieveHateoasLink: String
+
+    def downstreamUrl: String
+
+    def stubDownstreamSuccess(): Unit = {
+      DownstreamStub
+        .when(DownstreamStub.PUT, downstreamUrl)
+        .withRequestBody(downstreamRequestValid)
+        .thenReturn(OK, ignoredDownstreamResponse)
+    }
+
+    def request(): WSRequest = {
+      AuditStub.audit()
+      AuthStub.authorised()
+      MtdIdLookupStub.ninoFound(nino)
+      setupStubs()
+      buildRequest(s"/$nino/foreign-property/$calculationId/adjust")
+        .withQueryStringParameters(taxYear.map(ty => Seq("taxYear" -> ty)).getOrElse(Nil): _*)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.5.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    def taxYear: Option[String] = None
+
+    def setupStubs(): Unit = ()
+
+    def errorBody(code: String): String =
+      s"""
+         |      {
+         |        "code": "$code",
+         |        "reason": "message"
+         |      }
+    """.stripMargin
+
+  }
+
+  private trait NonTysTest extends Test {
+    def downstreamUrl: String = s"/income-tax/adjustable-summary-calculation/$nino/$calculationId"
+
+    def retrieveHateoasLink: String = s"/individuals/self-assessment/adjustable-summary/$nino/foreign-property/$calculationId"
+  }
+
+  private trait TysIfsTest extends Test {
+    override def taxYear: Option[String] = Some("2023-24")
+
+    def downstreamUrl: String = s"/income-tax/adjustable-summary-calculation/23-24/$nino/$calculationId"
+
+    def retrieveHateoasLink: String = s"/individuals/self-assessment/adjustable-summary/$nino/foreign-property/$calculationId?taxYear=2023-24"
+  }
+
+  "Calling the submit foreign property bsas endpoint" should {
+    "return a 200 status code" when {
+      "any valid foreignProperty request is made" in new NonTysTest {
+        override def setupStubs(): Unit = {
+          stubDownstreamSuccess()
+        }
+
+        val response: WSResponse = await(request().post(mtdRequestValid))
+        response.status shouldBe OK
+        response.json shouldBe responseBody
+        response.header("X-CorrelationId") should not be empty
+      }
+
+      "a valid request is made for TYS" in new TysIfsTest {
+        override def setupStubs(): Unit = {
+          stubDownstreamSuccess()
+        }
+
+        val response: WSResponse = await(request().post(mtdRequestValid))
+        response.status shouldBe OK
+        response.json shouldBe responseBody
+        response.header("X-CorrelationId") should not be empty
+
+      }
+
+    }
+
+    "return error according to spec" when {
+
+      def requestBodyWithCountryCode(code: String): JsValue = Json.parse(s"""
+           |{
+           |  "nonFurnishedHolidayLet": [
+           |    {
+           |      "countryCode": "$code",
+           |      "income": {
+           |        "totalRentsReceived": 123.12
+           |      }
+           |    }
+           |  ]
+           |}
+           |""".stripMargin)
+
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestCalculationId: String,
+                                requestTaxYear: Option[String],
+                                requestBody: JsValue,
+                                expectedStatus: Int,
+                                expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new TysIfsTest {
+
+            override val nino: String            = requestNino
+            override val calculationId: String   = requestCalculationId
+            override val taxYear: Option[String] = requestTaxYear
+
+            val response: WSResponse = await(request().post(requestBody))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+          }
+        }
+
+        val input = Seq(
+          ("Walrus", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", None, mtdRequestValid, BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "BAD_CALC_ID", None, mtdRequestValid, BAD_REQUEST, CalculationIdFormatError),
+          ("AA123456A", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", Some("2022-23"), mtdRequestValid, BAD_REQUEST, InvalidTaxYearParameterError),
+          ("AA123456A", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", Some("BAD_TAX_YEAR"), mtdRequestValid, BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", Some("2022-24"), mtdRequestValid, BAD_REQUEST, RuleTaxYearRangeInvalidError),
+          ("AA123456A", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", None, JsObject.empty, BAD_REQUEST, RuleIncorrectOrEmptyBodyError),
+          (
+            "AA123456A",
+            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
+            None,
+            mtdRequestNonFhlFull,
+            BAD_REQUEST,
+            RuleBothExpensesError.copy(paths = Some(Seq("/nonFurnishedHolidayLet/0/expenses")))),
+          (
+            "AA123456A",
+            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
+            None,
+            requestBodyWithCountryCode("XXX"),
+            BAD_REQUEST,
+            RuleCountryCodeError.copy(paths = Some(Seq("/nonFurnishedHolidayLet/0/countryCode")))),
+          (
+            "AA123456A",
+            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
+            None,
+            requestBodyWithCountryCode("FRANCE"),
+            BAD_REQUEST,
+            CountryCodeFormatError.copy(paths = Some(Seq("/nonFurnishedHolidayLet/0/countryCode"))))
+        )
+        input.foreach(args => (validationErrorTest _).tupled(args))
+      }
+
+      "service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new TysIfsTest {
+
+            override def setupStubs(): Unit =
+              DownstreamStub.onError(DownstreamStub.PUT, downstreamUrl, downstreamStatus, errorBody(downstreamCode))
+
+            val response: WSResponse = await(request().post(mtdRequestValid))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+          }
+        }
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_CALCULATION_ID", BAD_REQUEST, CalculationIdFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C15320", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C55508", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C55509", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C559107", BAD_REQUEST, RulePropertyIncomeAllowanceClaimed),
+          (FORBIDDEN, "BVR_FAILURE_C559103", BAD_REQUEST, RulePropertyIncomeAllowanceClaimed),
+          (FORBIDDEN, "BVR_FAILURE_C559099", BAD_REQUEST, RuleOverConsolidatedExpensesThreshold),
+          (FORBIDDEN, "BVR_FAILURE_C55503", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C55316", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (CONFLICT, "ASC_ALREADY_SUPERSEDED", BAD_REQUEST, RuleSummaryStatusSuperseded),
+          (CONFLICT, "ASC_ALREADY_ADJUSTED", BAD_REQUEST, RuleAlreadyAdjusted),
+          (UNPROCESSABLE_ENTITY, "UNALLOWABLE_VALUE", BAD_REQUEST, RuleResultingValueNotPermitted),
+          (UNPROCESSABLE_ENTITY, "ASC_ID_INVALID", BAD_REQUEST, RuleSummaryStatusInvalid),
+          (UNPROCESSABLE_ENTITY, "INCOMESOURCE_TYPE_NOT_MATCHED", BAD_REQUEST, RuleTypeOfBusinessIncorrectError)
+        )
+
+        val extraTysErrors = Seq(
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "INCOME_SOURCE_TYPE_NOT_MATCHED", BAD_REQUEST, RuleTypeOfBusinessIncorrectError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest _).tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/v5/endpoints/SubmitSelfEmploymentBsasControllerISpec.scala
+++ b/it/v5/endpoints/SubmitSelfEmploymentBsasControllerISpec.scala
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIED OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status._
+import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.domain.{CalculationId, Nino}
+import shared.models.errors._
+import shared.stubs._
+import support.IntegrationBaseSpec
+import v5.models.errors._
+
+class SubmitSelfEmploymentBsasControllerISpec extends IntegrationBaseSpec {
+
+  private trait Test {
+
+    val nino          = "AA123456A"
+    val calculationId = "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2"
+
+    def setupStubs(): StubMapping
+
+    def mtdUri: String
+
+    def downstreamUrl: String
+
+    def request(): WSRequest = {
+      setupStubs()
+      buildRequest(mtdUri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.5.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    def errorBody(code: String): String =
+      s"""
+         |      {
+         |        "code": "$code",
+         |        "reason": "error message"
+         |      }
+    """.stripMargin
+
+  }
+
+  private trait NonTysTest extends Test {
+    def mtdUri: String        = s"/$nino/self-employment/$calculationId/adjust"
+    def downstreamUrl: String = s"/income-tax/adjustable-summary-calculation/$nino/$calculationId"
+  }
+
+  private trait TysIfsTest extends Test {
+    def mtdUri: String        = s"/$nino/self-employment/$calculationId/adjust?taxYear=2023-24"
+    def downstreamUrl: String = s"/income-tax/adjustable-summary-calculation/23-24/$nino/$calculationId"
+  }
+
+  import v5.submitSelfEmploymentBsas.fixtures.def1.SubmitSelfEmploymentBsasFixtures._
+
+  val requestBody: JsValue = mtdRequestJson
+
+  "Calling the Submit Adjustments endpoint for self-employment" should {
+    "return a 200 status code" when {
+      "any valid request is made" in new NonTysTest {
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUrl, OK)
+        }
+
+        val result: WSResponse = await(request().post(requestBody))
+        result.status shouldBe OK
+        result.json shouldBe Json.parse(hateoasResponse(Nino(nino), CalculationId(calculationId)))
+        result.header("Content-Type") shouldBe Some("application/json")
+      }
+
+      "any valid TYS request is made" in new TysIfsTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub.onSuccess(DownstreamStub.PUT, downstreamUrl, OK)
+        }
+
+        val result: WSResponse = await(request().post(requestBody))
+        result.status shouldBe OK
+        result.json shouldBe Json.parse(hateoasResponse(Nino(nino), CalculationId(calculationId), Some("2023-24")))
+        result.header("Content-Type") shouldBe Some("application/json")
+      }
+
+    }
+
+    "return error according to spec" when {
+
+      "validation error" when {
+        def validationErrorTest(requestNino: String, expectedStatus: Int, expectedBody: MtdError, requestBodyJson: JsValue): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new NonTysTest {
+
+            override val nino: String = requestNino
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request().post(requestBodyJson))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+          }
+        }
+
+        val input = Seq(
+          ("AA1234A", BAD_REQUEST, NinoFormatError, requestBody),
+          ("AA123456A", BAD_REQUEST, RuleBothExpensesError.copy(paths = Some(Seq("/expenses"))), mtdRequestWithBothExpenses)
+        )
+        input.foreach(args => (validationErrorTest _).tupled(args))
+      }
+
+      "des service error" when {
+        def serviceErrorTest(desStatus: Int, desCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"des returns an $desCode error and status $desStatus" in new NonTysTest {
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.PUT, downstreamUrl, desStatus, errorBody(desCode))
+            }
+
+            val response: WSResponse = await(request().post(requestBody))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+          }
+        }
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_CALCULATION_ID", BAD_REQUEST, CalculationIdFormatError),
+          (UNPROCESSABLE_ENTITY, "ASC_ID_INVALID", BAD_REQUEST, RuleSummaryStatusInvalid),
+          (CONFLICT, "ASC_ALREADY_SUPERSEDED", BAD_REQUEST, RuleSummaryStatusSuperseded),
+          (CONFLICT, "ASC_ALREADY_ADJUSTED", BAD_REQUEST, RuleAlreadyAdjusted),
+          (UNPROCESSABLE_ENTITY, "UNALLOWABLE_VALUE", BAD_REQUEST, RuleResultingValueNotPermitted),
+          (FORBIDDEN, "BVR_FAILURE_C55316", BAD_REQUEST, RuleOverConsolidatedExpensesThreshold),
+          (FORBIDDEN, "BVR_FAILURE_C15320", BAD_REQUEST, RuleTradingIncomeAllowanceClaimed),
+          (FORBIDDEN, "BVR_FAILURE_C55503", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C55508", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C55509", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C559107", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C559103", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C559099", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "INCOMESOURCE_TYPE_NOT_MATCHED", BAD_REQUEST, RuleTypeOfBusinessIncorrectError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val extraTysErrors = Seq(
+          (UNPROCESSABLE_ENTITY, "INCOME_SOURCE_TYPE_NOT_MATCHED", BAD_REQUEST, RuleTypeOfBusinessIncorrectError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (BAD_REQUEST, "RULE_TAX_YEAR_RANGE_INVALID", BAD_REQUEST, RuleTaxYearRangeInvalidError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest _).tupled(args))
+      }
+    }
+  }
+
+}

--- a/it/v5/endpoints/SubmitUkPropertyBsasControllerISpec.scala
+++ b/it/v5/endpoints/SubmitUkPropertyBsasControllerISpec.scala
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIED OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.endpoints
+
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status._
+import play.api.libs.json._
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors._
+import shared.models.utils.JsonErrorValidators
+import shared.stubs._
+import support.IntegrationBaseSpec
+import v5.submitUkPropertyBsas.fixtures.def1.SubmitUKPropertyBsasRequestBodyFixtures._
+import v5.models.errors._
+
+class SubmitUkPropertyBsasControllerISpec extends IntegrationBaseSpec with JsonErrorValidators {
+
+  val requestBodyJson: JsValue = validfhlInputJson
+
+  "Calling the Submit UK Property Accounting Adjustments endpoint" should {
+    "return a 200 status code" when {
+      "any valid request is made for a non-tys tax year" in new NonTysTest {
+
+        override def setupStubs(): Unit = {
+          stubDownstreamSuccess()
+        }
+
+        val response: WSResponse = await(request().post(requestBodyJson))
+        response.status shouldBe OK
+        response.json shouldBe Json.parse(hateoasResponse(nino, calculationId))
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+
+      "any valid request is made for a TYS tax year" in new TysIfsTest {
+        override def setupStubs(): Unit = {
+          stubDownstreamSuccess()
+        }
+
+        val response: WSResponse = await(request().post(requestBodyJson))
+        response.status shouldBe OK
+        response.json shouldBe Json.parse(hateoasResponse(nino, calculationId, taxYear))
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+
+    }
+
+    "return validation error according to spec" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String,
+                                requestCalculationId: String,
+                                requestTaxYear: Option[String],
+                                requestBody: JsValue,
+                                expectedStatus: Int,
+                                expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new TysIfsTest {
+
+            override val nino: String            = requestNino
+            override val calculationId: String   = requestCalculationId
+            override val taxYear: Option[String] = requestTaxYear
+
+            val response: WSResponse = await(request().post(requestBody))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+          }
+        }
+
+        val input = Seq(
+          ("AA1234A", "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2", None, requestBodyJson, BAD_REQUEST, NinoFormatError),
+          ("AA123456A", "041f7e4d87b9", None, requestBodyJson, BAD_REQUEST, CalculationIdFormatError),
+          ("AA123456A", "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2", Some("2022-23"), requestBodyJson, BAD_REQUEST, InvalidTaxYearParameterError),
+          ("AA123456A", "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2", Some("BAD_TAX_YEAR"), requestBodyJson, BAD_REQUEST, TaxYearFormatError),
+          ("AA123456A", "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2", Some("2022-24"), requestBodyJson, BAD_REQUEST, RuleTaxYearRangeInvalidError),
+          (
+            "AA123456A",
+            "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
+            None,
+            requestBodyJson.replaceWithEmptyObject("/furnishedHolidayLet/income"),
+            BAD_REQUEST,
+            RuleIncorrectOrEmptyBodyError.copy(paths = Some(Seq("/furnishedHolidayLet/income")))),
+          (
+            "AA123456A",
+            "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
+            None,
+            requestBodyJson.update("/furnishedHolidayLet/expenses/consolidatedExpenses", JsNumber(1.23)),
+            BAD_REQUEST,
+            RuleBothExpensesError.copy(paths = Some(Seq("/furnishedHolidayLet/expenses")))),
+          (
+            "AA123456A",
+            "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
+            None,
+            requestBodyJson.update("/nonFurnishedHolidayLet/income/totalRentsReceived", JsNumber(2.25)),
+            BAD_REQUEST,
+            RuleBothPropertiesSuppliedError),
+          (
+            "AA123456A",
+            "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
+            None,
+            requestBodyJson
+              .update("/furnishedHolidayLet/expenses/travelCosts", JsNumber(1.523))
+              .update("/furnishedHolidayLet/expenses/other", JsNumber(0.00)),
+            BAD_REQUEST,
+            ValueFormatError.copy(
+              message = "The value must be between -99999999999.99 and 99999999999.99",
+              paths = Some(Seq("/furnishedHolidayLet/expenses/travelCosts", "/furnishedHolidayLet/expenses/other"))
+            ))
+        )
+        input.foreach(args => (validationErrorTest _).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+
+            override def setupStubs(): Unit = {
+              DownstreamStub.onError(DownstreamStub.PUT, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request().post(requestBodyJson))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+          }
+        }
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_CALCULATION_ID", BAD_REQUEST, CalculationIdFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C55316", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C15320", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C55508", BAD_REQUEST, RulePropertyIncomeAllowanceClaimed),
+          (FORBIDDEN, "BVR_FAILURE_C55503", BAD_REQUEST, RuleOverConsolidatedExpensesThreshold),
+          (FORBIDDEN, "BVR_FAILURE_C55509", BAD_REQUEST, RulePropertyIncomeAllowanceClaimed),
+          (FORBIDDEN, "BVR_FAILURE_C559107", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C559103", INTERNAL_SERVER_ERROR, InternalError),
+          (FORBIDDEN, "BVR_FAILURE_C559099", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
+          (CONFLICT, "ASC_ALREADY_SUPERSEDED", BAD_REQUEST, RuleSummaryStatusSuperseded),
+          (CONFLICT, "ASC_ALREADY_ADJUSTED", BAD_REQUEST, RuleAlreadyAdjusted),
+          (UNPROCESSABLE_ENTITY, "UNALLOWABLE_VALUE", BAD_REQUEST, RuleResultingValueNotPermitted),
+          (UNPROCESSABLE_ENTITY, "ASC_ID_INVALID", BAD_REQUEST, RuleSummaryStatusInvalid),
+          (UNPROCESSABLE_ENTITY, "INCOMESOURCE_TYPE_NOT_MATCHED", BAD_REQUEST, RuleTypeOfBusinessIncorrectError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError)
+        )
+        val extraTysErrors = Seq(
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (UNPROCESSABLE_ENTITY, "INCOME_SOURCE_TYPE_NOT_MATCHED", BAD_REQUEST, RuleTypeOfBusinessIncorrectError)
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest _).tupled(args))
+      }
+    }
+  }
+
+  private trait Test {
+
+    val nino: String                       = "AA123456A"
+    val calculationId: String              = "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2"
+    val ignoredDownstreamResponse: JsValue = Json.parse("""{"ignored": "doesn't matter"}""")
+
+    def downstreamUri: String
+
+    def stubDownstreamSuccess(): Unit = {
+      DownstreamStub
+        .onSuccess(DownstreamStub.PUT, downstreamUri, OK)
+    }
+
+    def request(): WSRequest = {
+      AuditStub.audit()
+      AuthStub.authorised()
+      MtdIdLookupStub.ninoFound(nino)
+      setupStubs()
+      buildRequest(s"/$nino/uk-property/$calculationId/adjust")
+        .withQueryStringParameters(taxYear.map(ty => Seq("taxYear" -> ty)).getOrElse(Nil): _*)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.5.0+json"),
+          (AUTHORIZATION, "Bearer 123")
+        )
+    }
+
+    def taxYear: Option[String] = None
+
+    def setupStubs(): Unit = ()
+
+    def errorBody(code: String): String =
+      s"""
+         |{
+         |  "code": "$code",
+         |  "reason": "message"
+         |}
+       """.stripMargin
+
+  }
+
+  private trait TysIfsTest extends Test {
+    override def taxYear: Option[String] = Some("2023-24")
+
+    def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/23-24/$nino/$calculationId"
+  }
+
+  private trait NonTysTest extends Test {
+
+    def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/$nino/$calculationId"
+  }
+
+}

--- a/it/v5/endpoints/TriggerBsasControllerISpec.scala
+++ b/it/v5/endpoints/TriggerBsasControllerISpec.scala
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIED OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.endpoints
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.HeaderNames.ACCEPT
+import play.api.http.Status._
+import play.api.libs.json.{JsObject, Json}
+import play.api.libs.ws.{WSRequest, WSResponse}
+import play.api.test.Helpers.AUTHORIZATION
+import shared.models.errors._
+import shared.stubs.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
+import support.IntegrationBaseSpec
+import v5.triggerBsas.fixtures.def1.TriggerBsasRequestBodyFixtures._
+import v5.models.errors._
+
+class TriggerBsasControllerISpec extends IntegrationBaseSpec {
+
+  private trait Test {
+
+    val nino = "AA123456A"
+
+    def mtdTaxYear: String
+
+    def downstreamTaxYear: String
+
+    def downstreamUri: String
+
+    def setupStubs(): StubMapping
+
+    def triggerHateoasLink(hateoasLinkPath: String): String
+
+    def request(): WSRequest = {
+      setupStubs()
+      buildRequest(uri)
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.5.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+
+    def uri: String = s"/$nino/trigger"
+
+    def errorBody(code: String): String =
+      s"""
+         |      {
+         |        "code": "$code",
+         |        "reason": "message"
+         |      }
+    """.stripMargin
+
+    def makeRequestBody(typeOfBusiness: String, tys: Boolean): JsObject = {
+
+      val startDate = if (tys) "2023-05-01" else "2019-01-01"
+
+      val endDate = if (tys) "2023-05-02" else "2022-10-31"
+
+      Json.obj(
+        "accountingPeriod" -> Json.obj("startDate" -> startDate, "endDate" -> endDate),
+        "typeOfBusiness"   -> typeOfBusiness,
+        "businessId"       -> "XAIS12345678901"
+      )
+    }
+
+    def responseBody(hateoasLinkPath: String): String =
+      s"""
+         |{
+         |  "calculationId": "c75f40a6-a3df-4429-a697-471eeec46435",
+         |  "links":[
+         |    {
+         |      "href":"${triggerHateoasLink(hateoasLinkPath)}",
+         |      "rel":"self",
+         |      "method":"GET"
+         |    }
+         |  ]
+         |}
+    """.stripMargin
+
+  }
+
+  private trait NonTysTest extends Test {
+    def mtdTaxYear: String = "2019-20"
+
+    def downstreamTaxYear: String = "2020"
+
+    override def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/$nino"
+
+    def triggerHateoasLink(hateoasLinkPath: String): String =
+      s"/individuals/self-assessment/adjustable-summary/$nino/$hateoasLinkPath/c75f40a6-a3df-4429-a697-471eeec46435"
+
+  }
+
+  private trait TysIfsTest extends Test {
+    def downstreamTaxYear: String = "23-24"
+
+    override def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/23-24/$nino"
+
+    def triggerHateoasLink(hateoasLinkPath: String): String =
+      s"/individuals/self-assessment/adjustable-summary/$nino/$hateoasLinkPath/c75f40a6-a3df-4429-a697-471eeec46435?taxYear=$mtdTaxYear"
+
+    def mtdTaxYear: String = "2023-24"
+  }
+
+  "Calling the triggerBsas" should {
+    "return a 200 status code" when {
+
+      List(
+        ("self-employment", "self-employment"),
+        ("uk-property-fhl", "uk-property"),
+        ("uk-property-non-fhl", "uk-property"),
+        ("foreign-property-fhl-eea", "foreign-property"),
+        ("foreign-property", "foreign-property")
+      ).foreach { case (typeOfBusiness, hateoasLinkPath) =>
+        s"any valid request is made with typeOfBusiness: $typeOfBusiness" in new NonTysTest {
+
+          override def setupStubs(): StubMapping = {
+            AuditStub.audit()
+            AuthStub.authorised()
+            MtdIdLookupStub.ninoFound(nino)
+
+            DownstreamStub.onSuccess(DownstreamStub.POST, downstreamUri, OK, Json.parse(downstreamResponse))
+          }
+
+          val result: WSResponse = await(request().post(makeRequestBody(typeOfBusiness, false)))
+          result.status shouldBe OK
+          result.json shouldBe Json.parse(responseBody(hateoasLinkPath))
+          result.header("Content-Type") shouldBe Some("application/json")
+        }
+
+        s"any valid request is made with typeOfBusiness: $typeOfBusiness (TYS)" in new TysIfsTest {
+
+          override def setupStubs(): StubMapping = {
+            AuditStub.audit()
+            AuthStub.authorised()
+            MtdIdLookupStub.ninoFound(nino)
+            DownstreamStub.onSuccess(DownstreamStub.POST, downstreamUri, OK, Json.parse(downstreamResponse))
+          }
+
+          val result: WSResponse = await(request().post(makeRequestBody(typeOfBusiness, true)))
+          result.status shouldBe OK
+          result.json shouldBe Json.parse(responseBody(hateoasLinkPath))
+          result.header("Content-Type") shouldBe Some("application/json")
+        }
+      }
+    }
+
+    "return error according to spec" when {
+      "validation error" when {
+        def validationErrorTest(requestNino: String, json: JsObject, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"validation fails with ${expectedBody.code} error" in new NonTysTest {
+
+            override val nino: String = requestNino
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+            }
+
+            val response: WSResponse = await(request().post(json))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+          }
+        }
+
+        val validRequestJson: JsObject = Json.obj(
+          "accountingPeriod" -> Json.obj("startDate" -> "2019-05-05", "endDate" -> "2020-05-06"),
+          "typeOfBusiness"   -> "self-employment",
+          "businessId"       -> "XAIS12345678901"
+        )
+
+        val missingFieldsRequestJson: JsObject = Json.obj(
+          "accountingPeriod" -> Json.obj("startDate" -> "2019-05-05")
+        )
+
+        val missingFieldsError: MtdError = RuleIncorrectOrEmptyBodyError.copy(
+          paths = Some(
+            Seq(
+              "/accountingPeriod/endDate",
+              "/businessId",
+              "/typeOfBusiness"
+            )))
+
+        val startDateErrorRequestJson: JsObject = Json.obj(
+          "accountingPeriod" -> Json.obj("startDate" -> "20180202", "endDate" -> "2019-05-06"),
+          "typeOfBusiness"   -> "self-employment",
+          "businessId"       -> "XAIS12345678901"
+        )
+
+        val endDateErrorRequestJson: JsObject = Json.obj(
+          "accountingPeriod" -> Json.obj("startDate" -> "2018-02-02", "endDate" -> "20190506"),
+          "typeOfBusiness"   -> "self-employment",
+          "businessId"       -> "XAIS12345678901"
+        )
+
+        val typeOfBusinessErrorRequestJson: JsObject = Json.obj(
+          "accountingPeriod" -> Json.obj("startDate" -> "2018-02-02", "endDate" -> "2019-05-06"),
+          "typeOfBusiness"   -> "selfemployment",
+          "businessId"       -> "XAIS12345678901"
+        )
+
+        val businessIdErrorRequestJson: JsObject = Json.obj(
+          "accountingPeriod" -> Json.obj("startDate" -> "2018-02-02", "endDate" -> "2019-05-06"),
+          "typeOfBusiness"   -> "self-employment",
+          "businessId"       -> "XAIS12345678901234"
+        )
+
+        val DateOrderErrorRequestJson: JsObject = Json.obj(
+          "accountingPeriod" -> Json.obj("startDate" -> "2020-02-02", "endDate" -> "2019-05-06"),
+          "typeOfBusiness"   -> "self-employment",
+          "businessId"       -> "XAIS12345678901"
+        )
+
+        val accountingPeriodNotSupportRequestJson: JsObject = Json.obj(
+          "accountingPeriod" -> Json.obj("startDate" -> "2018-02-02", "endDate" -> "2018-05-06"),
+          "typeOfBusiness"   -> "self-employment",
+          "businessId"       -> "XAIS12345678901"
+        )
+
+        val input = Seq(
+          ("AA1123A", validRequestJson, BAD_REQUEST, NinoFormatError),
+          ("AA123456A", missingFieldsRequestJson, BAD_REQUEST, missingFieldsError),
+          ("AA123456A", startDateErrorRequestJson, BAD_REQUEST, StartDateFormatError),
+          ("AA123456A", endDateErrorRequestJson, BAD_REQUEST, EndDateFormatError),
+          ("AA123456A", typeOfBusinessErrorRequestJson, BAD_REQUEST, TypeOfBusinessFormatError),
+          ("AA123456A", businessIdErrorRequestJson, BAD_REQUEST, BusinessIdFormatError),
+          ("AA123456A", DateOrderErrorRequestJson, BAD_REQUEST, RuleEndBeforeStartDateError),
+          ("AA123456A", accountingPeriodNotSupportRequestJson, BAD_REQUEST, RuleAccountingPeriodNotSupportedError)
+        )
+        input.foreach(args => (validationErrorTest _).tupled(args))
+      }
+
+      "downstream service error" when {
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
+
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.POST, downstreamUri, downstreamStatus, errorBody(downstreamCode))
+            }
+
+            val response: WSResponse = await(request().post(makeRequestBody("self-employment", false)))
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+          }
+        }
+
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (UNPROCESSABLE_ENTITY, "ACCOUNTING_PERIOD_NOT_ENDED", BAD_REQUEST, RuleAccountingPeriodNotEndedError),
+          (UNPROCESSABLE_ENTITY, "OBLIGATIONS_NOT_MET", BAD_REQUEST, RulePeriodicDataIncompleteError),
+          (UNPROCESSABLE_ENTITY, "NO_ACCOUNTING_PERIOD", BAD_REQUEST, RuleNoAccountingPeriodError),
+          (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, TriggerNotFoundError),
+          (BAD_REQUEST, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError)
+        )
+
+        val extraTysErrors = Seq(
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", INTERNAL_SERVER_ERROR, InternalError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
+        )
+        (errors ++ extraTysErrors).foreach(args => (serviceErrorTest _).tupled(args))
+      }
+    }
+  }
+
+}

--- a/test/shared/controllers/validators/resolvers/ResolveExclusiveJsonPropertySpec.scala
+++ b/test/shared/controllers/validators/resolvers/ResolveExclusiveJsonPropertySpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shared.controllers.validators.resolvers
+
+import cats.data.Validated.{Invalid, Valid}
+import play.api.http.Status.BAD_REQUEST
+import play.api.libs.json.{JsObject, JsString}
+import shared.UnitSpec
+import shared.models.errors.MtdError
+
+class ResolveExclusiveJsonPropertySpec extends UnitSpec {
+
+  private val error = MtdError("BOTH", "Can't have together", BAD_REQUEST)
+
+  private val resolveExclusiveJsonProperty = new ResolveExclusiveJsonProperty(error, "A1", "A2", "A3")
+
+  private def jsonWithFields(names: String*) =
+    JsObject(names.map(name => name -> JsString("ignored")))
+
+  "ResolveExclusiveJsonProperty" when {
+    "none of the exclusive properties appears" must {
+      val json = jsonWithFields("B", "C")
+
+      "validate successfully" in {
+        resolveExclusiveJsonProperty.validator(json) shouldBe None
+      }
+
+      "resolve successfully" in {
+        resolveExclusiveJsonProperty.resolver(json) shouldBe Valid(json)
+      }
+    }
+
+    "only one of the exclusive properties appears" must {
+      val json = jsonWithFields("A1", "B")
+
+      "validate successfully" in {
+        resolveExclusiveJsonProperty.validator(json) shouldBe None
+      }
+
+      "resolve successfully" in {
+        resolveExclusiveJsonProperty.resolver(json) shouldBe Valid(json)
+      }
+    }
+
+    "more than one of the exclusive properties appears" must {
+      val json = jsonWithFields("A2", "A3", "B")
+
+      "return a validation error from the validator" in {
+        resolveExclusiveJsonProperty.validator(json) shouldBe Some(Seq(error))
+      }
+
+      "return the validation error from the resolver" in {
+        resolveExclusiveJsonProperty.resolver(json) shouldBe Invalid(Seq(error))
+      }
+    }
+  }
+
+}

--- a/test/shared/models/domain/TaxYearPropertyCheckSupport.scala
+++ b/test/shared/models/domain/TaxYearPropertyCheckSupport.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shared.models.domain
+
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+trait TaxYearPropertyCheckSupport {
+  self : ScalaCheckDrivenPropertyChecks =>
+
+  implicit val arbTaxYear: Arbitrary[TaxYear] = Arbitrary(Gen.choose(2010, 2050).map(TaxYear.starting))
+
+}

--- a/test/v5/hateoas/HateoasLinksSpec.scala
+++ b/test/v5/hateoas/HateoasLinksSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.hateoas
+
+import shared.UnitSpec
+import shared.config.MockAppConfig
+import shared.hateoas.Method.{GET, POST}
+import shared.hateoas.{Link, Method}
+import shared.models.domain.TaxYear
+import v5.hateoas.RelType._
+
+class HateoasLinksSpec extends UnitSpec with MockAppConfig {
+
+  private val nino        = "AA111111A"
+  private val calcId      = "1234567890"
+  private val taxYear2023 = TaxYear.fromMtd("2022-23")
+  private val taxYear2024 = TaxYear.fromMtd("2023-24")
+
+  def assertCorrectLink(makeLink: Option[TaxYear] => Link, baseHref: String, method: Method, rel: String): Unit = {
+    "return the correct link" in new Test {
+      makeLink(None) shouldBe Link(href = baseHref, method = method, rel = rel)
+    }
+
+    "not include tax year query parameter given a non-TYS tax year" in new Test {
+      makeLink(Some(taxYear2023)) shouldBe Link(href = baseHref, method = method, rel = rel)
+    }
+
+    "include tax year query parameter given a TYS tax year" in new Test {
+      makeLink(Some(taxYear2024)) shouldBe Link(href = s"$baseHref?taxYear=2023-24", method = method, rel = rel)
+    }
+  }
+
+  class Test {
+    MockAppConfig.apiGatewayContext.returns("context").anyNumberOfTimes()
+  }
+
+  "HateoasLinks" when {
+    "triggerBsas" should {
+      "return the correct link" in new Test {
+        val link: Link = Link(href = s"/context/$nino/trigger", method = POST, rel = TRIGGER)
+        Target.triggerBsas(mockAppConfig, nino) shouldBe link
+      }
+    }
+
+    "listBsas" should {
+      assertCorrectLink(
+        makeLink = Target.listBsas(mockAppConfig, nino, _),
+        baseHref = s"/context/$nino",
+        method = GET,
+        rel = SELF
+      )
+    }
+
+    "getSelfEmploymentBsas" should {
+      assertCorrectLink(
+        makeLink = Target.getSelfEmploymentBsas(mockAppConfig, nino, calcId, _),
+        baseHref = s"/context/$nino/self-employment/$calcId",
+        method = GET,
+        rel = SELF
+      )
+    }
+
+    "getUkPropertyBsas" should {
+      assertCorrectLink(
+        makeLink = Target.getUkPropertyBsas(mockAppConfig, nino, calcId, _),
+        baseHref = s"/context/$nino/uk-property/$calcId",
+        method = GET,
+        rel = SELF
+      )
+    }
+
+    "getForeignPropertyBsas" should {
+      assertCorrectLink(
+        makeLink = Target.getForeignPropertyBsas(mockAppConfig, nino, calcId, _),
+        baseHref = s"/context/$nino/foreign-property/$calcId",
+        method = GET,
+        rel = SELF
+      )
+    }
+
+    "adjustSelfEmploymentBsas" should {
+      assertCorrectLink(
+        makeLink = Target.adjustSelfEmploymentBsas(mockAppConfig, nino, calcId, _),
+        baseHref = s"/context/$nino/self-employment/$calcId/adjust",
+        method = POST,
+        rel = SUBMIT_SE_ADJUSTMENTS
+      )
+    }
+
+    "adjustUkPropertyBsas" should {
+      assertCorrectLink(
+        makeLink = Target.adjustUkPropertyBsas(mockAppConfig, nino, calcId, _),
+        baseHref = s"/context/$nino/uk-property/$calcId/adjust",
+        method = POST,
+        rel = SUBMIT_UK_PROPERTY_ADJUSTMENTS
+      )
+    }
+
+    "adjustForeignPropertyBsas" should {
+      assertCorrectLink(
+        makeLink = Target.adjustForeignPropertyBsas(mockAppConfig, nino, calcId, _),
+        baseHref = s"/context/$nino/foreign-property/$calcId/adjust",
+        method = POST,
+        rel = SUBMIT_FOREIGN_PROPERTY_ADJUSTMENTS
+      )
+    }
+
+  }
+
+  object Target extends HateoasLinks
+}

--- a/test/v5/listBsas/connectors/ListBsasConnectorSpec.scala
+++ b/test/v5/listBsas/connectors/ListBsasConnectorSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.connectors
+
+import org.scalamock.handlers.CallHandler
+import shared.connectors.{ConnectorSpec, DownstreamOutcome}
+import shared.models.domain.{BusinessId, Nino, TaxYear}
+import shared.models.errors.{DownstreamErrorCode, DownstreamErrors}
+import shared.models.outcomes.ResponseWrapper
+import v5.listBsas.fixtures.def1.ListBsasFixture
+import v5.listBsas.models.def1.Def1_ListBsasRequestData
+import v5.listBsas.models.{BsasSummary, ListBsasRequestData, ListBsasResponse}
+
+import scala.concurrent.Future
+
+class ListBsasConnectorSpec extends ConnectorSpec with ListBsasFixture {
+
+  private val nino             = Nino("AA123456A")
+  private val incomeSourceId   = "XAIS12345678910"
+  private val incomeSourceType = "02"
+
+  private val preTysTaxYear = TaxYear.fromMtd("2018-19")
+  private val tysTaxYear    = TaxYear.fromMtd("2023-24")
+
+  private val additionalQueryParams: Seq[(String, String)] = List(
+    ("taxYear", preTysTaxYear.asDownstream)
+  )
+
+  private val commonQueryParams: Seq[(String, String)] = List(
+    ("incomeSourceId", incomeSourceId),
+    ("incomeSourceType", incomeSourceType)
+  )
+
+  "listBsas" should {
+    "return a valid response" when {
+      "a valid request is supplied" in new IfsTest with Test {
+        def taxYear: TaxYear                             = preTysTaxYear
+        def downstreamQueryParams: Seq[(String, String)] = commonQueryParams ++ additionalQueryParams
+
+        val outcome = Right(ResponseWrapper(correlationId, listBsasResponseModel))
+        stubHttpResponse(outcome)
+
+        val result: DownstreamOutcome[ListBsasResponse[BsasSummary]] = await(connector.listBsas(request))
+        result shouldBe outcome
+      }
+    }
+  }
+
+  "a valid request with Tax Year Specific tax year is supplied" in new TysIfsTest with Test {
+    def taxYear: TaxYear                             = tysTaxYear
+    def downstreamQueryParams: Seq[(String, String)] = commonQueryParams
+    val outcome                                      = Right(ResponseWrapper(correlationId, listBsasResponseModel))
+
+    stubTysHttpResponse(outcome)
+
+    await(connector.listBsas(request)) shouldBe outcome
+  }
+
+  "response is an error" must {
+    val downstreamErrorResponse: DownstreamErrors =
+      DownstreamErrors.single(DownstreamErrorCode("SOME_ERROR"))
+    val outcome = Left(ResponseWrapper(correlationId, downstreamErrorResponse))
+
+    "return the error" in new IfsTest with Test {
+      def taxYear: TaxYear                             = preTysTaxYear
+      def downstreamQueryParams: Seq[(String, String)] = commonQueryParams ++ additionalQueryParams
+
+      stubHttpResponse(outcome)
+
+      val result: DownstreamOutcome[ListBsasResponse[BsasSummary]] =
+        await(connector.listBsas(request))
+      result shouldBe outcome
+    }
+
+    "return the error given a TYS tax year request" in new TysIfsTest with Test {
+      def taxYear: TaxYear                             = tysTaxYear
+      def downstreamQueryParams: Seq[(String, String)] = commonQueryParams
+
+      stubTysHttpResponse(outcome)
+
+      val result: DownstreamOutcome[ListBsasResponse[BsasSummary]] =
+        await(connector.listBsas(request))
+      result shouldBe outcome
+    }
+  }
+
+  trait Test { _: ConnectorTest =>
+    protected def taxYear: TaxYear
+    protected def downstreamQueryParams: Seq[(String, String)]
+
+    protected val request: ListBsasRequestData =
+      Def1_ListBsasRequestData(nino, taxYear, Some(BusinessId(incomeSourceId)), Some(incomeSourceType))
+
+    protected val connector: ListBsasConnector =
+      new ListBsasConnector(http = mockHttpClient, appConfig = mockAppConfig)
+
+    protected def stubHttpResponse(
+        outcome: DownstreamOutcome[ListBsasResponse[BsasSummary]]
+    ): CallHandler[Future[DownstreamOutcome[ListBsasResponse[BsasSummary]]]]#Derived = {
+      willGet(
+        url = s"$baseUrl/income-tax/adjustable-summary-calculation/$nino",
+        parameters = downstreamQueryParams
+      ).returns(Future.successful(outcome))
+    }
+
+    protected def stubTysHttpResponse(
+        outcome: DownstreamOutcome[ListBsasResponse[BsasSummary]]
+    ): CallHandler[Future[DownstreamOutcome[ListBsasResponse[BsasSummary]]]]#Derived = {
+      willGet(
+        url = s"$baseUrl/income-tax/adjustable-summary-calculation/${taxYear.asTysDownstream}/$nino",
+        parameters = downstreamQueryParams
+      ).returns(Future.successful(outcome))
+    }
+
+  }
+
+}

--- a/test/v5/listBsas/connectors/MockListBsasConnector.scala
+++ b/test/v5/listBsas/connectors/MockListBsasConnector.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.connectors
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.connectors.DownstreamOutcome
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.listBsas.models.{BsasSummary, ListBsasRequestData, ListBsasResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockListBsasConnector extends MockFactory {
+
+  val mockConnector: ListBsasConnector = mock[ListBsasConnector]
+
+  object MockListBsasConnector {
+
+    def listBsas(requestData: ListBsasRequestData): CallHandler[Future[DownstreamOutcome[ListBsasResponse[BsasSummary]]]] = {
+      (mockConnector
+        .listBsas(_: ListBsasRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(requestData, *, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/listBsas/controllers/ListBsasControllerSpec.scala
+++ b/test/v5/listBsas/controllers/ListBsasControllerSpec.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.controllers
+
+import play.api.Configuration
+import play.api.mvc.Result
+import shared.config.MockAppConfig
+import shared.controllers.{ControllerBaseSpec, ControllerTestRunner}
+import shared.hateoas.{HateoasWrapper, MockHateoasFactory}
+import shared.models.domain.{BusinessId, TaxYear}
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.{MockEnrolmentsAuthService, MockMtdIdLookupService}
+import shared.utils.MockIdGenerator
+import v5.hateoas.HateoasLinks
+import v5.listBsas.fixtures.def1.ListBsasFixture
+import v5.listBsas.models._
+import v5.listBsas.models.def1.{BusinessSource, Def1_ListBsasRequestData, Def1_ListBsasResponse}
+import v5.listBsas.services.MockListBsasService
+import v5.listBsas.validators.MockListBsasValidatorFactory
+import v5.models.domain.TypeOfBusiness
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class ListBsasControllerSpec
+    extends ControllerBaseSpec
+    with ControllerTestRunner
+    with MockEnrolmentsAuthService
+    with MockMtdIdLookupService
+    with MockListBsasValidatorFactory
+    with MockListBsasService
+    with MockHateoasFactory
+    with MockAppConfig
+    with HateoasLinks
+    with MockIdGenerator
+    with ListBsasFixture {
+
+  private val typeOfBusiness = "self-employment"
+  private val businessId     = "XAIS12345678901"
+
+  "list bsas" should {
+    "return OK" when {
+      "the request is valid" in new Test {
+        MockAppConfig.apiGatewayContext.returns("individuals/self-assessment/adjustable-summary").anyNumberOfTimes()
+        MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> false)).anyNumberOfTimes()
+
+        willUseValidator(returningSuccess(requestData))
+
+        MockListBsasService
+          .listBsas(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
+
+        MockHateoasFactory
+          .wrapList(response, ListBsasHateoasData(validNino, response, Some(requestData.taxYear)))
+          .returns(responseWithHateoas)
+
+        runOkTest(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(summariesJSONWithHateoas(parsedNino))
+        )
+      }
+
+      "valid request with no taxYear path parameter" in new Test {
+        MockAppConfig.apiGatewayContext.returns("individuals/self-assessment/adjustable-summary").anyNumberOfTimes()
+        MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> false)).anyNumberOfTimes()
+
+        override def maybeTaxYear: Option[String] = None
+
+        willUseValidator(returningSuccess(requestData))
+
+        MockListBsasService
+          .listBsas(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
+
+        MockHateoasFactory
+          .wrapList(response, ListBsasHateoasData(validNino, response, Some(requestData.taxYear)))
+          .returns(responseWithHateoas)
+
+        runOkTest(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(summariesJSONWithHateoas(parsedNino))
+        )
+      }
+    }
+
+    "return the error as per spec" when {
+
+      "the parser validation fails" in new Test {
+        willUseValidator(returning(NinoFormatError))
+        runErrorTest(expectedError = NinoFormatError)
+      }
+
+      "the service returns an error" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockListBsasService
+          .listBsas(requestData)
+          .returns(Future.successful(Left(ErrorWrapper(correlationId, BusinessIdFormatError))))
+
+        runErrorTest(expectedError = BusinessIdFormatError)
+      }
+    }
+  }
+
+  private trait Test extends ControllerTest {
+    def maybeTaxYear: Option[String] = Some("2019-20")
+
+    val controller = new ListBsasController(
+      authService = mockEnrolmentsAuthService,
+      lookupService = mockMtdIdLookupService,
+      validatorFactory = mockListBsasValidatorFactory,
+      service = mockListBsasService,
+      hateoasFactory = mockHateoasFactory,
+      cc = cc,
+      idGenerator = mockIdGenerator
+    )
+
+    val requestData: ListBsasRequestData = Def1_ListBsasRequestData(
+      nino = parsedNino,
+      taxYear = TaxYear.currentTaxYear(),
+      incomeSourceId = Some(BusinessId(businessId)),
+      incomeSourceType = Some(typeOfBusiness)
+    )
+
+    val response: ListBsasResponse[BsasSummary] = Def1_ListBsasResponse(
+      List(
+        businessSourceSummaryModel(),
+        businessSourceSummaryModel().copy(
+          typeOfBusiness = TypeOfBusiness.`uk-property-fhl`,
+          summaries = List(
+            bsasSummaryModel.copy(calculationId = "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce5")
+          )),
+        businessSourceSummaryModel().copy(
+          typeOfBusiness = TypeOfBusiness.`uk-property-non-fhl`,
+          summaries = List(
+            bsasSummaryModel.copy(calculationId = "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce6")
+          ))
+      ))
+
+    def responseWithHateoas: HateoasWrapper[ListBsasResponse[HateoasWrapper[BsasSummary]]] = HateoasWrapper(
+      Def1_ListBsasResponse(
+        List(
+          BusinessSource(
+            businessId = "000000000000210",
+            typeOfBusiness = TypeOfBusiness.`self-employment`,
+            accountingPeriodModel,
+            taxYear = TaxYear.fromMtd("2019-20"),
+            List(
+              HateoasWrapper(
+                bsasSummaryModel,
+                List(getSelfEmploymentBsas(mockAppConfig, validNino, "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4", None))
+              ))
+          ),
+          BusinessSource(
+            businessId = "000000000000210",
+            typeOfBusiness = TypeOfBusiness.`uk-property-fhl`,
+            accountingPeriodModel,
+            taxYear = TaxYear.fromMtd("2019-20"),
+            List(
+              HateoasWrapper(
+                bsasSummaryModel.copy(calculationId = "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce5"),
+                List(getUkPropertyBsas(mockAppConfig, validNino, "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce5", None))
+              ))
+          ),
+          BusinessSource(
+            businessId = "000000000000210",
+            typeOfBusiness = TypeOfBusiness.`uk-property-non-fhl`,
+            accountingPeriodModel,
+            taxYear = TaxYear.fromMtd("2019-20"),
+            List(
+              HateoasWrapper(
+                bsasSummaryModel.copy(calculationId = "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce6"),
+                List(getUkPropertyBsas(mockAppConfig, validNino, "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce6", None))
+              ))
+          )
+        )
+      ),
+      List(triggerBsas(mockAppConfig, validNino), listBsas(mockAppConfig, validNino, None))
+    )
+
+    protected def callController(): Future[Result] =
+      controller.listBsas(validNino, maybeTaxYear, Some(typeOfBusiness), Some(businessId))(fakeGetRequest)
+
+  }
+
+}

--- a/test/v5/listBsas/fixtures/def1/ListBsasFixture.scala
+++ b/test/v5/listBsas/fixtures/def1/ListBsasFixture.scala
@@ -1,0 +1,415 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.fixtures.def1
+
+import play.api.libs.json.{JsArray, JsValue, Json}
+import shared.models.domain.{Nino, Status, TaxYear}
+import v5.listBsas.models.def1.{AccountingPeriod, BusinessSource, Def1_BsasSummary, Def1_ListBsasResponse}
+import v5.listBsas.models.{BsasSummary, ListBsasResponse}
+import v5.models.domain.TypeOfBusiness
+
+trait ListBsasFixture {
+
+  val bsasSummaryDownstreamJson: JsValue = Json.parse(
+    """
+      |{
+      |  "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+      |  "requestedDateTime": "2019-10-14T11:33:27Z",
+      |  "status": "valid",
+      |  "adjusted": false
+      |}
+    """.stripMargin
+  )
+
+  val bsasSummaryModel: Def1_BsasSummary = Def1_BsasSummary(
+    calculationId = "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+    requestedDateTime = "2019-10-14T11:33:27Z",
+    summaryStatus = Status.`valid`,
+    adjustedSummary = false,
+    adjustedDateTime = None
+  )
+
+  val bsasSummaryJson: JsValue = Json.parse(
+    """
+      |{
+      |  "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+      |  "requestedDateTime": "2019-10-14T11:33:27Z",
+      |  "summaryStatus": "valid",
+      |  "adjustedSummary": false
+      |}
+    """.stripMargin
+  )
+
+  val accountingPeriodDownstreamJson: JsValue = Json.parse(
+    """
+      |{
+      |  "accountingStartDate": "2018-10-11",
+      |  "accountingEndDate": "2019-10-10"
+      |}
+    """.stripMargin
+  )
+
+  val accountingPeriodModel: AccountingPeriod = AccountingPeriod(
+    startDate = "2018-10-11",
+    endDate = "2019-10-10"
+  )
+
+  val accountingPeriodJson: JsValue = Json.parse(
+    """
+      |{
+      |  "startDate": "2018-10-11",
+      |  "endDate": "2019-10-10"
+      |}
+    """.stripMargin
+  )
+
+  val businessSourceSummaryDownstreamJson: JsValue = Json.parse(
+    """
+      |{
+      |  "incomeSourceId": "000000000000210",
+      |  "incomeSourceType": "01",
+      |  "accountingStartDate": "2018-10-11",
+      |  "accountingEndDate": "2019-10-10",
+      |  "taxYear": 2020,
+      |  "ascCalculations": [
+      |    {
+      |      "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+      |      "requestedDateTime": "2019-10-14T11:33:27Z",
+      |      "status": "valid",
+      |      "adjusted": false
+      |    }
+      |  ]
+      |}
+    """.stripMargin
+  )
+
+  val businessSourceSummaryJson: JsValue = Json.parse(
+    """
+      |{
+      |  "businessId": "000000000000210",
+      |  "typeOfBusiness": "self-employment",
+      |  "accountingPeriod": {
+      |    "startDate": "2018-10-11",
+      |    "endDate": "2019-10-10"
+      |  },
+      |  "taxYear": "2019-20",
+      |  "summaries": [
+      |    {
+      |      "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+      |      "requestedDateTime": "2019-10-14T11:33:27Z",
+      |      "summaryStatus": "valid",
+      |      "adjustedSummary": false
+      |    }
+      |  ]
+      |}
+    """.stripMargin
+  )
+
+  val listBsasResponseDownstreamJson: JsValue = Json.parse(
+    """
+      |[
+      |  {
+      |    "incomeSourceId": "000000000000210",
+      |    "incomeSourceType": "01",
+      |    "accountingStartDate": "2018-10-11",
+      |    "accountingEndDate": "2019-10-10",
+      |    "taxYear": 2020,
+      |    "ascCalculations": [
+      |      {
+      |        "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+      |        "requestedDateTime": "2019-10-14T11:33:27Z",
+      |        "status": "valid",
+      |        "adjusted": false
+      |      }
+      |    ]
+      |  }
+      |]
+    """.stripMargin
+  )
+
+  val listBsasResponseDownstreamJsonForeign: JsValue = Json.parse(
+    """
+      |[
+      |  {
+      |    "incomeSourceId": "000000000000210",
+      |    "incomeSourceType": "15",
+      |    "accountingStartDate": "2018-10-11",
+      |    "accountingEndDate": "2019-10-10",
+      |    "taxYear": 2020,
+      |    "ascCalculations": [
+      |      {
+      |        "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+      |        "requestedDateTime": "2019-10-14T11:33:27Z",
+      |        "status": "valid",
+      |        "adjusted": false
+      |      }
+      |    ]
+      |  }
+      |]
+    """.stripMargin
+  )
+
+  val listBsasResponseModel: ListBsasResponse[BsasSummary] = Def1_ListBsasResponse(List(businessSourceSummaryModel()))
+
+  val listBsasResponseJson: JsValue = Json.parse(
+    """
+      |{
+      |  "businessSources": [
+      |    {
+      |      "businessId": "000000000000210",
+      |      "typeOfBusiness": "self-employment",
+      |      "accountingPeriod": {
+      |        "startDate": "2018-10-11",
+      |        "endDate": "2019-10-10"
+      |      },
+      |      "taxYear": "2019-20",
+      |      "summaries": [
+      |        {
+      |          "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+      |          "requestedDateTime": "2019-10-14T11:33:27Z",
+      |          "summaryStatus": "valid",
+      |          "adjustedSummary": false
+      |        }
+      |      ]
+      |    }
+      |  ]
+      |}
+    """.stripMargin
+  )
+
+  val listBsasResponseDownstreamJsonSE: JsValue = Json.parse(
+    """
+      |{
+      |  "incomeSourceType": "01",
+      |  "incomeSourceId": "000000000000210",
+      |  "taxYear": 2020,
+      |  "accountingStartDate": "2018-10-11",
+      |  "accountingEndDate": "2019-10-10",
+      |  "ascCalculations": [
+      |      {
+      |        "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+      |        "requestedDateTime": "2019-10-14T11:33:27Z",
+      |        "status": "valid",
+      |        "adjusted": false
+      |      }
+      |    ]
+      |}
+    """.stripMargin
+  )
+
+  val listBsasResponseDownstreamJsonUkFhl: JsValue = Json.parse(
+    """
+      |{
+      |  "incomeSourceType": "04",
+      |  "incomeSourceId": "000000000000210",
+      |  "accountingStartDate": "2018-10-11",
+      |  "accountingEndDate": "2019-10-10",
+      |  "taxYear": 2020,
+      |  "ascCalculations": [
+      |      {
+      |        "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce5",
+      |        "requestedDateTime": "2019-10-14T11:33:27Z",
+      |        "status": "valid",
+      |        "adjusted": false
+      |      }
+      |    ]
+      |}
+    """.stripMargin
+  )
+
+  val listBsasResponseDownstreamJsonUkNonFhl: JsValue = Json.parse(
+    """
+      |{
+      |  "incomeSourceType": "02",
+      |  "incomeSourceId": "000000000000210",
+      |  "accountingStartDate": "2018-10-11",
+      |  "accountingEndDate": "2019-10-10",
+      |  "taxYear": 2020,
+      |  "ascCalculations": [
+      |      {
+      |        "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce6",
+      |        "requestedDateTime": "2019-10-14T11:33:27Z",
+      |        "status": "valid",
+      |        "adjusted": false
+      |      }
+      |    ]
+      |}
+    """.stripMargin
+  )
+
+  val listBsasDownstreamJsonMultiple: JsArray = JsArray(
+    Seq(
+      listBsasResponseDownstreamJsonSE,
+      listBsasResponseDownstreamJsonUkFhl,
+      listBsasResponseDownstreamJsonUkNonFhl
+    ))
+
+  def businessSourceSummaryModel(taxYear: String = "2019-20"): BusinessSource[Def1_BsasSummary] = BusinessSource(
+    businessId = "000000000000210",
+    typeOfBusiness = TypeOfBusiness.`self-employment`,
+    accountingPeriod = accountingPeriodModel,
+    taxYear = TaxYear.fromMtd(taxYear),
+    summaries = Seq(bsasSummaryModel)
+  )
+
+  def summariesJSONWithHateoas(nino: Nino, taxYear: Option[String] = None): JsValue = {
+    val taxYearParam = taxYear.fold("")("?taxYear=" + _)
+
+    Json.parse(
+      s"""
+         |{
+         |  "businessSources": [
+         |    {
+         |      "businessId": "000000000000210",
+         |      "typeOfBusiness": "self-employment",
+         |      "accountingPeriod": {
+         |        "startDate": "2018-10-11",
+         |        "endDate": "2019-10-10"
+         |      },
+         |      "taxYear": "2019-20",
+         |      "summaries": [
+         |        {
+         |          "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+         |          "requestedDateTime": "2019-10-14T11:33:27Z",
+         |          "summaryStatus": "valid",
+         |          "adjustedSummary": false,
+         |          "links": [
+         |            {
+         |              "href": "/individuals/self-assessment/adjustable-summary/$nino/self-employment/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4$taxYearParam",
+         |              "method": "GET",
+         |              "rel": "self"
+         |            }
+         |          ]
+         |        }
+         |      ]
+         |    },
+         |    {
+         |      "businessId": "000000000000210",
+         |      "typeOfBusiness": "uk-property-fhl",
+         |      "accountingPeriod": {
+         |        "startDate": "2018-10-11",
+         |        "endDate": "2019-10-10"
+         |      },
+         |      "taxYear": "2019-20",
+         |      "summaries": [
+         |        {
+         |          "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce5",
+         |          "requestedDateTime": "2019-10-14T11:33:27Z",
+         |          "summaryStatus": "valid",
+         |          "adjustedSummary": false,
+         |          "links": [
+         |            {
+         |              "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce5$taxYearParam",
+         |              "method": "GET",
+         |              "rel": "self"
+         |            }
+         |          ]
+         |        }
+         |      ]
+         |    },
+         |    {
+         |      "businessId": "000000000000210",
+         |      "typeOfBusiness": "uk-property-non-fhl",
+         |      "accountingPeriod": {
+         |        "startDate": "2018-10-11",
+         |        "endDate": "2019-10-10"
+         |      },
+         |      "taxYear": "2019-20",
+         |      "summaries": [
+         |        {
+         |          "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce6",
+         |          "requestedDateTime": "2019-10-14T11:33:27Z",
+         |          "summaryStatus": "valid",
+         |          "adjustedSummary": false,
+         |          "links": [
+         |            {
+         |              "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce6$taxYearParam",
+         |              "method": "GET",
+         |              "rel": "self"
+         |            }
+         |          ]
+         |        }
+         |      ]
+         |    }
+         |  ],
+         |  "links": [
+         |    {
+         |      "href": "/individuals/self-assessment/adjustable-summary/$nino/trigger",
+         |      "method": "POST",
+         |      "rel": "trigger-business-source-adjustable-summary"
+         |    },
+         |    {
+         |      "href": "/individuals/self-assessment/adjustable-summary/$nino$taxYearParam",
+         |      "method": "GET",
+         |      "rel": "self"
+         |    }
+         |  ]
+         |}
+    """.stripMargin
+    )
+  }
+
+  def summariesJSONForeignWithHateoas(nino: Nino, taxYear: Option[String] = None): JsValue = {
+    val taxYearParam = taxYear.fold("")("?taxYear=" + _)
+
+    Json.parse(
+      s"""
+         |{
+         |  "businessSources": [
+         |    {
+         |      "typeOfBusiness": "foreign-property",
+         |      "businessId": "000000000000210",
+         |      "taxYear": "2019-20",
+         |      "accountingPeriod": {
+         |        "startDate": "2018-10-11",
+         |        "endDate": "2019-10-10"
+         |      },
+         |      "summaries": [
+         |        {
+         |          "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+         |          "requestedDateTime": "2019-10-14T11:33:27Z",
+         |          "summaryStatus": "valid",
+         |          "adjustedSummary": false,
+         |          "links": [
+         |            {
+         |              "href": "/individuals/self-assessment/adjustable-summary/$nino/foreign-property/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4$taxYearParam",
+         |              "method": "GET",
+         |              "rel": "self"
+         |            }
+         |          ]
+         |        }
+         |      ]
+         |    }
+         |  ],
+         |  "links": [
+         |    {
+         |      "href": "/individuals/self-assessment/adjustable-summary/$nino/trigger",
+         |      "method": "POST",
+         |      "rel": "trigger-business-source-adjustable-summary"
+         |    },
+         |    {
+         |      "href": "/individuals/self-assessment/adjustable-summary/$nino$taxYearParam",
+         |      "method": "GET",
+         |      "rel": "self"
+         |    }
+         |  ]
+         |}
+    """.stripMargin
+    )
+  }
+
+}

--- a/test/v5/listBsas/models/ListBsasResponseSpec.scala
+++ b/test/v5/listBsas/models/ListBsasResponseSpec.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models
+
+import play.api.Configuration
+import shared.UnitSpec
+import shared.config.MockAppConfig
+import shared.hateoas.Link
+import shared.hateoas.Method.{GET, POST}
+import shared.models.domain.TaxYear
+import v5.listBsas.fixtures.def1.ListBsasFixture
+import v5.listBsas.models.ListBsasResponse.LinksFactory._
+import v5.listBsas.models.def1.Def1_ListBsasResponse
+import v5.models.domain.TypeOfBusiness
+import v5.models.domain.TypeOfBusiness._
+
+class ListBsasResponseSpec extends UnitSpec with MockAppConfig with ListBsasFixture {
+
+  val selfEmploymentBsasResponse: ListBsasResponse[BsasSummary]        = makeResponse(`self-employment`)
+  val ukPropertyFhlBsasResponse: ListBsasResponse[BsasSummary]         = makeResponse(`uk-property-fhl`)
+  val ukPropertyNonFhlBsasResponse: ListBsasResponse[BsasSummary]      = makeResponse(`uk-property-non-fhl`)
+  val foreignPropertyFhlEeaBsasResponse: ListBsasResponse[BsasSummary] = makeResponse(`foreign-property-fhl-eea`)
+  val foreignPropertyBsasResponse: ListBsasResponse[BsasSummary]       = makeResponse(`foreign-property`)
+
+  def makeResponse(typeOfBusiness: TypeOfBusiness): Def1_ListBsasResponse[BsasSummary] = Def1_ListBsasResponse(
+    Seq(businessSourceSummaryModel().copy(typeOfBusiness = typeOfBusiness))
+  )
+
+  "Links Factory" should {
+    class Test extends MockAppConfig {
+      val nino    = "someNino"
+      val bsasId  = "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4"
+      val context = "individuals/self-assessment/adjustable-summary"
+      val taxYear = Some(TaxYear.fromMtd("2023-24"))
+
+      MockAppConfig.apiGatewayContext.returns(context).anyNumberOfTimes()
+    }
+
+    class TysDisabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> false)).anyNumberOfTimes()
+    }
+
+    class TysEnabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> true)).anyNumberOfTimes()
+    }
+
+    "top level links" should {
+      "return the correct links without tax year" in new TysDisabledTest {
+        private val result = links(mockAppConfig, ListBsasHateoasData(nino, listBsasResponseModel, None))
+        private val expectedLinks = Seq(
+          Link(s"/$context/$nino/trigger", POST, "trigger-business-source-adjustable-summary"),
+          Link(s"/$context/$nino", GET, "self")
+        )
+
+        result shouldBe expectedLinks
+      }
+
+      "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+        private val result = links(mockAppConfig, ListBsasHateoasData(nino, listBsasResponseModel, taxYear))
+        private val expectedLinks = Seq(
+          Link(s"/$context/$nino/trigger", POST, "trigger-business-source-adjustable-summary"),
+          Link(s"/$context/$nino?taxYear=2023-24", GET, "self")
+        )
+
+        result shouldBe expectedLinks
+      }
+    }
+
+    "item level links" when {
+      "given self-employment business type" should {
+        "return correct links without tax year" in new TysDisabledTest {
+          private val result = itemLinks(mockAppConfig, ListBsasHateoasData(nino, selfEmploymentBsasResponse, None), bsasSummaryModel)
+          result shouldBe Seq(Link(s"/$context/$nino/self-employment/$bsasId", GET, "self"))
+        }
+
+        "return correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+          private val result = itemLinks(mockAppConfig, ListBsasHateoasData(nino, selfEmploymentBsasResponse, taxYear), bsasSummaryModel)
+          result shouldBe Seq(Link(s"/$context/$nino/self-employment/$bsasId?taxYear=2023-24", GET, "self"))
+        }
+      }
+
+      "given uk-property-fhl business type" should {
+        "return correct links without tax year" in new TysDisabledTest {
+          private val result = itemLinks(mockAppConfig, ListBsasHateoasData(nino, ukPropertyFhlBsasResponse, None), bsasSummaryModel)
+          result shouldBe Seq(Link(s"/$context/$nino/uk-property/$bsasId", GET, "self"))
+        }
+
+        "return correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+          private val result = itemLinks(mockAppConfig, ListBsasHateoasData(nino, ukPropertyFhlBsasResponse, taxYear), bsasSummaryModel)
+          result shouldBe Seq(Link(s"/$context/$nino/uk-property/$bsasId?taxYear=2023-24", GET, "self"))
+        }
+      }
+
+      "given uk-property-non-fhl business type" should {
+        "return correct links without tax year" in new TysDisabledTest {
+          private val result = itemLinks(mockAppConfig, ListBsasHateoasData(nino, ukPropertyNonFhlBsasResponse, None), bsasSummaryModel)
+          result shouldBe Seq(Link(s"/$context/$nino/uk-property/$bsasId", GET, "self"))
+        }
+
+        "return correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+          private val result = itemLinks(mockAppConfig, ListBsasHateoasData(nino, ukPropertyNonFhlBsasResponse, taxYear), bsasSummaryModel)
+          result shouldBe Seq(Link(s"/$context/$nino/uk-property/$bsasId?taxYear=2023-24", GET, "self"))
+        }
+      }
+
+      "given foreign-property-fhl-eea business type" should {
+        "return correct links without tax year" in new TysDisabledTest {
+          private val result = itemLinks(mockAppConfig, ListBsasHateoasData(nino, foreignPropertyFhlEeaBsasResponse, None), bsasSummaryModel)
+          result shouldBe Seq(Link(s"/$context/$nino/foreign-property/$bsasId", GET, "self"))
+        }
+
+        "return correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+          private val result = itemLinks(mockAppConfig, ListBsasHateoasData(nino, foreignPropertyFhlEeaBsasResponse, taxYear), bsasSummaryModel)
+          result shouldBe Seq(Link(s"/$context/$nino/foreign-property/$bsasId?taxYear=2023-24", GET, "self"))
+        }
+      }
+
+      "given foreign-property business type" should {
+        "return correct links without tax year" in new TysDisabledTest {
+          private val result = itemLinks(mockAppConfig, ListBsasHateoasData(nino, foreignPropertyBsasResponse, None), bsasSummaryModel)
+          result shouldBe Seq(Link(s"/$context/$nino/foreign-property/$bsasId", GET, "self"))
+        }
+
+        "return correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+          private val result = itemLinks(mockAppConfig, ListBsasHateoasData(nino, foreignPropertyBsasResponse, taxYear), bsasSummaryModel)
+          result shouldBe Seq(Link(s"/$context/$nino/foreign-property/$bsasId?taxYear=2023-24", GET, "self"))
+        }
+      }
+    }
+  }
+
+}

--- a/test/v5/listBsas/models/def1/AccountingPeriodSpec.scala
+++ b/test/v5/listBsas/models/def1/AccountingPeriodSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models.def1
+
+import play.api.libs.json.{JsError, JsObject, Json}
+import shared.UnitSpec
+import v5.listBsas.fixtures.def1.ListBsasFixture
+
+class AccountingPeriodSpec extends UnitSpec with ListBsasFixture {
+
+  "AccountingPeriod" when {
+    "read from valid JSON" should {
+      "return the expected model" in {
+        accountingPeriodDownstreamJson.as[AccountingPeriod] shouldBe accountingPeriodModel
+      }
+    }
+
+    "read from invalid JSON" should {
+      "return a JsError" in {
+        JsObject.empty.validate[AccountingPeriod] shouldBe a[JsError]
+      }
+    }
+
+    "written to JSON" should {
+      "return the expected JSON" in {
+        Json.toJson(accountingPeriodModel) shouldBe accountingPeriodJson
+      }
+    }
+  }
+
+}

--- a/test/v5/listBsas/models/def1/BusinessSourceSpec.scala
+++ b/test/v5/listBsas/models/def1/BusinessSourceSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models.def1
+
+import play.api.libs.json.{JsError, JsObject, Json}
+import shared.UnitSpec
+import v5.listBsas.fixtures.def1.ListBsasFixture
+
+class BusinessSourceSpec extends UnitSpec with ListBsasFixture {
+
+  "BusinessSourceSummary" when {
+    "read from valid JSON" should {
+      "return the expected model" in {
+        businessSourceSummaryDownstreamJson.as[BusinessSource[Def1_BsasSummary]] shouldBe businessSourceSummaryModel()
+      }
+    }
+
+    "read from invalid JSON" should {
+      "return a JsError" in {
+        JsObject.empty.validate[BusinessSource[Def1_BsasSummary]] shouldBe a[JsError]
+      }
+    }
+
+    "written to JSON" should {
+      "return the expected JSON" in {
+        Json.toJson(businessSourceSummaryModel()) shouldBe businessSourceSummaryJson
+      }
+    }
+  }
+
+}

--- a/test/v5/listBsas/models/def1/Def1_BsasSummarySpec.scala
+++ b/test/v5/listBsas/models/def1/Def1_BsasSummarySpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models.def1
+
+import play.api.libs.json.{JsError, JsObject, Json}
+import shared.UnitSpec
+import v5.listBsas.fixtures.def1.ListBsasFixture
+
+class Def1_BsasSummarySpec extends UnitSpec with ListBsasFixture {
+
+  "BsasSummary" when {
+    "read from valid JSON" should {
+      "return the expected model" in {
+        bsasSummaryDownstreamJson.as[Def1_BsasSummary] shouldBe bsasSummaryModel
+      }
+    }
+
+    "read from invalid JSON" should {
+      "return a JsError" in {
+        JsObject.empty.validate[Def1_BsasSummary] shouldBe a[JsError]
+      }
+    }
+
+    "written to JSON" should {
+      "return the expected JSON" in {
+        Json.toJson(bsasSummaryModel) shouldBe bsasSummaryJson
+      }
+    }
+  }
+
+}

--- a/test/v5/listBsas/models/def1/Def1_ListBsasResponseSpec.scala
+++ b/test/v5/listBsas/models/def1/Def1_ListBsasResponseSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.models.def1
+
+import play.api.libs.json.{JsError, JsObject, Json}
+import shared.UnitSpec
+import shared.config.MockAppConfig
+import v5.listBsas.fixtures.def1.ListBsasFixture
+
+class Def1_ListBsasResponseSpec extends UnitSpec with MockAppConfig with ListBsasFixture {
+
+  "ListBsasResponse" when {
+    "read from valid JSON" should {
+      "return the expected object" in {
+        listBsasResponseDownstreamJson.as[Def1_ListBsasResponse[Def1_BsasSummary]] shouldBe listBsasResponseModel
+      }
+    }
+
+    "read from invalid JSON" should {
+      "return a JsError" in {
+        JsObject.empty.validate[Def1_ListBsasResponse[Def1_BsasSummary]] shouldBe a[JsError]
+      }
+    }
+
+    "written to JSON" should {
+      "return the expected JSON" in {
+        Json.toJson(listBsasResponseModel) shouldBe listBsasResponseJson
+      }
+    }
+  }
+
+}

--- a/test/v5/listBsas/schema/ListBsasSchemaSpec.scala
+++ b/test/v5/listBsas/schema/ListBsasSchemaSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.schema
+
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import shared.UnitSpec
+import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+
+import scala.math.Ordered.orderingToOrdered
+
+class ListBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
+
+  "schema lookup" when {
+    "a tax year is present" must {
+      "use Def1 for tax years from 2023-24" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
+            ListBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe ListBsasSchema.Def1
+          }
+        }
+      }
+
+      "use Def1 for other tax years" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
+            ListBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe ListBsasSchema.Def1
+          }
+        }
+      }
+    }
+
+    "the tax year is present but not valid" must {
+      "use a default of Def1" in {
+        ListBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe ListBsasSchema.Def1
+      }
+    }
+
+    "no tax year is present" must {
+      "use a default of Def1" in {
+        ListBsasSchema.schemaFor(None) shouldBe ListBsasSchema.Def1
+      }
+    }
+  }
+
+}

--- a/test/v5/listBsas/schema/ListBsasSchemaSpec.scala
+++ b/test/v5/listBsas/schema/ListBsasSchemaSpec.scala
@@ -20,25 +20,19 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import shared.UnitSpec
 import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
 
-import scala.math.Ordered.orderingToOrdered
-
 class ListBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
 
   "schema lookup" when {
     "a tax year is present" must {
       "use Def1 for tax years from 2023-24" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
-            ListBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe ListBsasSchema.Def1
-          }
+        forTaxYearsFrom(TaxYear.fromMtd("2023-24")) { taxYear =>
+          ListBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe ListBsasSchema.Def1
         }
       }
 
-      "use Def1 for other tax years" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
-            ListBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe ListBsasSchema.Def1
-          }
+      "use Def1 for pre-TYS tax years" in {
+        forPreTysTaxYears { taxYear =>
+          ListBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe ListBsasSchema.Def1
         }
       }
     }

--- a/test/v5/listBsas/services/ListBsasServiceSpec.scala
+++ b/test/v5/listBsas/services/ListBsasServiceSpec.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.services
+
+import shared.controllers.EndpointLogContext
+import shared.models.domain.{BusinessId, Nino, TaxYear}
+import shared.models.errors.{BusinessIdFormatError, DownstreamErrorCode, DownstreamErrors, ErrorWrapper, InternalError, MtdError, NinoFormatError, NotFoundError, RuleTaxYearNotSupportedError, TaxYearFormatError}
+import shared.models.outcomes.ResponseWrapper
+import shared.services.ServiceSpec
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.listBsas.connectors.MockListBsasConnector
+import v5.listBsas.fixtures.def1.ListBsasFixture
+import v5.listBsas.models.def1.Def1_ListBsasRequestData
+import v5.listBsas.models.{BsasSummary, ListBsasRequestData, ListBsasResponse}
+
+import scala.concurrent.Future
+
+class ListBsasServiceSpec extends ServiceSpec with ListBsasFixture {
+
+  private val nino                   = Nino("AA123456A")
+  private val taxYear                = TaxYear.fromMtd("2019-20")
+  private val incomeSourceIdentifier = "IncomeSourceType"
+  private val identifierValue        = BusinessId("01")
+
+  val request: ListBsasRequestData            = Def1_ListBsasRequestData(nino, taxYear, Some(identifierValue), Some(incomeSourceIdentifier))
+  val response: ListBsasResponse[BsasSummary] = listBsasResponseModel
+
+  trait Test extends MockListBsasConnector {
+    implicit val hc: HeaderCarrier              = HeaderCarrier()
+    implicit val logContext: EndpointLogContext = EndpointLogContext("controller", "listBsas")
+
+    val service = new ListBsasService(mockConnector)
+  }
+
+  "ListBsas" should {
+    "return a valid response" when {
+      "a valid request is supplied" in new Test {
+        MockListBsasConnector
+          .listBsas(request)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
+
+        await(service.listBsas(request)) shouldBe Right(ResponseWrapper(correlationId, response))
+      }
+    }
+
+    "return error response" when {
+
+      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
+        s"$downstreamErrorCode is returned from the service" in new Test {
+
+          MockListBsasConnector
+            .listBsas(request)
+            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+
+          await(service.listBsas(request)) shouldBe Left(ErrorWrapper(correlationId, error))
+        }
+
+      val errors = Seq(
+        ("INVALID_TAXABLE_ENTITY_ID", NinoFormatError),
+        ("NO_DATA_FOUND", NotFoundError),
+        ("INVALID_TAXYEAR", TaxYearFormatError),
+        ("INVALID_INCOMESOURCEID", BusinessIdFormatError),
+        ("INVALID_INCOMESOURCE_TYPE", InternalError),
+        ("SERVER_ERROR", InternalError),
+        ("SERVICE_UNAVAILABLE", InternalError)
+      )
+
+      val extraTysErrors = Seq(
+        ("INVALID_CORRELATION_ID", InternalError),
+        ("INVALID_TAX_YEAR", TaxYearFormatError),
+        ("INVALID_INCOMESOURCE_ID", BusinessIdFormatError),
+        ("NOT_FOUND", NotFoundError),
+        ("TAX_YEAR_NOT_SUPPORTED", RuleTaxYearNotSupportedError)
+      )
+
+      (errors ++ extraTysErrors).foreach(args => (serviceError _).tupled(args))
+    }
+  }
+
+}

--- a/test/v5/listBsas/services/MockListBsasService.scala
+++ b/test/v5/listBsas/services/MockListBsasService.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.services
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.controllers.RequestContext
+import shared.services.ServiceOutcome
+import v5.listBsas.models.{BsasSummary, ListBsasRequestData, ListBsasResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockListBsasService extends MockFactory {
+
+  val mockListBsasService: ListBsasService = mock[ListBsasService]
+
+  object MockListBsasService {
+
+    def listBsas(requestData: ListBsasRequestData): CallHandler[Future[ServiceOutcome[ListBsasResponse[BsasSummary]]]] = {
+      (mockListBsasService
+        .listBsas(_: ListBsasRequestData)(_: RequestContext, _: ExecutionContext))
+        .expects(requestData, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/listBsas/validators/MockListBsasValidatorFactory.scala
+++ b/test/v5/listBsas/validators/MockListBsasValidatorFactory.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.validators
+
+import org.scalamock.handlers.CallHandler
+import shared.controllers.validators.{MockValidatorFactory, Validator}
+import v5.listBsas.models.ListBsasRequestData
+import v5.listBsas.schema.ListBsasSchema
+
+trait MockListBsasValidatorFactory extends MockValidatorFactory[ListBsasRequestData] {
+
+  val mockListBsasValidatorFactory: ListBsasValidatorFactory = mock[ListBsasValidatorFactory]
+
+  def validator(): CallHandler[Validator[ListBsasRequestData]] =
+    (mockListBsasValidatorFactory
+      .validator(_: String, _: Option[String], _: Option[String], _: Option[String], _: ListBsasSchema))
+      .expects(*, *, *, *, *)
+
+}

--- a/test/v5/listBsas/validators/def1/Def1_ListBsasValidatorSpec.scala
+++ b/test/v5/listBsas/validators/def1/Def1_ListBsasValidatorSpec.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.listBsas.validators.def1
+
+import shared.UnitSpec
+import shared.models.domain.{BusinessId, Nino, TaxYear}
+import shared.models.errors._
+import v5.listBsas.models.def1.Def1_ListBsasRequestData
+import v5.models.errors.TypeOfBusinessFormatError
+
+class Def1_ListBsasValidatorSpec extends UnitSpec {
+
+  private implicit val correlationId: String = "1234"
+
+  private val validNino                = "AA123456B"
+  private val validTaxYear             = "2019-20"
+  private val validTypeOfBusinessSE    = "self-employment"
+  private val validTypeOfBusinessUkFhl = "uk-property-fhl"
+  private val validBusinessId          = "XAIS12345678901"
+
+  private val parsedNino                = Nino(validNino)
+  private val parsedTaxYear             = TaxYear.fromMtd(validTaxYear)
+  private val parsedTypeOfBusinessSE    = "01"
+  private val parsedTypeOfBusinessUkFhl = "04"
+  private val parsedBusinessId          = BusinessId(validBusinessId)
+
+  private def validator(nino: String, taxYear: Option[String], typeOfBusiness: Option[String], businessId: Option[String]) =
+    new Def1_ListBsasValidator(nino, taxYear, typeOfBusiness, businessId)
+
+  "validator" should {
+    "return the parsed domain object" when {
+      "passed a valid request with a Tax Year, 'self-employment' Type of Business and Business ID" in {
+        val result = validator(validNino, Some(validTaxYear), Some(validTypeOfBusinessSE), Some(validBusinessId)).validateAndWrapResult()
+        result shouldBe Right(Def1_ListBsasRequestData(parsedNino, parsedTaxYear, Some(parsedBusinessId), Some(parsedTypeOfBusinessSE)))
+      }
+
+      "passed a valid request with a Tax Year, 'uk property fhl' Type of Business and Business ID" in {
+        val result = validator(validNino, Some(validTaxYear), Some(validTypeOfBusinessUkFhl), Some(validBusinessId)).validateAndWrapResult()
+        result shouldBe Right(Def1_ListBsasRequestData(parsedNino, parsedTaxYear, Some(parsedBusinessId), Some(parsedTypeOfBusinessUkFhl)))
+      }
+
+      "passed a valid request with a Tax Year but no Type of Business or Business ID" in {
+        val result = validator(validNino, Some(validTaxYear), None, None).validateAndWrapResult()
+        result shouldBe Right(Def1_ListBsasRequestData(parsedNino, parsedTaxYear, None, None))
+      }
+
+      "passed a valid request with no query parameters" in {
+        withClue("If no taxYear is sent, the default is the current tax year for 'today'") {
+          val result = validator(validNino, None, None, None).validateAndWrapResult()
+          result shouldBe Right(Def1_ListBsasRequestData(parsedNino, TaxYear.currentTaxYear(), None, None))
+        }
+      }
+    }
+
+    "return a single error" when {
+      "passed an invalid nino" in {
+        val result = validator("A12344A", Some(validTaxYear), None, None).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, NinoFormatError)
+        )
+      }
+
+      "passed a tax year range of more than one year" in {
+        val result = validator(validNino, Some("2018-20"), None, None).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleTaxYearRangeInvalidError)
+        )
+      }
+
+      "passed an invalid taxYear (i.e. earlier than 2019-20)" in {
+        val result = validator(validNino, Some("2018-19"), None, None).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleTaxYearNotSupportedError)
+        )
+      }
+
+      "an invalid type of business is provided" in {
+        val result = validator(validNino, Some(validTaxYear), Some("not-a-type-of-business"), None).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, TypeOfBusinessFormatError)
+        )
+      }
+
+      "an invalid business id is provided" in {
+        val result = validator(validNino, Some(validTaxYear), None, Some("not-a-business-id")).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, BusinessIdFormatError)
+        )
+      }
+    }
+
+    "return multiple errors" when {
+      "multiple invalid parameters are provided" in {
+        val result = validator("not-a-nino", None, Some("not-a-type-of-business"), None).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            BadRequestError,
+            Some(List(NinoFormatError, TypeOfBusinessFormatError))
+          )
+        )
+      }
+    }
+  }
+
+}

--- a/test/v5/models/RoundTripTest.scala
+++ b/test/v5/models/RoundTripTest.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.models
+
+import play.api.libs.json.{JsValue, Json, Reads, Writes}
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+
+trait RoundTripTest extends UnitSpec with JsonErrorValidators {
+
+  def testRoundTrip[A](
+      testName: String,
+      downstreamJson: JsValue,
+      model: A,
+      mtdJson: JsValue
+  )(reads: Reads[A])(implicit writes: Writes[A]): Unit = {
+    s"$testName model tests" when {
+      "reads" should {
+        "return the parsed item" when {
+          "given valid JSON" in {
+            downstreamJson.as[A](reads) shouldBe model
+          }
+        }
+      }
+
+      "writes" should {
+        "return valid JSON" when {
+          "given a valid model" in {
+            Json.toJson(model) shouldBe mtdJson
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/test/v5/models/domain/IncomeSourceTypeSpec.scala
+++ b/test/v5/models/domain/IncomeSourceTypeSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.models.domain
+
+import shared.UnitSpec
+import shared.utils.enums.EnumJsonSpecSupport
+import v5.models.domain.IncomeSourceType._
+
+class IncomeSourceTypeSpec extends UnitSpec with EnumJsonSpecSupport {
+
+  testRoundTrip[IncomeSourceType](
+    ("01", `01`),
+    ("02", `02`),
+    ("04", `04`),
+    ("03", `03`),
+    ("15", `15`)
+  )
+
+  "toIdentifierValue" should {
+    "return the correct identifier value" in {
+      IncomeSourceType.`01`.toTypeOfBusiness shouldBe TypeOfBusiness.`self-employment`
+      IncomeSourceType.`02`.toTypeOfBusiness shouldBe TypeOfBusiness.`uk-property-non-fhl`
+      IncomeSourceType.`04`.toTypeOfBusiness shouldBe TypeOfBusiness.`uk-property-fhl`
+      IncomeSourceType.`03`.toTypeOfBusiness shouldBe TypeOfBusiness.`foreign-property-fhl-eea`
+      IncomeSourceType.`15`.toTypeOfBusiness shouldBe TypeOfBusiness.`foreign-property`
+    }
+  }
+
+}

--- a/test/v5/models/domain/TypeOfBusinessSpec.scala
+++ b/test/v5/models/domain/TypeOfBusinessSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.models.domain
+
+import shared.UnitSpec
+import shared.utils.enums.EnumJsonSpecSupport
+import v5.models.domain.TypeOfBusiness._
+
+class TypeOfBusinessSpec extends UnitSpec with EnumJsonSpecSupport {
+
+  testRoundTrip[TypeOfBusiness](
+    ("self-employment", `self-employment`),
+    ("uk-property-fhl", `uk-property-fhl`),
+    ("uk-property-non-fhl", `uk-property-non-fhl`),
+    ("foreign-property-fhl-eea", `foreign-property-fhl-eea`),
+    ("foreign-property", `foreign-property`)
+  )
+
+  "toIdentifierValue" should {
+    "return the correct identifier value" in {
+      TypeOfBusiness.`self-employment`.asDownstreamValue shouldBe "01"
+      TypeOfBusiness.`uk-property-non-fhl`.asDownstreamValue shouldBe "02"
+      TypeOfBusiness.`uk-property-fhl`.asDownstreamValue shouldBe "04"
+      TypeOfBusiness.`foreign-property-fhl-eea`.asDownstreamValue shouldBe "03"
+      TypeOfBusiness.`foreign-property`.asDownstreamValue shouldBe "15"
+    }
+  }
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/connectors/MockRetrieveForeignPropertyBsasConnector.scala
+++ b/test/v5/retrieveForeignPropertyBsas/connectors/MockRetrieveForeignPropertyBsasConnector.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.connectors
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.connectors.DownstreamOutcome
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.retrieveForeignPropertyBsas.models.{RetrieveForeignPropertyBsasRequestData, RetrieveForeignPropertyBsasResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockRetrieveForeignPropertyBsasConnector extends MockFactory {
+
+  val mockConnector: RetrieveForeignPropertyBsasConnector = mock[RetrieveForeignPropertyBsasConnector]
+
+  object MockRetrieveForeignPropertyBsasConnector {
+
+    def retrieveForeignPropertyBsas(
+        requestData: RetrieveForeignPropertyBsasRequestData): CallHandler[Future[DownstreamOutcome[RetrieveForeignPropertyBsasResponse]]] = {
+      (mockConnector
+        .retrieveForeignPropertyBsas(_: RetrieveForeignPropertyBsasRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(requestData, *, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/connectors/RetrieveForeignPropertyBsasConnectorSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/connectors/RetrieveForeignPropertyBsasConnectorSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.connectors
+
+import shared.connectors.{ConnectorSpec, DownstreamOutcome}
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.outcomes.ResponseWrapper
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+import v5.retrieveForeignPropertyBsas.models.def1.Def1_RetrieveForeignPropertyBsasRequestData
+import v5.retrieveForeignPropertyBsas.models.{RetrieveForeignPropertyBsasRequestData, RetrieveForeignPropertyBsasResponse}
+
+import scala.concurrent.Future
+
+class RetrieveForeignPropertyBsasConnectorSpec extends ConnectorSpec {
+
+  private val nino          = Nino("AA123456A")
+  private val calculationId = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c"
+
+  trait Test {
+    _: ConnectorTest =>
+    val connector: RetrieveForeignPropertyBsasConnector = new RetrieveForeignPropertyBsasConnector(http = mockHttpClient, appConfig = mockAppConfig)
+  }
+
+  "retrieveForeignPropertyBsas" should {
+    "return a valid response" when {
+      val outcome = Right(ResponseWrapper(correlationId, parsedNonFhlRetrieveForeignPropertyBsasResponse))
+
+      "a valid request is supplied for a non-TYS year" in new IfsTest with Test {
+        val request: RetrieveForeignPropertyBsasRequestData =
+          Def1_RetrieveForeignPropertyBsasRequestData(nino, CalculationId(calculationId), taxYear = None)
+
+        val expectedUrl = s"$baseUrl/income-tax/adjustable-summary-calculation/$nino/$calculationId"
+        willGet(url = expectedUrl) returns Future.successful(outcome)
+
+        await(connector.retrieveForeignPropertyBsas(request)) shouldBe outcome
+      }
+
+      "a valid request with queryParams is supplied for a TYS year" in new TysIfsTest with Test {
+        def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+
+        val request: RetrieveForeignPropertyBsasRequestData =
+          Def1_RetrieveForeignPropertyBsasRequestData(nino, CalculationId(calculationId), Some(taxYear))
+
+        willGet(s"$baseUrl/income-tax/adjustable-summary-calculation/23-24/$nino/$calculationId") returns Future.successful(outcome)
+
+        val result: DownstreamOutcome[RetrieveForeignPropertyBsasResponse] = await(connector.retrieveForeignPropertyBsas(request))
+        result shouldBe outcome
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/controllers/RetrieveForeignPropertyBsasControllerSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/controllers/RetrieveForeignPropertyBsasControllerSpec.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.controllers
+
+import play.api.libs.json.{JsObject, Json}
+import play.api.mvc.Result
+import shared.config.MockAppConfig
+import shared.controllers.{ControllerBaseSpec, ControllerTestRunner}
+import shared.hateoas.Method.GET
+import shared.hateoas.{HateoasWrapper, Link, MockHateoasFactory}
+import shared.models.domain.CalculationId
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.{MockEnrolmentsAuthService, MockMtdIdLookupService}
+import shared.utils.MockIdGenerator
+import v5.models.errors._
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+import v5.retrieveForeignPropertyBsas.models.RetrieveForeignPropertyHateoasData
+import v5.retrieveForeignPropertyBsas.models.def1.Def1_RetrieveForeignPropertyBsasRequestData
+import v5.retrieveForeignPropertyBsas.services.MockRetrieveForeignPropertyBsasService
+import v5.retrieveForeignPropertyBsas.validators.MockRetrieveForeignPropertyBsasValidatorFactory
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class RetrieveForeignPropertyBsasControllerSpec
+    extends ControllerBaseSpec
+    with ControllerTestRunner
+    with MockEnrolmentsAuthService
+    with MockMtdIdLookupService
+    with MockRetrieveForeignPropertyBsasValidatorFactory
+    with MockRetrieveForeignPropertyBsasService
+    with MockHateoasFactory
+    with MockIdGenerator
+    with MockAppConfig {
+
+  private val calculationId = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+
+  private val requestData =
+    Def1_RetrieveForeignPropertyBsasRequestData(parsedNino, calculationId, taxYear = None)
+
+  private val testHateoasLinks =
+    Seq(Link(href = "/some/link", method = GET, rel = "someRel"))
+
+  private val hateoasResponse = retrieveForeignPropertyBsasMtdNonFhlJson
+    .as[JsObject] ++ Json
+    .parse("""{
+      |  "links": [ { "href":"/some/link", "method":"GET", "rel":"someRel" } ]
+      |}
+      |""".stripMargin)
+    .as[JsObject]
+
+  "retrieve" should {
+    "return OK" when {
+      "the request is valid" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockRetrieveForeignPropertyBsasService.retrieveBsas(requestData) returns
+          Future.successful(Right(ResponseWrapper(correlationId, parsedNonFhlRetrieveForeignPropertyBsasResponse)))
+
+        MockHateoasFactory
+          .wrap(
+            parsedNonFhlRetrieveForeignPropertyBsasResponse,
+            RetrieveForeignPropertyHateoasData(validNino, calculationId.calculationId, None)) returns
+          HateoasWrapper(parsedNonFhlRetrieveForeignPropertyBsasResponse, testHateoasLinks)
+
+        runOkTest(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(hateoasResponse)
+        )
+      }
+    }
+
+    "return the error as per spec" when {
+      "the parser validation fails" in new Test {
+        willUseValidator(returning(NinoFormatError))
+        runErrorTest(expectedError = NinoFormatError)
+      }
+
+      "the service returns an error" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockRetrieveForeignPropertyBsasService.retrieveBsas(requestData) returns Future.successful(
+          Left(ErrorWrapper(correlationId, RuleTypeOfBusinessIncorrectError)))
+
+        runErrorTest(expectedError = RuleTypeOfBusinessIncorrectError)
+      }
+    }
+  }
+
+  private trait Test extends ControllerTest {
+
+    private val controller = new RetrieveForeignPropertyBsasController(
+      authService = mockEnrolmentsAuthService,
+      lookupService = mockMtdIdLookupService,
+      validatorFactory = mockRetrieveForeignPropertyBsasValidatorFactory,
+      service = mockService,
+      hateoasFactory = mockHateoasFactory,
+      cc = cc,
+      idGenerator = mockIdGenerator
+    )
+
+    protected def callController(): Future[Result] =
+      controller.retrieve(validNino, calculationId.calculationId, taxYear = None)(fakeGetRequest)
+
+  }
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/fixtures/def1/RetrieveForeignPropertyBsasBodyFixtures.scala
+++ b/test/v5/retrieveForeignPropertyBsas/fixtures/def1/RetrieveForeignPropertyBsasBodyFixtures.scala
@@ -1,0 +1,696 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.fixtures.def1
+
+import play.api.libs.json.{JsValue, Json}
+import v5.models.domain.TypeOfBusiness
+import v5.retrieveForeignPropertyBsas.models.def1._
+
+object RetrieveForeignPropertyBsasBodyFixtures {
+
+  /* Downstream JSON */
+
+  lazy val metadataDesJson: JsValue = Json.parse(
+    """{
+      |  "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+      |  "requestedDateTime": "2020-12-05T16:19:44Z",
+      |  "adjustedDateTime": "2020-12-05T16:19:44Z",
+      |  "taxableEntityId": "AA999999A",
+      |  "taxYear": 2020,
+      |  "status": "valid"
+      |}""".stripMargin
+  )
+
+  lazy val submissionPeriodDesJson: JsValue = Json.parse(
+    """{
+      |      "periodId": "617f3a7a-db8e-11e9-8a34-2a2ae2dbeed4",
+      |      "startDate": "2019-04-06",
+      |      "endDate": "2020-04-05",
+      |      "receivedDateTime": "2019-02-15T09:35:04.843Z"
+      |}""".stripMargin
+  )
+
+  lazy val inputsDesFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "incomeSourceId": "000000000000210",
+       |  "incomeSourceType": "03",
+       |  "incomeSourceName": "Business Name",
+       |  "accountingPeriodStartDate": "2019-04-06",
+       |  "accountingPeriodEndDate": "2020-04-05",
+       |  "source": "MTD-SA",
+       |  "submissionPeriods": [$submissionPeriodDesJson]
+       |}""".stripMargin
+  )
+
+  lazy val inputsDesNonFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "incomeSourceId": "000000000000210",
+       |  "incomeSourceType": "15",
+       |  "incomeSourceName": "Business Name",
+       |  "accountingPeriodStartDate": "2019-04-06",
+       |  "accountingPeriodEndDate": "2020-04-05",
+       |  "source": "MTD-SA",
+       |  "submissionPeriods": [$submissionPeriodDesJson]
+       |}""".stripMargin
+  )
+
+  lazy val summaryCalculationIncomeDesJson: JsValue = Json.parse(
+    """{
+      |  "rent": 0.02,
+      |  "premiumsOfLeaseGrant": 0.03,
+      |  "otherPropertyIncome": 0.04
+      |}""".stripMargin
+  )
+
+  lazy val summaryCalculationExpensesDesJson: JsValue = Json.parse(
+    """{
+      |  "consolidatedExpenses": 0.06,
+      |  "premisesRunningCosts": 0.07,
+      |  "repairsAndMaintenance": 0.08,
+      |  "financialCosts": 0.09,
+      |  "professionalFees": 0.10,
+      |  "travelCosts": 0.11,
+      |  "costOfServices": 0.12,
+      |  "residentialFinancialCost": 0.13,
+      |  "broughtFwdResidentialFinancialCost": 0.14,
+      |  "other": 0.15
+      |}""".stripMargin
+  )
+
+  lazy val summaryCalculationAdditionsDesJson: JsValue = Json.parse(
+    """{
+      |  "privateUseAdjustment": 0.19,
+      |  "balancingCharge": 0.20
+      |}""".stripMargin
+  )
+
+  lazy val summaryCalculationDeductionsDesJson: JsValue = Json.parse(
+    """{
+      |  "annualInvestmentAllowance": 0.22,
+      |  "costOfReplacingDomesticItems": 0.23,
+      |  "zeroEmissionsGoodsVehicleAllowance": 0.24,
+      |  "propertyAllowance": 0.25,
+      |  "otherCapitalAllowance": 0.26,
+      |  "electricChargePointAllowance": 0.27,
+      |  "structuredBuildingAllowance": 0.28,
+      |  "zeroEmissionsCarAllowance": 0.29
+      |}""".stripMargin
+  )
+
+  lazy val summaryCalculationCountryLevelDetailDesJson: JsValue = Json.parse(
+    s"""{
+       |  "countryCode": "AFG",
+       |  "totalIncome": 0.01,
+       |  "income": $summaryCalculationIncomeDesJson,
+       |  "totalExpenses": 0.02,
+       |  "expenses": $summaryCalculationExpensesDesJson,
+       |  "netProfit": 0.03,
+       |  "netLoss": 0.04,
+       |  "totalAdditions": 0.05,
+       |  "additions": $summaryCalculationAdditionsDesJson,
+       |  "totalDeductions": 0.06,
+       |  "deductions": $summaryCalculationDeductionsDesJson,
+       |  "taxableProfit": 1.12,
+       |  "adjustedIncomeTaxLoss": 1.13
+       |}""".stripMargin
+  )
+
+  lazy val summaryCalculationDesFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "totalIncome": 0.01,
+       |  "income": $summaryCalculationIncomeDesJson,
+       |  "totalExpenses": 0.05,
+       |  "expenses": $summaryCalculationExpensesDesJson,
+       |  "netProfit": 0.16,
+       |  "netLoss": 0.17,
+       |  "totalAdditions": 0.18,
+       |  "additions": $summaryCalculationAdditionsDesJson,
+       |  "totalDeductions": 0.21,
+       |  "deductions": $summaryCalculationDeductionsDesJson,
+       |  "taxableProfit": 0.30,
+       |  "adjustedIncomeTaxLoss": 0.31
+       |}""".stripMargin
+  )
+
+  lazy val summaryCalculationDesNonFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "totalIncome": 0.01,
+       |  "income": $summaryCalculationIncomeDesJson,
+       |  "totalExpenses": 0.05,
+       |  "expenses": $summaryCalculationExpensesDesJson,
+       |  "netProfit": 0.16,
+       |  "netLoss": 0.17,
+       |  "totalAdditions": 0.18,
+       |  "additions": $summaryCalculationAdditionsDesJson,
+       |  "totalDeductions": 0.21,
+       |  "deductions": $summaryCalculationDeductionsDesJson,
+       |  "taxableProfit": 0.30,
+       |  "adjustedIncomeTaxLoss": 0.31,
+       |  "countryLevelDetail": [$summaryCalculationCountryLevelDetailDesJson]
+       |}""".stripMargin
+  )
+
+  lazy val adjustmentsIncomeDesFhlJson: JsValue = Json.parse(
+    """{
+      |  "rent": 0.12
+      |}""".stripMargin
+  )
+
+  lazy val adjustmentsIncomeDesNonFhlJson: JsValue = Json.parse(
+    """{
+      |  "rentReceived": 0.12,
+      |  "premiumsOfLeaseGrant": 0.13,
+      |  "otherPropertyIncome": 0.14
+      |}""".stripMargin
+  )
+
+  lazy val adjustmentsExpensesDesJson: JsValue = Json.parse(
+    """{
+      |  "consolidatedExpenses": 0.01,
+      |  "repairsAndMaintenance": 0.02,
+      |  "financialCosts": 0.03,
+      |  "professionalFees": 0.04,
+      |  "costOfServices": 0.05,
+      |  "travelCosts": 0.06,
+      |  "other": 0.07,
+      |  "premisesRunningCosts": 0.08,
+      |  "residentialFinancialCost": 0.09
+      |}""".stripMargin
+  )
+
+  lazy val adjustmentsDesFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "income": $adjustmentsIncomeDesFhlJson,
+       |  "expenses": $adjustmentsExpensesDesJson
+       |}""".stripMargin
+  )
+
+  lazy val adjustmentsDesNonFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "countryCode": "AFG",
+       |  "income": $adjustmentsIncomeDesNonFhlJson,
+       |  "expenses": $adjustmentsExpensesDesJson
+       |}""".stripMargin
+  )
+
+  lazy val retrieveForeignPropertyBsasDesFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "metadata": $metadataDesJson,
+       |  "inputs": $inputsDesFhlJson,
+       |  "adjustableSummaryCalculation": $summaryCalculationDesFhlJson,
+       |  "adjustments": $adjustmentsDesFhlJson,
+       |  "adjustedSummaryCalculation": $summaryCalculationDesFhlJson
+       |}""".stripMargin
+  )
+
+  lazy val retrieveForeignPropertyBsasDesNonFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "metadata": $metadataDesJson,
+       |  "inputs": $inputsDesNonFhlJson,
+       |  "adjustableSummaryCalculation": $summaryCalculationDesNonFhlJson,
+       |  "adjustments": [$adjustmentsDesNonFhlJson],
+       |  "adjustedSummaryCalculation": $summaryCalculationDesNonFhlJson
+       |}""".stripMargin
+  )
+
+  /* MTD JSON */
+
+  lazy val metadataMtdJson: JsValue = Json.parse(
+    """{
+      |  "calculationId": "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+      |  "requestedDateTime": "2020-12-05T16:19:44Z",
+      |  "adjustedDateTime": "2020-12-05T16:19:44Z",
+      |  "nino": "AA999999A",
+      |  "taxYear": "2019-20",
+      |  "summaryStatus": "valid"
+      |}""".stripMargin
+  )
+
+  lazy val submissionPeriodMtdJson: JsValue = Json.parse(
+    """{
+      |  "submissionId": "617f3a7a-db8e-11e9-8a34-2a2ae2dbeed4",
+      |  "startDate": "2019-04-06",
+      |  "endDate": "2020-04-05",
+      |  "receivedDateTime": "2019-02-15T09:35:04.843Z"
+      |}""".stripMargin
+  )
+
+  lazy val inputsMtdFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "businessId": "000000000000210",
+       |  "typeOfBusiness": "foreign-property-fhl-eea",
+       |  "businessName": "Business Name",
+       |  "accountingPeriodStartDate": "2019-04-06",
+       |  "accountingPeriodEndDate": "2020-04-05",
+       |  "source": "MTD-SA",
+       |  "submissionPeriods": [$submissionPeriodMtdJson]
+       |}""".stripMargin
+  )
+
+  lazy val inputsMtdNonFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "businessId": "000000000000210",
+       |  "typeOfBusiness": "foreign-property",
+       |  "businessName": "Business Name",
+       |  "accountingPeriodStartDate": "2019-04-06",
+       |  "accountingPeriodEndDate": "2020-04-05",
+       |  "source": "MTD-SA",
+       |  "submissionPeriods": [$submissionPeriodMtdJson]
+       |}""".stripMargin
+  )
+
+  lazy val summaryCalculationIncomeMtdFhlJson: JsValue = Json.parse(
+    """{
+      |  "totalRentsReceived": 0.02
+      |}""".stripMargin
+  )
+
+  lazy val summaryCalculationIncomeMtdNonFhlJson: JsValue = Json.parse(
+    """{
+      |  "totalRentsReceived": 0.02,
+      |  "premiumsOfLeaseGrant": 0.03,
+      |  "otherPropertyIncome": 0.04
+      |}""".stripMargin
+  )
+
+  lazy val summaryCalculationExpensesMtdJson: JsValue = Json.parse(
+    """{
+      |  "consolidatedExpenses": 0.06,
+      |  "premisesRunningCosts": 0.07,
+      |  "repairsAndMaintenance": 0.08,
+      |  "financialCosts": 0.09,
+      |  "professionalFees": 0.10,
+      |  "travelCosts": 0.11,
+      |  "costOfServices": 0.12,
+      |  "residentialFinancialCost": 0.13,
+      |  "broughtFwdResidentialFinancialCost": 0.14,
+      |  "other": 0.15
+      |}""".stripMargin
+  )
+
+  lazy val summaryCalculationAdditionsMtdJson: JsValue = Json.parse(
+    """{
+      |  "privateUseAdjustment": 0.19,
+      |  "balancingCharge": 0.20
+      |}""".stripMargin
+  )
+
+  lazy val summaryCalculationDeductionsMtdFhlJson: JsValue = Json.parse(
+    """{
+      |  "annualInvestmentAllowance": 0.22,
+      |  "propertyAllowance": 0.25,
+      |  "otherCapitalAllowance": 0.26,
+      |  "electricChargePointAllowance": 0.27,
+      |  "zeroEmissionsCarAllowance": 0.29
+      |}""".stripMargin
+  )
+
+  lazy val summaryCalculationDeductionsMtdNonFhlJson: JsValue = Json.parse(
+    """{
+      |  "annualInvestmentAllowance": 0.22,
+      |  "costOfReplacingDomesticItems": 0.23,
+      |  "zeroEmissionGoods": 0.24,
+      |  "propertyAllowance": 0.25,
+      |  "otherCapitalAllowance": 0.26,
+      |  "electricChargePointAllowance": 0.27,
+      |  "structuredBuildingAllowance": 0.28,
+      |  "zeroEmissionsCarAllowance": 0.29
+      |}""".stripMargin
+  )
+
+  lazy val summaryCalculationCountryLevelDetailMtdJson: JsValue = Json.parse(
+    s"""{
+       |  "countryCode": "AFG",
+       |  "totalIncome": 0.01,
+       |  "income": $summaryCalculationIncomeMtdNonFhlJson,
+       |  "totalExpenses": 0.02,
+       |  "expenses": $summaryCalculationExpensesMtdJson,
+       |  "netProfit": 0.03,
+       |  "netLoss": 0.04,
+       |  "totalAdditions": 0.05,
+       |  "additions": $summaryCalculationAdditionsMtdJson,
+       |  "totalDeductions": 0.06,
+       |  "deductions": $summaryCalculationDeductionsMtdNonFhlJson,
+       |  "taxableProfit": 1.12,
+       |  "adjustedIncomeTaxLoss": 1.13
+       |}""".stripMargin
+  )
+
+  lazy val summaryCalculationMtdFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "totalIncome": 0.01,
+       |  "income": $summaryCalculationIncomeMtdFhlJson,
+       |  "totalExpenses": 0.05,
+       |  "expenses": $summaryCalculationExpensesMtdJson,
+       |  "netProfit": 0.16,
+       |  "netLoss": 0.17,
+       |  "totalAdditions": 0.18,
+       |  "additions": $summaryCalculationAdditionsMtdJson,
+       |  "totalDeductions": 0.21,
+       |  "deductions": $summaryCalculationDeductionsMtdFhlJson,
+       |  "taxableProfit": 0.30,
+       |  "adjustedIncomeTaxLoss": 0.31
+       |}""".stripMargin
+  )
+
+  lazy val summaryCalculationMtdNonFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "totalIncome": 0.01,
+       |  "income": $summaryCalculationIncomeMtdNonFhlJson,
+       |  "totalExpenses": 0.05,
+       |  "expenses": $summaryCalculationExpensesMtdJson,
+       |  "netProfit": 0.16,
+       |  "netLoss": 0.17,
+       |  "totalAdditions": 0.18,
+       |  "additions": $summaryCalculationAdditionsMtdJson,
+       |  "totalDeductions": 0.21,
+       |  "deductions": $summaryCalculationDeductionsMtdNonFhlJson,
+       |  "taxableProfit": 0.30,
+       |  "adjustedIncomeTaxLoss": 0.31,
+       |  "countryLevelDetail": [$summaryCalculationCountryLevelDetailMtdJson]
+       |}""".stripMargin
+  )
+
+  lazy val adjustmentsIncomeMtdFhlJson: JsValue = Json.parse(
+    """{
+      |  "totalRentsReceived": 0.12
+      |}""".stripMargin
+  )
+
+  lazy val adjustmentsIncomeMtdNonFhlJson: JsValue = Json.parse(
+    """{
+      |  "totalRentsReceived": 0.12,
+      |  "premiumsOfLeaseGrant": 0.13,
+      |  "otherPropertyIncome": 0.14
+      |}""".stripMargin
+  )
+
+  lazy val adjustmentsExpensesMtdFhlJson: JsValue = Json.parse(
+    """{
+      |  "consolidatedExpenses": 0.01,
+      |  "repairsAndMaintenance": 0.02,
+      |  "financialCosts": 0.03,
+      |  "professionalFees": 0.04,
+      |  "costOfServices": 0.05,
+      |  "travelCosts": 0.06,
+      |  "other": 0.07,
+      |  "premisesRunningCosts": 0.08
+      |}""".stripMargin
+  )
+
+  lazy val adjustmentsExpensesMtdNonFhlJson: JsValue = Json.parse(
+    """{
+      |  "consolidatedExpenses": 0.01,
+      |  "repairsAndMaintenance": 0.02,
+      |  "financialCosts": 0.03,
+      |  "professionalFees": 0.04,
+      |  "costOfServices": 0.05,
+      |  "travelCosts": 0.06,
+      |  "other": 0.07,
+      |  "premisesRunningCosts": 0.08,
+      |  "residentialFinancialCost": 0.09
+      |}""".stripMargin
+  )
+
+  lazy val adjustmentsMtdFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "income": $adjustmentsIncomeMtdFhlJson,
+       |  "expenses": $adjustmentsExpensesMtdFhlJson
+       |}""".stripMargin
+  )
+
+  lazy val adjustmentsCountryLevelDetailMtdNonFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "countryCode": "AFG",
+       |  "income": $adjustmentsIncomeMtdNonFhlJson,
+       |  "expenses": $adjustmentsExpensesMtdNonFhlJson
+       |}""".stripMargin
+  )
+
+  lazy val adjustmentsMtdNonFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "countryLevelDetail": [$adjustmentsCountryLevelDetailMtdNonFhlJson]
+       |}""".stripMargin
+  )
+
+  lazy val retrieveForeignPropertyBsasMtdFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "metadata": $metadataMtdJson,
+       |  "inputs": $inputsMtdFhlJson,
+       |  "adjustableSummaryCalculation": $summaryCalculationMtdFhlJson,
+       |  "adjustments": $adjustmentsMtdFhlJson,
+       |  "adjustedSummaryCalculation": $summaryCalculationMtdFhlJson
+       |}""".stripMargin
+  )
+
+  lazy val retrieveForeignPropertyBsasMtdNonFhlJson: JsValue = Json.parse(
+    s"""{
+       |  "metadata": $metadataMtdJson,
+       |  "inputs": $inputsMtdNonFhlJson,
+       |  "adjustableSummaryCalculation": $summaryCalculationMtdNonFhlJson,
+       |  "adjustments": $adjustmentsMtdNonFhlJson,
+       |  "adjustedSummaryCalculation": $summaryCalculationMtdNonFhlJson
+       |}""".stripMargin
+  )
+
+  /* Parsed items */
+
+  lazy val parsedMetadata: Metadata = Metadata(
+    calculationId = "717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4",
+    requestedDateTime = "2020-12-05T16:19:44Z",
+    adjustedDateTime = Some("2020-12-05T16:19:44Z"),
+    nino = "AA999999A",
+    taxYear = "2019-20",
+    summaryStatus = "valid"
+  )
+
+  lazy val parsedSubmissionPeriod: SubmissionPeriods = SubmissionPeriods(
+    submissionId = "617f3a7a-db8e-11e9-8a34-2a2ae2dbeed4",
+    startDate = "2019-04-06",
+    endDate = "2020-04-05",
+    receivedDateTime = "2019-02-15T09:35:04.843Z"
+  )
+
+  lazy val parsedFhlInputs: Inputs = Inputs(
+    businessId = "000000000000210",
+    typeOfBusiness = TypeOfBusiness.`foreign-property-fhl-eea`,
+    businessName = Some("Business Name"),
+    accountingPeriodStartDate = "2019-04-06",
+    accountingPeriodEndDate = "2020-04-05",
+    source = "MTD-SA",
+    submissionPeriods = Seq(parsedSubmissionPeriod)
+  )
+
+  lazy val parsedNonFhlInputs: Inputs = Inputs(
+    businessId = "000000000000210",
+    typeOfBusiness = TypeOfBusiness.`foreign-property`,
+    businessName = Some("Business Name"),
+    accountingPeriodStartDate = "2019-04-06",
+    accountingPeriodEndDate = "2020-04-05",
+    source = "MTD-SA",
+    submissionPeriods = Seq(parsedSubmissionPeriod)
+  )
+
+  lazy val parsedFhlSummaryCalculationIncome: SummaryCalculationIncome = SummaryCalculationIncome(
+    totalRentsReceived = Some(0.02),
+    premiumsOfLeaseGrant = None,
+    otherPropertyIncome = None
+  )
+
+  lazy val parsedNonFhlSummaryCalculationIncome: SummaryCalculationIncome = SummaryCalculationIncome(
+    totalRentsReceived = Some(0.02),
+    premiumsOfLeaseGrant = Some(0.03),
+    otherPropertyIncome = Some(0.04)
+  )
+
+  lazy val parsedSummaryCalculationExpenses: SummaryCalculationExpenses = SummaryCalculationExpenses(
+    consolidatedExpenses = Some(0.06),
+    premisesRunningCosts = Some(0.07),
+    repairsAndMaintenance = Some(0.08),
+    financialCosts = Some(0.09),
+    professionalFees = Some(0.10),
+    costOfServices = Some(0.12),
+    residentialFinancialCost = Some(0.13),
+    broughtFwdResidentialFinancialCost = Some(0.14),
+    other = Some(0.15),
+    travelCosts = Some(0.11)
+  )
+
+  lazy val parsedSummaryCalculationAdditions: SummaryCalculationAdditions = SummaryCalculationAdditions(
+    privateUseAdjustment = Some(0.19),
+    balancingCharge = Some(0.20)
+  )
+
+  lazy val parsedFhlSummaryCalculationDeductions: SummaryCalculationDeductions = SummaryCalculationDeductions(
+    annualInvestmentAllowance = Some(0.22),
+    costOfReplacingDomesticItems = None,
+    zeroEmissionGoods = None,
+    propertyAllowance = Some(0.25),
+    otherCapitalAllowance = Some(0.26),
+    electricChargePointAllowance = Some(0.27),
+    structuredBuildingAllowance = None,
+    zeroEmissionsCarAllowance = Some(0.29)
+  )
+
+  lazy val parsedNonFhlSummaryCalculationDeductions: SummaryCalculationDeductions = SummaryCalculationDeductions(
+    annualInvestmentAllowance = Some(0.22),
+    costOfReplacingDomesticItems = Some(0.23),
+    zeroEmissionGoods = Some(0.24),
+    propertyAllowance = Some(0.25),
+    otherCapitalAllowance = Some(0.26),
+    electricChargePointAllowance = Some(0.27),
+    structuredBuildingAllowance = Some(0.28),
+    zeroEmissionsCarAllowance = Some(0.29)
+  )
+
+  lazy val parsedSummaryCalculationCountryLevelDetail: SummaryCalculationCountryLevelDetail = SummaryCalculationCountryLevelDetail(
+    countryCode = "AFG",
+    totalIncome = Some(0.01),
+    income = Some(parsedNonFhlSummaryCalculationIncome),
+    totalExpenses = Some(0.02),
+    expenses = Some(parsedSummaryCalculationExpenses),
+    netProfit = Some(0.03),
+    netLoss = Some(0.04),
+    totalAdditions = Some(0.05),
+    additions = Some(parsedSummaryCalculationAdditions),
+    totalDeductions = Some(0.06),
+    deductions = Some(parsedNonFhlSummaryCalculationDeductions),
+    taxableProfit = Some(1.12),
+    adjustedIncomeTaxLoss = Some(1.13)
+  )
+
+  lazy val parsedFhlsummaryCalculation: SummaryCalculation = SummaryCalculation(
+    totalIncome = Some(0.01),
+    income = Some(parsedFhlSummaryCalculationIncome),
+    totalExpenses = Some(0.05),
+    expenses = Some(parsedSummaryCalculationExpenses),
+    netProfit = Some(0.16),
+    netLoss = Some(0.17),
+    totalAdditions = Some(0.18),
+    additions = Some(parsedSummaryCalculationAdditions),
+    totalDeductions = Some(0.21),
+    deductions = Some(parsedFhlSummaryCalculationDeductions),
+    taxableProfit = Some(0.30),
+    adjustedIncomeTaxLoss = Some(0.31),
+    countryLevelDetail = None
+  )
+
+  lazy val parsedNonFhlSummaryCalculation: SummaryCalculation = SummaryCalculation(
+    totalIncome = Some(0.01),
+    income = Some(parsedNonFhlSummaryCalculationIncome),
+    totalExpenses = Some(0.05),
+    expenses = Some(parsedSummaryCalculationExpenses),
+    netProfit = Some(0.16),
+    netLoss = Some(0.17),
+    totalAdditions = Some(0.18),
+    additions = Some(parsedSummaryCalculationAdditions),
+    totalDeductions = Some(0.21),
+    deductions = Some(parsedNonFhlSummaryCalculationDeductions),
+    taxableProfit = Some(0.30),
+    adjustedIncomeTaxLoss = Some(0.31),
+    countryLevelDetail = Some(Seq(parsedSummaryCalculationCountryLevelDetail))
+  )
+
+  lazy val parsedFhlAdjustmentsIncome: AdjustmentsIncome = AdjustmentsIncome(
+    totalRentsReceived = Some(0.12),
+    premiumsOfLeaseGrant = None,
+    otherPropertyIncome = None
+  )
+
+  lazy val parsedNonFhlAdjustmentsIncome: AdjustmentsIncome = AdjustmentsIncome(
+    totalRentsReceived = Some(0.12),
+    premiumsOfLeaseGrant = Some(0.13),
+    otherPropertyIncome = Some(0.14)
+  )
+
+  lazy val parsedFhlAdjustmentsExpenses: AdjustmentsExpenses = AdjustmentsExpenses(
+    consolidatedExpenses = Some(0.01),
+    premisesRunningCosts = Some(0.08),
+    repairsAndMaintenance = Some(0.02),
+    financialCosts = Some(0.03),
+    professionalFees = Some(0.04),
+    costOfServices = Some(0.05),
+    residentialFinancialCost = None,
+    other = Some(0.07),
+    travelCosts = Some(0.06)
+  )
+
+  lazy val parsedNonFhlAdjustmentsExpenses: AdjustmentsExpenses = AdjustmentsExpenses(
+    consolidatedExpenses = Some(0.01),
+    premisesRunningCosts = Some(0.08),
+    repairsAndMaintenance = Some(0.02),
+    financialCosts = Some(0.03),
+    professionalFees = Some(0.04),
+    costOfServices = Some(0.05),
+    residentialFinancialCost = Some(0.09),
+    other = Some(0.07),
+    travelCosts = Some(0.06)
+  )
+
+  lazy val parsedFhlAdjustments: Adjustments = Adjustments(
+    countryLevelDetail = None,
+    countryCode = None,
+    income = Some(parsedFhlAdjustmentsIncome),
+    expenses = Some(parsedFhlAdjustmentsExpenses)
+  )
+
+  lazy val parsedNonFhlAdjustments: Adjustments = Adjustments(
+    countryLevelDetail = None,
+    countryCode = Some("AFG"),
+    income = Some(parsedNonFhlAdjustmentsIncome),
+    expenses = Some(parsedNonFhlAdjustmentsExpenses)
+  )
+
+  lazy val parsedNonFhlAdjustmentsSeq: Adjustments = Adjustments(
+    countryLevelDetail = Some(
+      List(Adjustments(
+        countryLevelDetail = None,
+        countryCode = parsedNonFhlAdjustments.countryCode,
+        income = parsedNonFhlAdjustments.income,
+        expenses = parsedNonFhlAdjustments.expenses
+      ))),
+    countryCode = None,
+    income = None,
+    expenses = None
+  )
+
+  lazy val parsedFhlRetrieveForeignPropertyBsasResponse: Def1_RetrieveForeignPropertyBsasResponse = Def1_RetrieveForeignPropertyBsasResponse(
+    metadata = parsedMetadata,
+    inputs = parsedFhlInputs,
+    adjustableSummaryCalculation = parsedFhlsummaryCalculation,
+    adjustments = Some(parsedFhlAdjustments),
+    adjustedSummaryCalculation = Some(parsedFhlsummaryCalculation)
+  )
+
+  lazy val parsedNonFhlRetrieveForeignPropertyBsasResponse: Def1_RetrieveForeignPropertyBsasResponse = Def1_RetrieveForeignPropertyBsasResponse(
+    metadata = parsedMetadata,
+    inputs = parsedNonFhlInputs,
+    adjustableSummaryCalculation = parsedNonFhlSummaryCalculation,
+    adjustments = Some(parsedNonFhlAdjustmentsSeq),
+    adjustedSummaryCalculation = Some(parsedNonFhlSummaryCalculation)
+  )
+
+  def parsedNonFhlRetrieveForeignPropertyBsasResponseWith(typeOfBusiness: TypeOfBusiness): Def1_RetrieveForeignPropertyBsasResponse =
+    Def1_RetrieveForeignPropertyBsasResponse(
+      metadata = parsedMetadata,
+      inputs = parsedNonFhlInputs.copy(typeOfBusiness = typeOfBusiness),
+      adjustableSummaryCalculation = parsedNonFhlSummaryCalculation,
+      adjustments = Some(parsedNonFhlAdjustmentsSeq),
+      adjustedSummaryCalculation = Some(parsedNonFhlSummaryCalculation)
+    )
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/RetrieveForeignPropertyBsasResponseSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/RetrieveForeignPropertyBsasResponseSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models
+
+import play.api.Configuration
+import shared.UnitSpec
+import shared.config.MockAppConfig
+import shared.hateoas.Method.{GET, POST}
+import shared.hateoas.{HateoasFactory, HateoasWrapper, Link}
+import shared.models.domain.TaxYear
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class RetrieveForeignPropertyBsasResponseSpec extends UnitSpec {
+
+  "HateoasFactory" should {
+    class Test extends MockAppConfig {
+      val hateoasFactory                                   = new HateoasFactory(mockAppConfig)
+      val nino                                             = "someNino"
+      val calculationId                                    = "anId"
+      val context                                          = "individuals/self-assessment/adjustable-summary"
+      val taxYear                                          = Some(TaxYear.fromMtd("2023-24"))
+      val rawResponse: RetrieveForeignPropertyBsasResponse = parsedFhlRetrieveForeignPropertyBsasResponse
+
+      MockAppConfig.apiGatewayContext.returns(context).anyNumberOfTimes()
+    }
+
+    class TysDisabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> false)).anyNumberOfTimes()
+    }
+
+    class TysEnabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> true)).anyNumberOfTimes()
+    }
+
+    "return the correct links without tax year" in new TysDisabledTest {
+      private val result = hateoasFactory.wrap(rawResponse, RetrieveForeignPropertyHateoasData(nino, calculationId, None))
+      private val expectedLinks = Seq(
+        Link(s"/$context/$nino/foreign-property/$calculationId", GET, "self"),
+        Link(s"/$context/$nino/foreign-property/$calculationId/adjust", POST, "submit-foreign-property-accounting-adjustments")
+      )
+
+      result shouldBe HateoasWrapper(rawResponse, expectedLinks)
+    }
+
+    "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+      private val result = hateoasFactory.wrap(rawResponse, RetrieveForeignPropertyHateoasData(nino, calculationId, taxYear))
+      private val expectedLinks = Seq(
+        Link(s"/$context/$nino/foreign-property/$calculationId?taxYear=2023-24", GET, "self"),
+        Link(s"/$context/$nino/foreign-property/$calculationId/adjust?taxYear=2023-24", POST, "submit-foreign-property-accounting-adjustments")
+      )
+
+      result shouldBe HateoasWrapper(rawResponse, expectedLinks)
+    }
+  }
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/AdjustmentsExpensesSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/AdjustmentsExpensesSpec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import v5.models.RoundTripTest
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class AdjustmentsExpensesSpec extends UnitSpec with RoundTripTest {
+
+  import v5.retrieveForeignPropertyBsas.models.def1.AdjustmentsExpenses._
+
+  testRoundTrip("Adjustments Expenses FHL", adjustmentsExpensesDesJson, parsedFhlAdjustmentsExpenses, adjustmentsExpensesMtdFhlJson)(readsFhl)
+  testRoundTrip("Adjustments Non-FHL", adjustmentsExpensesDesJson, parsedNonFhlAdjustmentsExpenses, adjustmentsExpensesMtdNonFhlJson)(readsNonFhl)
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/AdjustmentsIncomeSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/AdjustmentsIncomeSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import v5.models.RoundTripTest
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class AdjustmentsIncomeSpec extends UnitSpec with RoundTripTest {
+
+  import v5.retrieveForeignPropertyBsas.models.def1.AdjustmentsIncome._
+
+  testRoundTrip("Adjustments Income FHL", adjustmentsIncomeDesFhlJson, parsedFhlAdjustmentsIncome, adjustmentsIncomeMtdFhlJson)(readsFhl)
+
+  testRoundTrip("Adjustments Income Non-FHL", adjustmentsIncomeDesNonFhlJson, parsedNonFhlAdjustmentsIncome, adjustmentsIncomeMtdNonFhlJson)(
+    readsNonFhl)
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/AdjustmentsSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/AdjustmentsSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import v5.models.RoundTripTest
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class AdjustmentsSpec extends UnitSpec with RoundTripTest {
+
+  import v5.retrieveForeignPropertyBsas.models.def1.Adjustments._
+
+  testRoundTrip("Adjustments FHL", adjustmentsDesFhlJson, parsedFhlAdjustments, adjustmentsMtdFhlJson)(readsFhl)
+  testRoundTrip("Adjustments Non-FHL", adjustmentsDesNonFhlJson, parsedNonFhlAdjustments, adjustmentsCountryLevelDetailMtdNonFhlJson)(readsNonFhl)
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/Def1_RetrieveForeignPropertyBsasResponseSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/Def1_RetrieveForeignPropertyBsasResponseSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import v5.models.RoundTripTest
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class Def1_RetrieveForeignPropertyBsasResponseSpec extends UnitSpec with RoundTripTest {
+
+  import v5.retrieveForeignPropertyBsas.models.def1.Def1_RetrieveForeignPropertyBsasResponse._
+
+  testRoundTrip(
+    "Retrieve Foreign Property Bsas Response FHL",
+    retrieveForeignPropertyBsasDesFhlJson,
+    parsedFhlRetrieveForeignPropertyBsasResponse,
+    retrieveForeignPropertyBsasMtdFhlJson
+  )(reads)
+
+  testRoundTrip(
+    "Retrieve Foreign Property Bsas Response Non-FHL",
+    retrieveForeignPropertyBsasDesNonFhlJson,
+    parsedNonFhlRetrieveForeignPropertyBsasResponse,
+    retrieveForeignPropertyBsasMtdNonFhlJson
+  )(reads)
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/InputsSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/InputsSpec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import v5.models.RoundTripTest
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class InputsSpec extends UnitSpec with RoundTripTest {
+
+  import v5.retrieveForeignPropertyBsas.models.def1.Inputs._
+
+  testRoundTrip("Inputs FHL", inputsDesFhlJson, parsedFhlInputs, inputsMtdFhlJson)(reads)
+  testRoundTrip("Inputs Non-FHL", inputsDesNonFhlJson, parsedNonFhlInputs, inputsMtdNonFhlJson)(reads)
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/MetadataSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/MetadataSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class MetadataSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid metadata model" when {
+      "a valid json with all fields are supplied" in {
+        metadataDesJson.as[Metadata] shouldBe parsedMetadata
+      }
+    }
+  }
+
+  "writes" should {
+    "return a valid metadata json" when {
+      "a valid model is supplied" in {
+        parsedMetadata.toJson shouldBe metadataMtdJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/SubmissionPeriodSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/SubmissionPeriodSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class SubmissionPeriodSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid submission period model" when {
+      "a valid json with all fields are supplied" in {
+        submissionPeriodDesJson.as[SubmissionPeriods] shouldBe parsedSubmissionPeriod
+      }
+    }
+  }
+
+  "writes" should {
+    "return a valid json" when {
+      "a valid model is supplied" in {
+        parsedSubmissionPeriod.toJson shouldBe submissionPeriodMtdJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationAdditionsSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationAdditionsSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import v5.models.RoundTripTest
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class SummaryCalculationAdditionsSpec extends UnitSpec with RoundTripTest {
+
+  import v5.retrieveForeignPropertyBsas.models.def1.SummaryCalculationAdditions._
+
+  testRoundTrip(
+    "Summary Calculation Additions",
+    summaryCalculationAdditionsDesJson,
+    parsedSummaryCalculationAdditions,
+    summaryCalculationAdditionsMtdJson)(reads)
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationCountryLevelDetailSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationCountryLevelDetailSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import v5.models.RoundTripTest
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class SummaryCalculationCountryLevelDetailSpec extends UnitSpec with RoundTripTest {
+
+  import v5.retrieveForeignPropertyBsas.models.def1.SummaryCalculationCountryLevelDetail._
+
+  testRoundTrip(
+    "Summary Calculation Country Level Detail",
+    summaryCalculationCountryLevelDetailDesJson,
+    parsedSummaryCalculationCountryLevelDetail,
+    summaryCalculationCountryLevelDetailMtdJson
+  )(reads)
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationDeductionsSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationDeductionsSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import v5.models.RoundTripTest
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class SummaryCalculationDeductionsSpec extends UnitSpec with RoundTripTest {
+
+  import v5.retrieveForeignPropertyBsas.models.def1.SummaryCalculationDeductions._
+
+  testRoundTrip(
+    "Summary Calculation Deductions FHL",
+    summaryCalculationDeductionsDesJson,
+    parsedFhlSummaryCalculationDeductions,
+    summaryCalculationDeductionsMtdFhlJson)(readsFhl)
+
+  testRoundTrip(
+    "Adjustments Non-FHL",
+    summaryCalculationDeductionsDesJson,
+    parsedNonFhlSummaryCalculationDeductions,
+    summaryCalculationDeductionsMtdNonFhlJson)(readsNonFhl)
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationExpensesSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationExpensesSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import v5.models.RoundTripTest
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class SummaryCalculationExpensesSpec extends UnitSpec with RoundTripTest {
+
+  import v5.retrieveForeignPropertyBsas.models.def1.SummaryCalculationExpenses._
+
+  testRoundTrip(
+    "Summary Calculation Expenses",
+    summaryCalculationExpensesDesJson,
+    parsedSummaryCalculationExpenses,
+    summaryCalculationExpensesMtdJson)(reads)
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationIncomeSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationIncomeSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import v5.models.RoundTripTest
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class SummaryCalculationIncomeSpec extends UnitSpec with RoundTripTest {
+
+  import v5.retrieveForeignPropertyBsas.models.def1.SummaryCalculationIncome._
+
+  testRoundTrip(
+    "Summary Calculation Income FHL",
+    summaryCalculationIncomeDesJson,
+    parsedFhlSummaryCalculationIncome,
+    summaryCalculationIncomeMtdFhlJson)(readsFhl)
+
+  testRoundTrip(
+    "Summary Calculation Income Non-FHL",
+    summaryCalculationIncomeDesJson,
+    parsedNonFhlSummaryCalculationIncome,
+    summaryCalculationIncomeMtdNonFhlJson)(readsNonFhl)
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/models/def1/SummaryCalculationSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.models.def1
+
+import shared.UnitSpec
+import v5.models.RoundTripTest
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+
+class SummaryCalculationSpec extends UnitSpec with RoundTripTest {
+
+  import v5.retrieveForeignPropertyBsas.models.def1.SummaryCalculation._
+
+  testRoundTrip("Summary Calculation FHL", summaryCalculationDesFhlJson, parsedFhlsummaryCalculation, summaryCalculationMtdFhlJson)(readsFhl)
+
+  testRoundTrip("Summary Calculation Non-FHL", summaryCalculationDesNonFhlJson, parsedNonFhlSummaryCalculation, summaryCalculationMtdNonFhlJson)(
+    readsNonFhl)
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/schema/RetrieveForeignPropertyBsasSchemaSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/schema/RetrieveForeignPropertyBsasSchemaSpec.scala
@@ -20,25 +20,19 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import shared.UnitSpec
 import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
 
-import scala.math.Ordered.orderingToOrdered
-
 class RetrieveForeignPropertyBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
 
   "schema lookup" when {
     "a tax year is present" must {
       "use Def1 for tax years from 2023-24" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
-            RetrieveForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveForeignPropertyBsasSchema.Def1
-          }
+        forTaxYearsFrom(TaxYear.fromMtd("2023-24")) { taxYear =>
+          RetrieveForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveForeignPropertyBsasSchema.Def1
         }
       }
 
-      "use Def1 for other tax years" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
+      "use Def1 for pre-TYS tax years" in {
+        forPreTysTaxYears { taxYear =>
             RetrieveForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveForeignPropertyBsasSchema.Def1
-          }
         }
       }
     }

--- a/test/v5/retrieveForeignPropertyBsas/schema/RetrieveForeignPropertyBsasSchemaSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/schema/RetrieveForeignPropertyBsasSchemaSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.schema
+
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import shared.UnitSpec
+import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+
+import scala.math.Ordered.orderingToOrdered
+
+class RetrieveForeignPropertyBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
+
+  "schema lookup" when {
+    "a tax year is present" must {
+      "use Def1 for tax years from 2023-24" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
+            RetrieveForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveForeignPropertyBsasSchema.Def1
+          }
+        }
+      }
+
+      "use Def1 for other tax years" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
+            RetrieveForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveForeignPropertyBsasSchema.Def1
+          }
+        }
+      }
+    }
+
+    "the tax year is present but not valid" must {
+      "use a default of Def1" in {
+        RetrieveForeignPropertyBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe RetrieveForeignPropertyBsasSchema.Def1
+      }
+    }
+
+    "no tax year is present" must {
+      "use a default of Def1" in {
+        RetrieveForeignPropertyBsasSchema.schemaFor(None) shouldBe RetrieveForeignPropertyBsasSchema.Def1
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/services/MockRetrieveForeignPropertyBsasService.scala
+++ b/test/v5/retrieveForeignPropertyBsas/services/MockRetrieveForeignPropertyBsasService.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.services
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.controllers.RequestContext
+import shared.services.ServiceOutcome
+import v5.retrieveForeignPropertyBsas.models.{RetrieveForeignPropertyBsasRequestData, RetrieveForeignPropertyBsasResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockRetrieveForeignPropertyBsasService extends MockFactory {
+
+  val mockService: RetrieveForeignPropertyBsasService = mock[RetrieveForeignPropertyBsasService]
+
+  object MockRetrieveForeignPropertyBsasService {
+
+    def retrieveBsas(
+        requestData: RetrieveForeignPropertyBsasRequestData): CallHandler[Future[ServiceOutcome[RetrieveForeignPropertyBsasResponse]]] = {
+      (mockService
+        .retrieveForeignPropertyBsas(_: RetrieveForeignPropertyBsasRequestData)(_: RequestContext, _: ExecutionContext))
+        .expects(requestData, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/services/RetrieveForeignPropertyBsasServiceSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/services/RetrieveForeignPropertyBsasServiceSpec.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.services
+
+import shared.controllers.EndpointLogContext
+import shared.models.domain.{CalculationId, Nino}
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.ServiceSpec
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.models.domain.TypeOfBusiness
+import v5.models.errors._
+import v5.retrieveForeignPropertyBsas.connectors.MockRetrieveForeignPropertyBsasConnector
+import v5.retrieveForeignPropertyBsas.fixtures.def1.RetrieveForeignPropertyBsasBodyFixtures._
+import v5.retrieveForeignPropertyBsas.models.def1.Def1_RetrieveForeignPropertyBsasRequestData
+import v5.retrieveForeignPropertyBsas.models.{RetrieveForeignPropertyBsasRequestData, RetrieveForeignPropertyBsasResponse}
+
+import scala.concurrent.Future
+
+class RetrieveForeignPropertyBsasServiceSpec extends ServiceSpec {
+
+  private val nino = Nino("AA123456A")
+  private val id   = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+
+  val request: RetrieveForeignPropertyBsasRequestData = Def1_RetrieveForeignPropertyBsasRequestData(nino, id, taxYear = None)
+
+  val response: RetrieveForeignPropertyBsasResponse = parsedNonFhlRetrieveForeignPropertyBsasResponse
+
+  trait Test extends MockRetrieveForeignPropertyBsasConnector {
+    implicit val hc: HeaderCarrier              = HeaderCarrier()
+    implicit val logContext: EndpointLogContext = EndpointLogContext("RetrieveForeignPropertyBSAS", "retrieve")
+
+    val service = new RetrieveForeignPropertyBsasService(mockConnector)
+  }
+
+  "retrieve" should {
+    "return a valid response" when {
+      "a valid request is supplied" in new Test {
+        MockRetrieveForeignPropertyBsasConnector
+          .retrieveForeignPropertyBsas(request)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
+
+        await(service.retrieveForeignPropertyBsas(request)) shouldBe Right(ResponseWrapper(correlationId, response))
+      }
+    }
+
+    "return error response" when {
+      "downstream returns a success response with invalid type of business" should {
+        import TypeOfBusiness._
+        Seq(`self-employment`, `uk-property-fhl`, `uk-property-non-fhl`).foreach(typeOfBusiness =>
+          s"return an error for $typeOfBusiness" in new Test {
+            val response: RetrieveForeignPropertyBsasResponse = parsedNonFhlRetrieveForeignPropertyBsasResponseWith(typeOfBusiness)
+
+            MockRetrieveForeignPropertyBsasConnector
+              .retrieveForeignPropertyBsas(request)
+              .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
+
+            await(service.retrieveForeignPropertyBsas(request)) shouldBe Left(ErrorWrapper(correlationId, RuleTypeOfBusinessIncorrectError))
+          })
+      }
+
+      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
+        s"$downstreamErrorCode is returned from the service" in new Test {
+
+          MockRetrieveForeignPropertyBsasConnector
+            .retrieveForeignPropertyBsas(request)
+            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+
+          await(service.retrieveForeignPropertyBsas(request)) shouldBe Left(ErrorWrapper(correlationId, error))
+        }
+
+      val errors = Seq(
+        ("INVALID_TAXABLE_ENTITY_ID", NinoFormatError),
+        ("INVALID_CALCULATION_ID", CalculationIdFormatError),
+        ("INVALID_RETURN", InternalError),
+        ("INVALID_CORRELATIONID", InternalError),
+        ("NO_DATA_FOUND", NotFoundError),
+        ("UNPROCESSABLE_ENTITY", InternalError),
+        ("SERVER_ERROR", InternalError),
+        ("SERVICE_UNAVAILABLE", InternalError)
+      )
+
+      val extraTysErrors = Seq(
+        ("INVALID_TAX_YEAR", TaxYearFormatError),
+        ("NOT_FOUND", NotFoundError),
+        ("TAX_YEAR_NOT_SUPPORTED", RuleTaxYearNotSupportedError)
+      )
+
+      (errors ++ extraTysErrors).foreach(args => (serviceError _).tupled(args))
+    }
+  }
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/validators/MockRetrieveForeignPropertyBsasValidatorFactory.scala
+++ b/test/v5/retrieveForeignPropertyBsas/validators/MockRetrieveForeignPropertyBsasValidatorFactory.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.validators
+
+import org.scalamock.handlers.CallHandler
+import shared.controllers.validators.{MockValidatorFactory, Validator}
+import v5.retrieveForeignPropertyBsas.models.RetrieveForeignPropertyBsasRequestData
+import v5.retrieveForeignPropertyBsas.schema.RetrieveForeignPropertyBsasSchema
+
+trait MockRetrieveForeignPropertyBsasValidatorFactory extends MockValidatorFactory[RetrieveForeignPropertyBsasRequestData] {
+
+  val mockRetrieveForeignPropertyBsasValidatorFactory: RetrieveForeignPropertyBsasValidatorFactory = mock[RetrieveForeignPropertyBsasValidatorFactory]
+
+  def validator(): CallHandler[Validator[RetrieveForeignPropertyBsasRequestData]] =
+    (mockRetrieveForeignPropertyBsasValidatorFactory
+      .validator(_: String, _: String, _: Option[String], _: RetrieveForeignPropertyBsasSchema))
+      .expects(*, *, *, *)
+
+}

--- a/test/v5/retrieveForeignPropertyBsas/validators/def1/Def1_RetrieveForeignPropertyBsasValidatorSpec.scala
+++ b/test/v5/retrieveForeignPropertyBsas/validators/def1/Def1_RetrieveForeignPropertyBsasValidatorSpec.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveForeignPropertyBsas.validators.def1
+
+import shared.UnitSpec
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.errors._
+import v5.retrieveForeignPropertyBsas.models.def1.Def1_RetrieveForeignPropertyBsasRequestData
+
+class Def1_RetrieveForeignPropertyBsasValidatorSpec extends UnitSpec {
+
+  private implicit val correlationId: String = "1234"
+
+  val validNino          = "AA123456A"
+  val validCalculationId = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c"
+  val validTaxYear       = "2023-24"
+
+  private val parsedNino          = Nino(validNino)
+  private val parsedCalculationId = CalculationId(validCalculationId)
+  private val parsedTaxYear       = TaxYear.fromMtd(validTaxYear)
+
+  private def validator(nino: String, calculationId: String, taxYear: Option[String]) =
+    new Def1_RetrieveForeignPropertyBsasValidator(nino, calculationId, taxYear)
+
+  "validator" should {
+    "return the parsed domain object" when {
+      "passed a valid request" in {
+        val result = validator(validNino, validCalculationId, None).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_RetrieveForeignPropertyBsasRequestData(parsedNino, parsedCalculationId, None)
+        )
+      }
+
+      "passed a valid TYS request" in {
+        val result = validator(validNino, validCalculationId, Some(validTaxYear)).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_RetrieveForeignPropertyBsasRequestData(parsedNino, parsedCalculationId, Some(parsedTaxYear))
+        )
+      }
+    }
+
+    "return a single error" when {
+      "passed an invalid nino" in {
+        val result = validator("A12344A", validCalculationId, None).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, NinoFormatError)
+        )
+      }
+
+      "passed an invalid calculation id" in {
+        val result = validator(validNino, "not-a-calculation-id", None).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, CalculationIdFormatError)
+        )
+      }
+    }
+
+    "return TYS errors for an invalid TYS request" when {
+      "passed an invalid taxYear (i.e. earlier than 2023-24)" in {
+        val result = validator(validNino, validCalculationId, Some("2022-23")).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, InvalidTaxYearParameterError)
+        )
+      }
+
+      "passed an incorrectly formatted taxYear" in {
+        val result = validator(validNino, validCalculationId, Some("202324")).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, TaxYearFormatError)
+        )
+      }
+
+      "passed a tax year range of more than one year" in {
+        val result = validator(validNino, validCalculationId, Some("2022-24")).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleTaxYearRangeInvalidError)
+        )
+      }
+    }
+
+    "return multiple errors" when {
+      "passed multiple invalid fields" in {
+        val result = validator("not-a-nino", "not-a-calculation-id", None).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            BadRequestError,
+            Some(List(CalculationIdFormatError, NinoFormatError))
+          )
+        )
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/connectors/MockRetrieveSelfEmploymentBsasConnector.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/connectors/MockRetrieveSelfEmploymentBsasConnector.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.connectors
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.connectors.DownstreamOutcome
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.retrieveSelfEmploymentBsas.models.{RetrieveSelfEmploymentBsasRequestData, RetrieveSelfEmploymentBsasResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockRetrieveSelfEmploymentBsasConnector extends MockFactory {
+
+  val mockConnector: RetrieveSelfEmploymentBsasConnector = mock[RetrieveSelfEmploymentBsasConnector]
+
+  object MockRetrieveSelfEmploymentBsasConnector {
+
+    def retrieveSelfEmploymentBsas(
+        requestData: RetrieveSelfEmploymentBsasRequestData): CallHandler[Future[DownstreamOutcome[RetrieveSelfEmploymentBsasResponse]]] = {
+      (mockConnector
+        .retrieveSelfEmploymentBsas(_: RetrieveSelfEmploymentBsasRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(requestData, *, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/connectors/RetrieveSelfEmploymentBsasConnectorSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/connectors/RetrieveSelfEmploymentBsasConnectorSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.connectors
+
+import shared.connectors.{ConnectorSpec, DownstreamOutcome}
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.outcomes.ResponseWrapper
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+import v5.retrieveSelfEmploymentBsas.models.def1.Def1_RetrieveSelfEmploymentBsasRequestData
+import v5.retrieveSelfEmploymentBsas.models.{RetrieveSelfEmploymentBsasRequestData, RetrieveSelfEmploymentBsasResponse}
+
+import scala.concurrent.Future
+
+class RetrieveSelfEmploymentBsasConnectorSpec extends ConnectorSpec {
+
+  private val nino          = Nino("AA123456A")
+  private val calculationId = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+
+  trait Test {
+    _: ConnectorTest =>
+
+    val connector: RetrieveSelfEmploymentBsasConnector = new RetrieveSelfEmploymentBsasConnector(http = mockHttpClient, appConfig = mockAppConfig)
+
+    def requestWith(taxYear: Option[TaxYear]): RetrieveSelfEmploymentBsasRequestData =
+      Def1_RetrieveSelfEmploymentBsasRequestData(nino, calculationId, taxYear)
+
+  }
+
+  "RetrieveSelfEmploymentBsasConnectorSpec" when {
+    "retrieveSelfEmploymentBsas is called" must {
+      "a valid request is supplied" in {
+        new IfsTest with Test {
+          val outcome     = Right(ResponseWrapper(correlationId, mtdRetrieveBsasResponseJson))
+          val expectedUrl = s"$baseUrl/income-tax/adjustable-summary-calculation/$nino/$calculationId"
+          willGet(url = expectedUrl) returns Future.successful(outcome)
+
+          val result: DownstreamOutcome[RetrieveSelfEmploymentBsasResponse] = await(connector.retrieveSelfEmploymentBsas(requestWith(None)))
+          result shouldBe outcome
+        }
+      }
+    }
+
+    "retrieveSelfEmploymentBsas is called for a TaxYearSpecific tax year" must {
+      "a valid request is supplied" in {
+        new TysIfsTest with Test {
+          val taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+          val outcome          = Right(ResponseWrapper(correlationId, mtdRetrieveBsasResponseJson))
+          val expectedUrl      = s"$baseUrl/income-tax/adjustable-summary-calculation/${taxYear.asTysDownstream}/$nino/$calculationId"
+          willGet(url = expectedUrl) returns Future.successful(outcome)
+
+          val result: DownstreamOutcome[RetrieveSelfEmploymentBsasResponse] = await(connector.retrieveSelfEmploymentBsas(requestWith(Some(taxYear))))
+          result shouldBe outcome
+        }
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/controllers/RetrieveSelfEmploymentBsasControllerSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/controllers/RetrieveSelfEmploymentBsasControllerSpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.controllers
+
+import play.api.libs.json.{JsObject, Json}
+import play.api.mvc.Result
+import shared.config.MockAppConfig
+import shared.controllers.{ControllerBaseSpec, ControllerTestRunner}
+import shared.hateoas.Method.GET
+import shared.hateoas.{HateoasWrapper, Link, MockHateoasFactory}
+import shared.models.domain.CalculationId
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.{MockEnrolmentsAuthService, MockMtdIdLookupService}
+import shared.utils.MockIdGenerator
+import v5.models.errors._
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+import v5.retrieveSelfEmploymentBsas.models.RetrieveSelfEmploymentBsasHateoasData
+import v5.retrieveSelfEmploymentBsas.models.def1.Def1_RetrieveSelfEmploymentBsasRequestData
+import v5.retrieveSelfEmploymentBsas.services.MockRetrieveSelfEmploymentBsasService
+import v5.retrieveSelfEmploymentBsas.validators.MockRetrieveSelfEmploymentBsasValidatorFactory
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class RetrieveSelfEmploymentBsasControllerSpec
+    extends ControllerBaseSpec
+    with ControllerTestRunner
+    with MockEnrolmentsAuthService
+    with MockMtdIdLookupService
+    with MockRetrieveSelfEmploymentBsasValidatorFactory
+    with MockRetrieveSelfEmploymentBsasService
+    with MockHateoasFactory
+    with MockIdGenerator
+    with MockAppConfig {
+
+  private val calculationId    = CalculationId("03e3bc8b-910d-4f5b-88d7-b627c84f2ed7")
+  private val requestData      = Def1_RetrieveSelfEmploymentBsasRequestData(parsedNino, calculationId, None)
+  private val testHateoasLinks = List(Link(href = "/some/link", method = GET, rel = "someRel"))
+
+  private val hateoasResponse = mtdRetrieveBsasResponseJson
+    .as[JsObject] ++ Json
+    .parse("""{
+      |  "links": [ { "href":"/some/link", "method":"GET", "rel":"someRel" } ]
+      |}
+      |""".stripMargin)
+    .as[JsObject]
+
+  "retrieve" should {
+    "return OK" when {
+      "the request is valid" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockRetrieveSelfEmploymentBsasService
+          .retrieveBsas(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveBsasResponseModel))))
+
+        MockHateoasFactory
+          .wrap(retrieveBsasResponseModel, RetrieveSelfEmploymentBsasHateoasData(validNino, calculationId.calculationId, None))
+          .returns(HateoasWrapper(retrieveBsasResponseModel, testHateoasLinks))
+
+        runOkTest(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(hateoasResponse)
+        )
+      }
+    }
+
+    "return the error as per spec" when {
+      "the parser validation fails" in new Test {
+        willUseValidator(returning(NinoFormatError))
+        runErrorTest(expectedError = NinoFormatError)
+      }
+
+      "the service returns an error" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockRetrieveSelfEmploymentBsasService
+          .retrieveBsas(requestData)
+          .returns(Future.successful(Left(ErrorWrapper(correlationId, RuleTypeOfBusinessIncorrectError))))
+
+        runErrorTest(expectedError = RuleTypeOfBusinessIncorrectError)
+      }
+    }
+  }
+
+  private trait Test extends ControllerTest {
+
+    val controller = new RetrieveSelfEmploymentBsasController(
+      authService = mockEnrolmentsAuthService,
+      lookupService = mockMtdIdLookupService,
+      validatorFactory = mockRetrieveSelfEmploymentBsasValidatorFactory,
+      service = mockService,
+      hateoasFactory = mockHateoasFactory,
+      cc = cc,
+      idGenerator = mockIdGenerator
+    )
+
+    protected def callController(): Future[Result] = controller.handleRequest(validNino, calculationId.calculationId)(fakeGetRequest)
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/fixtures/def1/RetrieveSelfEmploymentBsasFixtures.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/fixtures/def1/RetrieveSelfEmploymentBsasFixtures.scala
@@ -1,0 +1,764 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.fixtures.def1
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import shared.models.domain.{Source, Status}
+import v5.models.domain.{IncomeSourceType, TypeOfBusiness}
+import v5.retrieveSelfEmploymentBsas.models.RetrieveSelfEmploymentBsasResponse
+import v5.retrieveSelfEmploymentBsas.models.def1._
+
+object RetrieveSelfEmploymentBsasFixtures {
+
+  private val now          = "2019-04-06"
+  private val aYearFromNow = "2020-04-05"
+
+  val downstreamMetadataJson: JsValue = Json.parse(
+    """
+      |{
+      |  "calculationId": "03e3bc8b-910d-4f5b-88d7-b627c84f2ed7",
+      |  "requestedDateTime": "2000-01-01T10:12:10Z",
+      |  "adjustedDateTime": "2000-01-01T10:12:10Z",
+      |  "taxableEntityId": "AA999999A",
+      |  "taxYear": 2021,
+      |  "status": "valid"
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSubmissionPeriodWithPeriodIdRegexJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "periodId": "1234567890123456",
+      |  "startDate": "$now",
+      |  "endDate": "$aYearFromNow",
+      |  "receivedDateTime": "2000-01-01T10:12:10Z"
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSubmissionPeriodWithInvalidPeriodIdRegexJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "periodId": "7038926d-d7a1-4399-8641-f278b438259c",
+       |  "startDate": "$now",
+       |  "endDate": "$aYearFromNow",
+       |  "receivedDateTime": "2000-01-01T10:12:10Z"
+       |}
+       |""".stripMargin
+  )
+
+  val downstreamInputsJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "incomeSourceType": "01",
+      |  "incomeSourceId": "XAIS12345678910",
+      |  "incomeSourceName": "Business Name",
+      |  "accountingPeriodStartDate": "$now",
+      |  "accountingPeriodEndDate": "$aYearFromNow",
+      |  "source": "MTD-SA",
+      |  "submissionPeriods": [$downstreamSubmissionPeriodWithPeriodIdRegexJson, $downstreamSubmissionPeriodWithInvalidPeriodIdRegexJson]
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamInputsInvalidSourceJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "incomeSourceType": "01",
+      |  "incomeSourceId": "XAIS12345678910",
+      |  "incomeSourceName": "Business Name",
+      |  "accountingPeriodStartDate": "$now",
+      |  "accountingPeriodEndDate": "$aYearFromNow",
+      |  "source": "MTD-VAT",
+      |  "submissionPeriods": [$downstreamSubmissionPeriodWithPeriodIdRegexJson]
+      |}
+      |""".stripMargin
+  )
+
+  def downstreamInputsInvalidIncomeSourceTypeJson(incomeSourceType: IncomeSourceType): JsValue = Json.parse(
+    s"""
+      |{
+      |  "incomeSourceType": "$incomeSourceType",
+      |  "incomeSourceId": "XAIS12345678910",
+      |  "incomeSourceName": "Business Name",
+      |  "accountingPeriodStartDate": "$now",
+      |  "accountingPeriodEndDate": "$aYearFromNow",
+      |  "source": "MTD-SA",
+      |  "submissionPeriods": [$downstreamSubmissionPeriodWithPeriodIdRegexJson]
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSummaryCalculationIncomeJson: JsValue = Json.parse(
+    """
+      |{
+      |  "turnover": 1.01,
+      |  "other": 1.02
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSummaryCalculationExpensesJson: JsValue = Json.parse(
+    """
+       |{
+       |  "consolidatedExpenses": 2.01,
+       |  "costOfGoodsAllowable": 2.02,
+       |  "paymentsToSubcontractorsAllowable": 2.03,
+       |  "wagesAndStaffCostsAllowable": 2.04,
+       |  "carVanTravelExpensesAllowable": 2.05,
+       |  "premisesRunningCostsAllowable": 2.06,
+       |  "maintenanceCostsAllowable": 2.07,
+       |  "adminCostsAllowable": 2.08,
+       |  "interestOnBankOtherLoansAllowable": 2.09,
+       |  "financeChargesAllowable": 2.10,
+       |  "irrecoverableDebtsAllowable": 2.11,
+       |  "professionalFeesAllowable": 2.12,
+       |  "depreciationAllowable": 2.13,
+       |  "otherExpensesAllowable": 2.14,
+       |  "advertisingCostsAllowable": 2.15,
+       |  "businessEntertainmentCostsAllowable": 2.16
+       |}
+       |""".stripMargin
+  )
+
+  val downstreamSummaryCalculationAdditionsJson: JsValue = Json.parse(
+    """
+      |{
+      |  "costOfGoodsDisallowable": 5.01,
+      |  "paymentsToSubcontractorsDisallowable": 5.02,
+      |  "wagesAndStaffCostsDisallowable": 5.03,
+      |  "carVanTravelExpensesDisallowable": 5.04,
+      |  "premisesRunningCostsDisallowable": 5.05,
+      |  "maintenanceCostsDisallowable": 5.06,
+      |  "adminCostsDisallowable": 5.07,
+      |  "interestOnBankOtherLoansDisallowable": 5.08,
+      |  "financeChargesDisallowable": 5.09,
+      |  "irrecoverableDebtsDisallowable": 5.10,
+      |  "professionalFeesDisallowable": 5.11,
+      |  "depreciationDisallowable": 5.12,
+      |  "otherExpensesDisallowable": 5.13,
+      |  "advertisingCostsDisallowable": 5.14,
+      |  "businessEntertainmentCostsDisallowable": 5.15,
+      |  "outstandingBusinessIncome": 5.16,
+      |  "balancingChargeOther": 5.17,
+      |  "balancingChargeBpra": 5.18,
+      |  "goodAndServicesOwnUse": 5.19
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSummaryCalculationDeductionsJson: JsValue = Json.parse(
+    """
+      |{
+      |  "tradingAllowance": 6.01,
+      |  "annualInvestmentAllowance": 6.02,
+      |  "capitalAllowanceMainPool": 6.03,
+      |  "capitalAllowanceSpecialRatePool": 6.04,
+      |  "zeroEmissionGoods": 6.05,
+      |  "businessPremisesRenovationAllowance": 6.06,
+      |  "enhancedCapitalAllowance": 6.07,
+      |  "allowanceOnSales": 6.08,
+      |  "capitalAllowanceSingleAssetPool": 6.09,
+      |  "includedNonTaxableProfits": 6.10,
+      |  "electricChargePointAllowance": 6.11,
+      |  "structuredBuildingAllowance": 6.12,
+      |  "enhancedStructuredBuildingAllowance": 6.13,
+      |  "zeroEmissionsCarAllowance": 6.14
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSummaryCalculationAccountingAdjustmentsJson: JsValue = Json.parse(
+    """
+      |{
+      |  "basisAdjustment": 7.01,
+      |  "overlapReliefUsed": 7.02,
+      |  "accountingAdjustment": 7.03,
+      |  "averagingAdjustment": 7.04
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSummaryCalculationJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "totalIncome": 1.00,
+      |  "income": $downstreamSummaryCalculationIncomeJson,
+      |  "totalExpenses": 2.00,
+      |  "expenses": $downstreamSummaryCalculationExpensesJson,
+      |  "netProfit": 3.00,
+      |  "netLoss": 4.00,
+      |  "totalAdditions": 5.00,
+      |  "additions": $downstreamSummaryCalculationAdditionsJson,
+      |  "totalDeductions": 6.00,
+      |  "deductions": $downstreamSummaryCalculationDeductionsJson,
+      |  "accountingAdjustments": 7.00,
+      |  "selfEmploymentAccountingAdjustments": $downstreamSummaryCalculationAccountingAdjustmentsJson,
+      |  "taxableProfit": 8.00,
+      |  "adjustedIncomeTaxLoss": 9.00
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamAdjustmentsIncomeJson: JsValue = Json.parse(
+    """
+      |{
+      |  "turnover": 1.01,
+      |  "other": 1.02
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamAdjustmentsExpensesJson: JsValue = Json.parse(
+    """
+      |{
+      |    "consolidatedExpenses": 2.01,
+      |    "costOfGoodsAllowable": 2.02,
+      |    "paymentsToSubcontractorsAllowable": 2.03,
+      |    "wagesAndStaffCostsAllowable": 2.04,
+      |    "carVanTravelExpensesAllowable": 2.05,
+      |    "premisesRunningCostsAllowable": 2.06,
+      |    "maintenanceCostsAllowable": 2.07,
+      |    "adminCostsAllowable": 2.08,
+      |    "interestOnBankOtherLoansAllowable": 2.09,
+      |    "financeChargesAllowable": 2.10,
+      |    "irrecoverableDebtsAllowable": 2.11,
+      |    "professionalFeesAllowable": 2.12,
+      |    "depreciationAllowable": 2.13,
+      |    "otherExpensesAllowable": 2.14,
+      |    "advertisingCostsAllowable": 2.15,
+      |    "businessEntertainmentCostsAllowable": 2.16
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamAdjustmentsAdditionsJson: JsValue = Json.parse(
+    """
+      |{
+      |  "costOfGoodsDisallowable": 3.01,
+      |  "paymentsToSubcontractorsDisallowable": 3.02,
+      |  "wagesAndStaffCostsDisallowable": 3.03,
+      |  "carVanTravelExpensesDisallowable": 3.04,
+      |  "premisesRunningCostsDisallowable": 3.05,
+      |  "maintenanceCostsDisallowable": 3.06,
+      |  "adminCostsDisallowable": 3.07,
+      |  "interestOnBankOtherLoansDisallowable": 3.08,
+      |  "financeChargesDisallowable": 3.09,
+      |  "irrecoverableDebtsDisallowable": 3.10,
+      |  "professionalFeesDisallowable": 3.11,
+      |  "depreciationDisallowable": 3.12,
+      |  "otherExpensesDisallowable": 3.13,
+      |  "advertisingCostsDisallowable": 3.14,
+      |  "businessEntertainmentCostsDisallowable": 3.15
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamAdjustmentsJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "income": $downstreamAdjustmentsIncomeJson,
+      |  "expenses": $downstreamAdjustmentsExpensesJson,
+      |  "additions": $downstreamAdjustmentsAdditionsJson
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamRetrieveBsasResponseJson: JsValue = Json.parse(s"""
+       |{
+       |  "metadata": $downstreamMetadataJson,
+       |  "inputs": $downstreamInputsJson,
+       |  "adjustableSummaryCalculation": $downstreamSummaryCalculationJson,
+       |  "adjustments": $downstreamAdjustmentsJson,
+       |  "adjustedSummaryCalculation": $downstreamSummaryCalculationJson
+       |}
+       |""".stripMargin)
+
+  def downstreamRetrieveBsasResponseJsonInvalidIncomeSourceType(incomeSourceType: IncomeSourceType): JsValue = Json.parse(s"""
+       |{
+       |  "metadata": $downstreamMetadataJson,
+       |  "inputs": ${downstreamInputsInvalidIncomeSourceTypeJson(incomeSourceType)},
+       |  "adjustableSummaryCalculation": $downstreamSummaryCalculationJson,
+       |  "adjustments": $downstreamAdjustmentsJson,
+       |  "adjustedSummaryCalculation": $downstreamSummaryCalculationJson
+       |}
+       |""".stripMargin)
+
+  val mtdMetadataJson: JsValue = Json.parse(
+    """
+      |{
+      |  "calculationId": "03e3bc8b-910d-4f5b-88d7-b627c84f2ed7",
+      |  "requestedDateTime": "2000-01-01T10:12:10Z",
+      |  "adjustedDateTime": "2000-01-01T10:12:10Z",
+      |  "nino": "AA999999A",
+      |  "taxYear": "2020-21",
+      |  "summaryStatus": "valid"
+      |}
+      |""".stripMargin
+  )
+
+  val mtdSubmissionPeriodWithPeriodIdJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "periodId": "1234567890123456",
+       |  "startDate": "$now",
+       |  "endDate": "$aYearFromNow",
+       |  "receivedDateTime": "2000-01-01T10:12:10Z"
+       |}
+       |""".stripMargin
+  )
+
+  val mtdSubmissionPeriodWithSubmissionIdJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "submissionId": "${now}_$aYearFromNow",
+       |  "startDate": "$now",
+       |  "endDate": "$aYearFromNow",
+       |  "receivedDateTime": "2000-01-01T10:12:10Z"
+       |}
+       |""".stripMargin
+  )
+
+  val mtdInputsJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "typeOfBusiness": "self-employment",
+       |  "businessId": "XAIS12345678910",
+       |  "businessName": "Business Name",
+       |  "accountingPeriodStartDate": "$now",
+       |  "accountingPeriodEndDate": "$aYearFromNow",
+       |  "source": "MTD-SA",
+       |  "submissionPeriods": [$mtdSubmissionPeriodWithPeriodIdJson, $mtdSubmissionPeriodWithSubmissionIdJson]
+       |}
+       |""".stripMargin
+  )
+
+  val mtdSummaryCalculationIncomeJson: JsValue = Json.parse(
+    """
+      |{
+      |  "turnover": 1.01,
+      |  "other": 1.02
+      |}
+      |""".stripMargin
+  )
+
+  val mtdSummaryCalculationExpensesJson: JsValue = Json.parse(
+    """
+       |{
+       |  "consolidatedExpenses": 2.01,
+       |  "costOfGoodsAllowable": 2.02,
+       |  "paymentsToSubcontractorsAllowable": 2.03,
+       |  "wagesAndStaffCostsAllowable": 2.04,
+       |  "carVanTravelExpensesAllowable": 2.05,
+       |  "premisesRunningCostsAllowable": 2.06,
+       |  "maintenanceCostsAllowable": 2.07,
+       |  "adminCostsAllowable": 2.08,
+       |  "interestOnBankOtherLoansAllowable": 2.09,
+       |  "financeChargesAllowable": 2.10,
+       |  "irrecoverableDebtsAllowable": 2.11,
+       |  "professionalFeesAllowable": 2.12,
+       |  "depreciationAllowable": 2.13,
+       |  "otherExpensesAllowable": 2.14,
+       |  "advertisingCostsAllowable": 2.15,
+       |  "businessEntertainmentCostsAllowable": 2.16
+       |}
+       |""".stripMargin
+  )
+
+  val mtdSummaryCalculationAdditionsJson: JsValue = Json.parse(
+    """
+      |{
+      |  "costOfGoodsDisallowable": 5.01,
+      |  "paymentsToSubcontractorsDisallowable": 5.02,
+      |  "wagesAndStaffCostsDisallowable": 5.03,
+      |  "carVanTravelExpensesDisallowable": 5.04,
+      |  "premisesRunningCostsDisallowable": 5.05,
+      |  "maintenanceCostsDisallowable": 5.06,
+      |  "adminCostsDisallowable": 5.07,
+      |  "interestOnBankOtherLoansDisallowable": 5.08,
+      |  "financeChargesDisallowable": 5.09,
+      |  "irrecoverableDebtsDisallowable": 5.10,
+      |  "professionalFeesDisallowable": 5.11,
+      |  "depreciationDisallowable": 5.12,
+      |  "otherExpensesDisallowable": 5.13,
+      |  "advertisingCostsDisallowable": 5.14,
+      |  "businessEntertainmentCostsDisallowable": 5.15,
+      |  "outstandingBusinessIncome": 5.16,
+      |  "balancingChargeOther": 5.17,
+      |  "balancingChargeBpra": 5.18,
+      |  "goodsAndServicesOwnUse": 5.19
+      |}
+      |""".stripMargin
+  )
+
+  val mtdSummaryCalculationDeductionsJson: JsValue = Json.parse(
+    """
+      |{
+      |  "tradingAllowance": 6.01,
+      |  "annualInvestmentAllowance": 6.02,
+      |  "capitalAllowanceMainPool": 6.03,
+      |  "capitalAllowanceSpecialRatePool": 6.04,
+      |  "zeroEmissionGoods": 6.05,
+      |  "businessPremisesRenovationAllowance": 6.06,
+      |  "enhancedCapitalAllowance": 6.07,
+      |  "allowanceOnSales": 6.08,
+      |  "capitalAllowanceSingleAssetPool": 6.09,
+      |  "includedNonTaxableProfits": 6.10,
+      |  "electricChargePointAllowance": 6.11,
+      |  "structuredBuildingAllowance": 6.12,
+      |  "enhancedStructuredBuildingAllowance": 6.13,
+      |  "zeroEmissionsCarAllowance": 6.14
+      |}
+      |""".stripMargin
+  )
+
+  val mtdSummaryCalculationAccountingAdjustmentsJson: JsValue = Json.parse(
+    """
+      |{
+      |  "basisAdjustment": 7.01,
+      |  "overlapReliefUsed": 7.02,
+      |  "accountingAdjustment": 7.03,
+      |  "averagingAdjustment": 7.04
+      |}
+      |""".stripMargin
+  )
+
+  val mtdSummaryCalculationJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "totalIncome": 1,
+       |  "income": $mtdSummaryCalculationIncomeJson,
+       |  "totalExpenses": 2,
+       |  "expenses": $mtdSummaryCalculationExpensesJson,
+       |  "netProfit": 3,
+       |  "netLoss": 4,
+       |  "totalAdditions": 5,
+       |  "additions": $mtdSummaryCalculationAdditionsJson,
+       |  "totalDeductions": 6,
+       |  "deductions": $mtdSummaryCalculationDeductionsJson,
+       |  "totalAccountingAdjustments": 7,
+       |  "accountingAdjustments": $mtdSummaryCalculationAccountingAdjustmentsJson,
+       |  "taxableProfit": 8,
+       |  "adjustedIncomeTaxLoss": 9
+       |}
+       |""".stripMargin
+  )
+
+  val mtdAdjustmentsIncomeJson: JsValue = Json.parse(
+    """
+      |{
+      |  "turnover": 1.01,
+      |  "other": 1.02
+      |}
+      |""".stripMargin
+  )
+
+  val mtdAdjustmentsExpensesJson: JsValue = Json.parse(
+    """
+      |{
+      |    "consolidatedExpenses": 2.01,
+      |    "costOfGoodsAllowable": 2.02,
+      |    "paymentsToSubcontractorsAllowable": 2.03,
+      |    "wagesAndStaffCostsAllowable": 2.04,
+      |    "carVanTravelExpensesAllowable": 2.05,
+      |    "premisesRunningCostsAllowable": 2.06,
+      |    "maintenanceCostsAllowable": 2.07,
+      |    "adminCostsAllowable": 2.08,
+      |    "interestOnBankOtherLoansAllowable": 2.09,
+      |    "financeChargesAllowable": 2.10,
+      |    "irrecoverableDebtsAllowable": 2.11,
+      |    "professionalFeesAllowable": 2.12,
+      |    "depreciationAllowable": 2.13,
+      |    "otherExpensesAllowable": 2.14,
+      |    "advertisingCostsAllowable": 2.15,
+      |    "businessEntertainmentCostsAllowable": 2.16
+      |}
+      |""".stripMargin
+  )
+
+  val mtdAdjustmentsAdditionsJson: JsValue = Json.parse(
+    """
+      |{
+      |  "costOfGoodsDisallowable": 3.01,
+      |  "paymentsToSubcontractorsDisallowable": 3.02,
+      |  "wagesAndStaffCostsDisallowable": 3.03,
+      |  "carVanTravelExpensesDisallowable": 3.04,
+      |  "premisesRunningCostsDisallowable": 3.05,
+      |  "maintenanceCostsDisallowable": 3.06,
+      |  "adminCostsDisallowable": 3.07,
+      |  "interestOnBankOtherLoansDisallowable": 3.08,
+      |  "financeChargesDisallowable": 3.09,
+      |  "irrecoverableDebtsDisallowable": 3.10,
+      |  "professionalFeesDisallowable": 3.11,
+      |  "depreciationDisallowable": 3.12,
+      |  "otherExpensesDisallowable": 3.13,
+      |  "advertisingCostsDisallowable": 3.14,
+      |  "businessEntertainmentCostsDisallowable": 3.15
+      |}
+      |""".stripMargin
+  )
+
+  val mtdAdjustmentsJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "income": $mtdAdjustmentsIncomeJson,
+       |  "expenses": $mtdAdjustmentsExpensesJson,
+       |  "additions": $mtdAdjustmentsAdditionsJson
+       |}
+       |""".stripMargin
+  )
+
+  val mtdRetrieveBsasResponseJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "metadata": $mtdMetadataJson,
+       |  "inputs": $mtdInputsJson,
+       |  "adjustableSummaryCalculation": $mtdSummaryCalculationJson,
+       |  "adjustments": $mtdAdjustmentsJson,
+       |  "adjustedSummaryCalculation": $mtdSummaryCalculationJson
+       |}
+       |""".stripMargin
+  )
+
+  def mtdRetrieveBsasReponseJsonWithHateoas(nino: String, calculationId: String, taxYear: Option[String] = None): JsValue = {
+    val taxYearParam = taxYear.fold("")("?taxYear=" + _)
+
+    mtdRetrieveBsasResponseJson.as[JsObject] ++ Json
+      .parse(s"""
+      |{
+      |  "links": [
+      |    {
+      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/self-employment/$calculationId$taxYearParam",
+      |      "method": "GET",
+      |      "rel": "self"
+      |    }, {
+      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/self-employment/$calculationId/adjust$taxYearParam",
+      |      "method": "POST",
+      |      "rel": "submit-self-employment-accounting-adjustments"
+      |    }
+      |  ]
+      |}
+      |""".stripMargin)
+      .as[JsObject]
+  }
+
+  val metadataModel: Metadata = Metadata(
+    calculationId = "03e3bc8b-910d-4f5b-88d7-b627c84f2ed7",
+    requestedDateTime = "2000-01-01T10:12:10Z",
+    adjustedDateTime = Some("2000-01-01T10:12:10Z"),
+    nino = "AA999999A",
+    taxYear = "2020-21",
+    summaryStatus = Status.`valid`
+  )
+
+  val submissionPeriodWithPeriodIdModel: SubmissionPeriod = SubmissionPeriod(
+    periodId = Some("1234567890123456"),
+    submissionId = None,
+    startDate = now,
+    endDate = aYearFromNow,
+    receivedDateTime = "2000-01-01T10:12:10Z"
+  )
+
+  val submissionPeriodWithSubmissionIdModel: SubmissionPeriod = SubmissionPeriod(
+    periodId = None,
+    submissionId = Some(s"${now}_$aYearFromNow"),
+    startDate = now,
+    endDate = aYearFromNow,
+    receivedDateTime = "2000-01-01T10:12:10Z"
+  )
+
+  val inputsModel: Inputs = Inputs(
+    typeOfBusiness = TypeOfBusiness.`self-employment`,
+    businessId = "XAIS12345678910",
+    businessName = Some("Business Name"),
+    accountingPeriodStartDate = now,
+    accountingPeriodEndDate = aYearFromNow,
+    source = Source.`MTD-SA`,
+    submissionPeriods = Seq(submissionPeriodWithPeriodIdModel, submissionPeriodWithSubmissionIdModel)
+  )
+
+  val summaryCalculationIncomeModel: SummaryCalculationIncome = SummaryCalculationIncome(
+    turnover = Some(1.01),
+    other = Some(1.02)
+  )
+
+  val summaryCalculationExpensesModel: SummaryCalculationExpenses = SummaryCalculationExpenses(
+    consolidatedExpenses = Some(2.01),
+    costOfGoodsAllowable = Some(2.02),
+    paymentsToSubcontractorsAllowable = Some(2.03),
+    wagesAndStaffCostsAllowable = Some(2.04),
+    carVanTravelExpensesAllowable = Some(2.05),
+    premisesRunningCostsAllowable = Some(2.06),
+    maintenanceCostsAllowable = Some(2.07),
+    adminCostsAllowable = Some(2.08),
+    interestOnBankOtherLoansAllowable = Some(2.09),
+    financeChargesAllowable = Some(2.10),
+    irrecoverableDebtsAllowable = Some(2.11),
+    professionalFeesAllowable = Some(2.12),
+    depreciationAllowable = Some(2.13),
+    otherExpensesAllowable = Some(2.14),
+    advertisingCostsAllowable = Some(2.15),
+    businessEntertainmentCostsAllowable = Some(2.16)
+  )
+
+  val summaryCalculationAdditionsModel: SummaryCalculationAdditions = SummaryCalculationAdditions(
+    costOfGoodsDisallowable = Some(5.01),
+    paymentsToSubcontractorsDisallowable = Some(5.02),
+    wagesAndStaffCostsDisallowable = Some(5.03),
+    carVanTravelExpensesDisallowable = Some(5.04),
+    premisesRunningCostsDisallowable = Some(5.05),
+    maintenanceCostsDisallowable = Some(5.06),
+    adminCostsDisallowable = Some(5.07),
+    interestOnBankOtherLoansDisallowable = Some(5.08),
+    financeChargesDisallowable = Some(5.09),
+    irrecoverableDebtsDisallowable = Some(5.10),
+    professionalFeesDisallowable = Some(5.11),
+    depreciationDisallowable = Some(5.12),
+    otherExpensesDisallowable = Some(5.13),
+    advertisingCostsDisallowable = Some(5.14),
+    businessEntertainmentCostsDisallowable = Some(5.15),
+    outstandingBusinessIncome = Some(5.16),
+    balancingChargeOther = Some(5.17),
+    balancingChargeBpra = Some(5.18),
+    goodsAndServicesOwnUse = Some(5.19)
+  )
+
+  val summaryCalculationDeductionsModel: SummaryCalculationDeductions = SummaryCalculationDeductions(
+    tradingAllowance = Some(6.01),
+    annualInvestmentAllowance = Some(6.02),
+    capitalAllowanceMainPool = Some(6.03),
+    capitalAllowanceSpecialRatePool = Some(6.04),
+    zeroEmissionGoods = Some(6.05),
+    businessPremisesRenovationAllowance = Some(6.06),
+    enhancedCapitalAllowance = Some(6.07),
+    allowanceOnSales = Some(6.08),
+    capitalAllowanceSingleAssetPool = Some(6.09),
+    includedNonTaxableProfits = Some(6.10),
+    electricChargePointAllowance = Some(6.11),
+    structuredBuildingAllowance = Some(6.12),
+    enhancedStructuredBuildingAllowance = Some(6.13),
+    zeroEmissionsCarAllowance = Some(6.14)
+  )
+
+  val summaryCalculationAccountingAdjustmentsModel: SummaryCalculationAccountingAdjustments = SummaryCalculationAccountingAdjustments(
+    basisAdjustment = Some(7.01),
+    overlapReliefUsed = Some(7.02),
+    accountingAdjustment = Some(7.03),
+    averagingAdjustment = Some(7.04)
+  )
+
+  val adjustableSummaryCalculationModel: AdjustableSummaryCalculation = AdjustableSummaryCalculation(
+    totalIncome = Some(1),
+    income = Some(summaryCalculationIncomeModel),
+    totalExpenses = Some(2),
+    expenses = Some(summaryCalculationExpensesModel),
+    netProfit = Some(3),
+    netLoss = Some(4),
+    totalAdditions = Some(5),
+    additions = Some(summaryCalculationAdditionsModel),
+    totalDeductions = Some(6),
+    deductions = Some(summaryCalculationDeductionsModel),
+    totalAccountingAdjustments = Some(7),
+    accountingAdjustments = Some(summaryCalculationAccountingAdjustmentsModel),
+    taxableProfit = Some(8),
+    adjustedIncomeTaxLoss = Some(9)
+  )
+
+  val adjustmentsIncomeModel: AdjustmentsIncome = AdjustmentsIncome(
+    turnover = Some(1.01),
+    other = Some(1.02)
+  )
+
+  val adjustmentsExpensesModel: AdjustmentsExpenses = AdjustmentsExpenses(
+    consolidatedExpenses = Some(2.01),
+    costOfGoodsAllowable = Some(2.02),
+    paymentsToSubcontractorsAllowable = Some(2.03),
+    wagesAndStaffCostsAllowable = Some(2.04),
+    carVanTravelExpensesAllowable = Some(2.05),
+    premisesRunningCostsAllowable = Some(2.06),
+    maintenanceCostsAllowable = Some(2.07),
+    adminCostsAllowable = Some(2.08),
+    interestOnBankOtherLoansAllowable = Some(2.09),
+    financeChargesAllowable = Some(2.10),
+    irrecoverableDebtsAllowable = Some(2.11),
+    professionalFeesAllowable = Some(2.12),
+    depreciationAllowable = Some(2.13),
+    otherExpensesAllowable = Some(2.14),
+    advertisingCostsAllowable = Some(2.15),
+    businessEntertainmentCostsAllowable = Some(2.16)
+  )
+
+  val adjustmentsAdditionsModel: AdjustmentsAdditions = AdjustmentsAdditions(
+    costOfGoodsDisallowable = Some(3.01),
+    paymentsToSubcontractorsDisallowable = Some(3.02),
+    wagesAndStaffCostsDisallowable = Some(3.03),
+    carVanTravelExpensesDisallowable = Some(3.04),
+    premisesRunningCostsDisallowable = Some(3.05),
+    maintenanceCostsDisallowable = Some(3.06),
+    adminCostsDisallowable = Some(3.07),
+    interestOnBankOtherLoansDisallowable = Some(3.08),
+    financeChargesDisallowable = Some(3.09),
+    irrecoverableDebtsDisallowable = Some(3.10),
+    professionalFeesDisallowable = Some(3.11),
+    depreciationDisallowable = Some(3.12),
+    otherExpensesDisallowable = Some(3.13),
+    advertisingCostsDisallowable = Some(3.14),
+    businessEntertainmentCostsDisallowable = Some(3.15)
+  )
+
+  val adjustmentsModel: Adjustments = Adjustments(
+    income = Some(adjustmentsIncomeModel),
+    expenses = Some(adjustmentsExpensesModel),
+    additions = Some(adjustmentsAdditionsModel)
+  )
+
+  val adjustedSummaryCalculationModel: AdjustedSummaryCalculation = AdjustedSummaryCalculation(
+    totalIncome = Some(1),
+    income = Some(summaryCalculationIncomeModel),
+    totalExpenses = Some(2),
+    expenses = Some(summaryCalculationExpensesModel),
+    netProfit = Some(3),
+    netLoss = Some(4),
+    totalAdditions = Some(5),
+    additions = Some(summaryCalculationAdditionsModel),
+    totalDeductions = Some(6),
+    deductions = Some(summaryCalculationDeductionsModel),
+    totalAccountingAdjustments = Some(7),
+    accountingAdjustments = Some(summaryCalculationAccountingAdjustmentsModel),
+    taxableProfit = Some(8),
+    adjustedIncomeTaxLoss = Some(9)
+  )
+
+  val retrieveBsasResponseModel: RetrieveSelfEmploymentBsasResponse = Def1_RetrieveSelfEmploymentBsasResponse(
+    metadata = metadataModel,
+    inputs = inputsModel,
+    adjustableSummaryCalculation = adjustableSummaryCalculationModel,
+    adjustments = Some(adjustmentsModel),
+    adjustedSummaryCalculation = Some(adjustedSummaryCalculationModel)
+  )
+
+  def retrieveBsasResponseInvalidTypeOfBusinessModel(typeOfBusiness: TypeOfBusiness): RetrieveSelfEmploymentBsasResponse =
+    Def1_RetrieveSelfEmploymentBsasResponse(
+      metadata = metadataModel,
+      inputs = inputsModel.copy(typeOfBusiness = typeOfBusiness),
+      adjustableSummaryCalculation = adjustableSummaryCalculationModel,
+      adjustments = Some(adjustmentsModel),
+      adjustedSummaryCalculation = Some(adjustedSummaryCalculationModel)
+    )
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/RetrieveSelfEmploymentBsasResponseSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/RetrieveSelfEmploymentBsasResponseSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models
+
+import play.api.Configuration
+import shared.UnitSpec
+import shared.config.MockAppConfig
+import shared.hateoas.Method._
+import shared.hateoas.{HateoasFactory, HateoasWrapper, Link}
+import shared.models.domain.TaxYear
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+
+class RetrieveSelfEmploymentBsasResponseSpec extends UnitSpec  {
+
+
+  "HateoasFactory" should {
+    class Test extends MockAppConfig {
+      val hateoasFactory = new HateoasFactory(mockAppConfig)
+      val nino = "someNino"
+      val calculationId = "anId"
+      val context = "individuals/self-assessment/adjustable-summary"
+      val taxYear = Some(TaxYear.fromMtd("2023-24"))
+
+      MockAppConfig.apiGatewayContext.returns(context).anyNumberOfTimes()
+    }
+
+    class TysDisabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> false)).anyNumberOfTimes()
+    }
+
+    class TysEnabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> true)).anyNumberOfTimes()
+    }
+
+    "return the correct links without tax year" in new TysDisabledTest {
+      private val result = hateoasFactory.wrap(retrieveBsasResponseModel, RetrieveSelfEmploymentBsasHateoasData(nino, calculationId, None))
+      private val expectedLinks = Seq(
+        Link(s"/$context/$nino/self-employment/$calculationId", GET, "self"),
+        Link(s"/$context/$nino/self-employment/$calculationId/adjust", POST, "submit-self-employment-accounting-adjustments")
+      )
+
+      result shouldBe HateoasWrapper(retrieveBsasResponseModel, expectedLinks)
+    }
+
+    "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+      private val result = hateoasFactory.wrap(retrieveBsasResponseModel, RetrieveSelfEmploymentBsasHateoasData(nino, calculationId, taxYear))
+      private val expectedLinks = Seq(
+        Link(s"/$context/$nino/self-employment/$calculationId?taxYear=2023-24", GET, "self"),
+        Link(s"/$context/$nino/self-employment/$calculationId/adjust?taxYear=2023-24", POST, "submit-self-employment-accounting-adjustments")
+      )
+
+      result shouldBe HateoasWrapper(retrieveBsasResponseModel, expectedLinks)
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsAdditionsSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsAdditionsSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures.{adjustmentsAdditionsModel, downstreamAdjustmentsAdditionsJson, mtdAdjustmentsAdditionsJson}
+
+class AdjustmentsAdditionsSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON" in {
+        downstreamAdjustmentsAdditionsJson.as[AdjustmentsAdditions] shouldBe adjustmentsAdditionsModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model" in {
+        Json.toJson(adjustmentsAdditionsModel) shouldBe mtdAdjustmentsAdditionsJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsExpensesSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsExpensesSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures.{adjustmentsExpensesModel, downstreamAdjustmentsExpensesJson, mtdAdjustmentsExpensesJson}
+
+class AdjustmentsExpensesSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON" in {
+        downstreamAdjustmentsExpensesJson.as[AdjustmentsExpenses] shouldBe adjustmentsExpensesModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model" in {
+        Json.toJson(adjustmentsExpensesModel) shouldBe mtdAdjustmentsExpensesJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsIncomeSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsIncomeSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures.{adjustmentsIncomeModel, downstreamAdjustmentsIncomeJson, mtdAdjustmentsIncomeJson}
+
+class AdjustmentsIncomeSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON" in {
+        downstreamAdjustmentsIncomeJson.as[AdjustmentsIncome] shouldBe adjustmentsIncomeModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model" in {
+        Json.toJson(adjustmentsIncomeModel) shouldBe mtdAdjustmentsIncomeJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/AdjustmentsSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures.{adjustmentsModel, downstreamAdjustmentsJson, mtdAdjustmentsJson}
+
+class AdjustmentsSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON" in {
+        downstreamAdjustmentsJson.as[Adjustments] shouldBe adjustmentsModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model" in {
+        Json.toJson(adjustmentsModel) shouldBe mtdAdjustmentsJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/Def1_RetrieveSelfEmploymentBsasResponseSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/Def1_RetrieveSelfEmploymentBsasResponseSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures.{downstreamRetrieveBsasResponseJson, mtdRetrieveBsasResponseJson, retrieveBsasResponseModel}
+
+class Def1_RetrieveSelfEmploymentBsasResponseSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON" in {
+        downstreamRetrieveBsasResponseJson.as[Def1_RetrieveSelfEmploymentBsasResponse] shouldBe retrieveBsasResponseModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model" in {
+        Json.toJson(retrieveBsasResponseModel) shouldBe mtdRetrieveBsasResponseJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/InputsSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/InputsSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.{JsResultException, Json}
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+
+class InputsSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON" in {
+        downstreamInputsJson.as[Inputs] shouldBe inputsModel
+      }
+    }
+    "return an error" when {
+      "passed JSON with an invalid source" in {
+        a[JsResultException] should be thrownBy downstreamInputsInvalidSourceJson.as[Inputs]
+
+        val thrown: JsResultException = the[JsResultException] thrownBy downstreamInputsInvalidSourceJson.as[Inputs]
+        thrown.errors
+          .map { case (path, errors) =>
+            (path, errors.map(_.messages))
+          }
+          .map { case (path, errors) =>
+            path.toString() shouldBe "/source"
+            errors.flatten.contains("error.expected.Source") shouldBe true
+          }
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model" in {
+        Json.toJson(inputsModel) shouldBe mtdInputsJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/MetadataSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/MetadataSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures.{downstreamMetadataJson, metadataModel, mtdMetadataJson}
+
+class MetadataSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return the parsed Metadata" when {
+      "given valid JSON" in {
+        downstreamMetadataJson.as[Metadata] shouldBe metadataModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "given a Metadata instance" in {
+        Json.toJson(metadataModel) shouldBe mtdMetadataJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/SubmissionPeriodSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/SubmissionPeriodSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+
+class SubmissionPeriodSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON with periodId regex" in {
+        downstreamSubmissionPeriodWithPeriodIdRegexJson.as[SubmissionPeriod] shouldBe submissionPeriodWithPeriodIdModel
+      }
+      "passed valid JSON with invalid periodId regex" in {
+        downstreamSubmissionPeriodWithInvalidPeriodIdRegexJson.as[SubmissionPeriod] shouldBe submissionPeriodWithSubmissionIdModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model with periodId" in {
+        Json.toJson(submissionPeriodWithPeriodIdModel) shouldBe mtdSubmissionPeriodWithPeriodIdJson
+      }
+      "passed a valid model with submissionId" in {
+        Json.toJson(submissionPeriodWithSubmissionIdModel) shouldBe mtdSubmissionPeriodWithSubmissionIdJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationAccountingAdjustmentsSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationAccountingAdjustmentsSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+
+class SummaryCalculationAccountingAdjustmentsSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON with periodId regex" in {
+        downstreamSummaryCalculationAccountingAdjustmentsJson
+          .as[SummaryCalculationAccountingAdjustments] shouldBe summaryCalculationAccountingAdjustmentsModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model with periodId" in {
+        Json.toJson(summaryCalculationAccountingAdjustmentsModel) shouldBe mtdSummaryCalculationAccountingAdjustmentsJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationAdditionsSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationAdditionsSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+
+class SummaryCalculationAdditionsSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON with periodId regex" in {
+        downstreamSummaryCalculationAdditionsJson.as[SummaryCalculationAdditions] shouldBe summaryCalculationAdditionsModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model with periodId" in {
+        Json.toJson(summaryCalculationAdditionsModel) shouldBe mtdSummaryCalculationAdditionsJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationDeductionsSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationDeductionsSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+
+class SummaryCalculationDeductionsSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON with periodId regex" in {
+        downstreamSummaryCalculationDeductionsJson.as[SummaryCalculationDeductions] shouldBe summaryCalculationDeductionsModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model with periodId" in {
+        Json.toJson(summaryCalculationDeductionsModel) shouldBe mtdSummaryCalculationDeductionsJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationExpensesSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationExpensesSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+
+class SummaryCalculationExpensesSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON with periodId regex" in {
+        downstreamSummaryCalculationExpensesJson.as[SummaryCalculationExpenses] shouldBe summaryCalculationExpensesModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model with periodId" in {
+        Json.toJson(summaryCalculationExpensesModel) shouldBe mtdSummaryCalculationExpensesJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationIncomeSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationIncomeSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+
+class SummaryCalculationIncomeSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" should {
+    "return a valid model" when {
+      "passed valid JSON with periodId regex" in {
+        downstreamSummaryCalculationIncomeJson.as[SummaryCalculationIncome] shouldBe summaryCalculationIncomeModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid model with periodId" in {
+        Json.toJson(summaryCalculationIncomeModel) shouldBe mtdSummaryCalculationIncomeJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/models/def1/SummaryCalculationSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures.{adjustableSummaryCalculationModel, adjustedSummaryCalculationModel, downstreamSummaryCalculationJson, mtdSummaryCalculationJson}
+
+class SummaryCalculationSpec extends UnitSpec with JsonErrorValidators {
+
+  "reads" when {
+    "passed valid JSON" should {
+      "return a valid adjustableSummaryCalculationModel" in {
+        downstreamSummaryCalculationJson.as[AdjustableSummaryCalculation] shouldBe adjustableSummaryCalculationModel
+      }
+      "return a valid adjustedSummaryCalculationModel" in {
+        downstreamSummaryCalculationJson.as[AdjustedSummaryCalculation] shouldBe adjustedSummaryCalculationModel
+      }
+    }
+  }
+
+  "writes" should {
+    "return valid JSON" when {
+      "passed a valid adjustableSummaryCalculationModel" in {
+        Json.toJson(adjustableSummaryCalculationModel) shouldBe mtdSummaryCalculationJson
+      }
+      "passed a valid adjustedSummaryCalculationModel" in {
+        Json.toJson(adjustedSummaryCalculationModel) shouldBe mtdSummaryCalculationJson
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/schema/RetrieveSelfEmploymentBsasSchemaSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/schema/RetrieveSelfEmploymentBsasSchemaSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.schema
+
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import shared.UnitSpec
+import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+
+import scala.math.Ordered.orderingToOrdered
+
+class RetrieveSelfEmploymentBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
+
+  "schema lookup" when {
+    "a tax year is present" must {
+      "use Def1 for tax years from 2023-24" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
+            RetrieveSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveSelfEmploymentBsasSchema.Def1
+          }
+        }
+      }
+
+      "use Def1 for other tax years" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
+            RetrieveSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveSelfEmploymentBsasSchema.Def1
+          }
+        }
+      }
+    }
+
+    "the tax year is present but not valid" must {
+      "use a default of Def1" in {
+        RetrieveSelfEmploymentBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe RetrieveSelfEmploymentBsasSchema.Def1
+      }
+    }
+
+    "no tax year is present" must {
+      "use a default of Def1" in {
+        RetrieveSelfEmploymentBsasSchema.schemaFor(None) shouldBe RetrieveSelfEmploymentBsasSchema.Def1
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/schema/RetrieveSelfEmploymentBsasSchemaSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/schema/RetrieveSelfEmploymentBsasSchemaSpec.scala
@@ -20,25 +20,19 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import shared.UnitSpec
 import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
 
-import scala.math.Ordered.orderingToOrdered
-
 class RetrieveSelfEmploymentBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
 
   "schema lookup" when {
     "a tax year is present" must {
       "use Def1 for tax years from 2023-24" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
-            RetrieveSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveSelfEmploymentBsasSchema.Def1
-          }
+        forTaxYearsFrom(TaxYear.fromMtd("2023-24")) { taxYear =>
+          RetrieveSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveSelfEmploymentBsasSchema.Def1
         }
       }
 
-      "use Def1 for other tax years" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
-            RetrieveSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveSelfEmploymentBsasSchema.Def1
-          }
+      "use Def1 for pre-TYS tax years" in {
+        forPreTysTaxYears { taxYear =>
+          RetrieveSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveSelfEmploymentBsasSchema.Def1
         }
       }
     }

--- a/test/v5/retrieveSelfEmploymentBsas/services/MockRetrieveSelfEmploymentBsasService.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/services/MockRetrieveSelfEmploymentBsasService.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.services
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.controllers.RequestContext
+import shared.services.ServiceOutcome
+import v5.retrieveSelfEmploymentBsas.models.{RetrieveSelfEmploymentBsasRequestData, RetrieveSelfEmploymentBsasResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockRetrieveSelfEmploymentBsasService extends MockFactory {
+
+  val mockService: RetrieveSelfEmploymentBsasService = mock[RetrieveSelfEmploymentBsasService]
+
+  object MockRetrieveSelfEmploymentBsasService {
+
+    def retrieveBsas(requestData: RetrieveSelfEmploymentBsasRequestData): CallHandler[Future[ServiceOutcome[RetrieveSelfEmploymentBsasResponse]]] = {
+      (mockService
+        .retrieveSelfEmploymentBsas(_: RetrieveSelfEmploymentBsasRequestData)(_: RequestContext, _: ExecutionContext))
+        .expects(requestData, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/services/RetrieveSelfEmploymentBsasServiceSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/services/RetrieveSelfEmploymentBsasServiceSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.services
+
+import shared.controllers.EndpointLogContext
+import shared.models.domain.{CalculationId, Nino}
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.ServiceSpec
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.models.domain.TypeOfBusiness
+import v5.models.errors._
+import v5.retrieveSelfEmploymentBsas.connectors.MockRetrieveSelfEmploymentBsasConnector
+import v5.retrieveSelfEmploymentBsas.fixtures.def1.RetrieveSelfEmploymentBsasFixtures._
+import v5.retrieveSelfEmploymentBsas.models.def1.Def1_RetrieveSelfEmploymentBsasRequestData
+import v5.retrieveSelfEmploymentBsas.models.{RetrieveSelfEmploymentBsasRequestData, RetrieveSelfEmploymentBsasResponse}
+
+import scala.concurrent.Future
+
+class RetrieveSelfEmploymentBsasServiceSpec extends ServiceSpec {
+
+  private val nino = Nino("AA123456A")
+  private val id   = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+
+  val request: RetrieveSelfEmploymentBsasRequestData = Def1_RetrieveSelfEmploymentBsasRequestData(nino, id, None)
+
+  trait Test extends MockRetrieveSelfEmploymentBsasConnector {
+    implicit val hc: HeaderCarrier              = HeaderCarrier()
+    implicit val logContext: EndpointLogContext = EndpointLogContext("RetrieveSelfEmploymentBsasConnector", "retrieveSelfEmploymentBsas")
+
+    val service = new RetrieveSelfEmploymentBsasService(mockConnector)
+  }
+
+  "retrieveSelfEmploymentBsas" should {
+    "return a valid response" when {
+      "a valid request is supplied" in new Test {
+        MockRetrieveSelfEmploymentBsasConnector
+          .retrieveSelfEmploymentBsas(request)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveBsasResponseModel))))
+
+        await(service.retrieveSelfEmploymentBsas(request)) shouldBe Right(ResponseWrapper(correlationId, retrieveBsasResponseModel))
+      }
+    }
+
+    "return error response" when {
+      "downstream returns a success response with invalid type of business" should {
+        import TypeOfBusiness._
+        Seq(`uk-property-fhl`, `uk-property-non-fhl`, `foreign-property`, `foreign-property-fhl-eea`).foreach(typeOfBusiness =>
+          s"return an error for $typeOfBusiness" in new Test {
+            val response: RetrieveSelfEmploymentBsasResponse = retrieveBsasResponseInvalidTypeOfBusinessModel(typeOfBusiness = typeOfBusiness)
+
+            MockRetrieveSelfEmploymentBsasConnector
+              .retrieveSelfEmploymentBsas(request)
+              .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
+
+            await(service.retrieveSelfEmploymentBsas(request)) shouldBe Left(ErrorWrapper(correlationId, RuleTypeOfBusinessIncorrectError))
+          })
+      }
+
+      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
+        s"a $downstreamErrorCode error is returned from the service" in new Test {
+
+          MockRetrieveSelfEmploymentBsasConnector
+            .retrieveSelfEmploymentBsas(request)
+            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+
+          await(service.retrieveSelfEmploymentBsas(request)) shouldBe Left(ErrorWrapper(correlationId, error))
+        }
+
+      val errors = Seq(
+        ("INVALID_TAXABLE_ENTITY_ID", NinoFormatError),
+        ("INVALID_CALCULATION_ID", CalculationIdFormatError),
+        ("INVALID_CORRELATIONID", InternalError),
+        ("INVALID_RETURN", InternalError),
+        ("UNPROCESSABLE_ENTITY", InternalError),
+        ("NO_DATA_FOUND", NotFoundError),
+        ("SERVER_ERROR", InternalError),
+        ("SERVICE_UNAVAILABLE", InternalError)
+      )
+
+      val extraTysErrors = Seq(
+        ("INVALID_TAX_YEAR", TaxYearFormatError),
+        ("NOT_FOUND", NotFoundError),
+        ("TAX_YEAR_NOT_SUPPORTED", RuleTaxYearNotSupportedError)
+      )
+
+      (errors ++ extraTysErrors).foreach(args => (serviceError _).tupled(args))
+    }
+  }
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/validators/MockRetrieveSelfEmploymentBsasValidatorFactory.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/validators/MockRetrieveSelfEmploymentBsasValidatorFactory.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.validators
+
+import org.scalamock.handlers.CallHandler
+import shared.controllers.validators.{MockValidatorFactory, Validator}
+import v5.retrieveSelfEmploymentBsas.models.RetrieveSelfEmploymentBsasRequestData
+import v5.retrieveSelfEmploymentBsas.schema.RetrieveSelfEmploymentBsasSchema
+
+trait MockRetrieveSelfEmploymentBsasValidatorFactory extends MockValidatorFactory[RetrieveSelfEmploymentBsasRequestData] {
+
+  val mockRetrieveSelfEmploymentBsasValidatorFactory: RetrieveSelfEmploymentBsasValidatorFactory = mock[RetrieveSelfEmploymentBsasValidatorFactory]
+
+  def validator(): CallHandler[Validator[RetrieveSelfEmploymentBsasRequestData]] =
+    (mockRetrieveSelfEmploymentBsasValidatorFactory
+      .validator(_: String, _: String, _: Option[String], _: RetrieveSelfEmploymentBsasSchema))
+      .expects(*, *, *, *)
+
+}

--- a/test/v5/retrieveSelfEmploymentBsas/validators/def1/Def1_RetrieveSelfEmploymentBsasValidatorSpec.scala
+++ b/test/v5/retrieveSelfEmploymentBsas/validators/def1/Def1_RetrieveSelfEmploymentBsasValidatorSpec.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveSelfEmploymentBsas.validators.def1
+
+import shared.UnitSpec
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.errors._
+import v5.retrieveSelfEmploymentBsas.models.def1.Def1_RetrieveSelfEmploymentBsasRequestData
+
+class Def1_RetrieveSelfEmploymentBsasValidatorSpec extends UnitSpec {
+
+  private implicit val correlationId: String = "1234"
+
+  private val validNino          = "AA123456A"
+  private val validCalculationId = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c"
+  private val validTaxYear       = "2023-24"
+
+  private val parsedNino          = Nino(validNino)
+  private val parsedCalculationId = CalculationId(validCalculationId)
+  private val parsedTaxYear       = TaxYear.fromMtd(validTaxYear)
+
+  private def validator(nino: String, calculationId: String, taxYear: Option[String]) =
+    new Def1_RetrieveSelfEmploymentBsasValidator(nino, calculationId, taxYear)
+
+  "validator" should {
+    "return the parsed domain object" when {
+      "passed a valid non-TYS request" in {
+        val result = validator(validNino, validCalculationId, None).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_RetrieveSelfEmploymentBsasRequestData(parsedNino, parsedCalculationId, None)
+        )
+      }
+
+      "passed a valid TYS request" in {
+        val result = validator(validNino, validCalculationId, Some(validTaxYear)).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_RetrieveSelfEmploymentBsasRequestData(parsedNino, parsedCalculationId, Some(parsedTaxYear))
+        )
+      }
+    }
+
+    "return a single error" when {
+      "passed an invalid nino" in {
+        val result = validator("A12344A", validCalculationId, None).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, NinoFormatError)
+        )
+      }
+
+      "passed an invalid calculation id" in {
+        val result = validator(validNino, "12345", None).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, CalculationIdFormatError)
+        )
+      }
+    }
+
+    "return TYS errors for an invalid TYS request" when {
+      "passed an invalid taxYear (i.e. earlier than 2023-24)" in {
+        val result = validator(validNino, validCalculationId, Some("2022-23")).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, InvalidTaxYearParameterError)
+        )
+      }
+
+      "passed an incorrectly formatted taxYear" in {
+        val result = validator(validNino, validCalculationId, Some("202324")).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, TaxYearFormatError)
+        )
+      }
+
+      "passed a tax year range of more than one year" in {
+        val result = validator(validNino, validCalculationId, Some("2022-24")).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleTaxYearRangeInvalidError)
+        )
+      }
+    }
+
+    "return multiple errors" when {
+      "passed multiple invalid fields" in {
+        val result = validator("not-a-nino", "not-a-calculation-id", None).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            BadRequestError,
+            Some(List(CalculationIdFormatError, NinoFormatError))
+          )
+        )
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveUkPropertyBsas/connectors/MockRetrieveUkPropertyBsasConnector.scala
+++ b/test/v5/retrieveUkPropertyBsas/connectors/MockRetrieveUkPropertyBsasConnector.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.connectors
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.connectors.DownstreamOutcome
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.retrieveUkPropertyBsas.models.{RetrieveUkPropertyBsasRequestData, RetrieveUkPropertyBsasResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockRetrieveUkPropertyBsasConnector extends MockFactory {
+
+  val mockConnector: RetrieveUkPropertyBsasConnector = mock[RetrieveUkPropertyBsasConnector]
+
+  object MockRetrievePropertyBsasConnector {
+
+    def retrievePropertyBsas(
+        requestData: RetrieveUkPropertyBsasRequestData): CallHandler[Future[DownstreamOutcome[RetrieveUkPropertyBsasResponse]]] = {
+      (mockConnector
+        .retrieve(_: RetrieveUkPropertyBsasRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(requestData, *, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/retrieveUkPropertyBsas/connectors/RetrieveUkPropertyBsasConnectorSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/connectors/RetrieveUkPropertyBsasConnectorSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.connectors
+
+import shared.connectors.{ConnectorSpec, DownstreamOutcome}
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.outcomes.ResponseWrapper
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyBsasResponse
+import v5.retrieveUkPropertyBsas.models.def1.Def1_RetrieveUkPropertyBsasRequestData
+
+import scala.concurrent.Future
+
+class RetrieveUkPropertyBsasConnectorSpec extends ConnectorSpec {
+
+  private val nino          = Nino("AA123456A")
+  private val calculationId = CalculationId("717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4")
+
+  trait Test {
+    _: ConnectorTest =>
+    val connector: RetrieveUkPropertyBsasConnector = new RetrieveUkPropertyBsasConnector(http = mockHttpClient, appConfig = mockAppConfig)
+  }
+
+  "retrieve" should {
+    "return a valid response" when {
+      val outcome = Right(ResponseWrapper(correlationId, retrieveBsasResponseFhlModel))
+
+      "a valid request is supplied for a non-TYS year" in new IfsTest with Test {
+        private val request     = Def1_RetrieveUkPropertyBsasRequestData(nino, calculationId, taxYear = None)
+        private val expectedUrl = s"$baseUrl/income-tax/adjustable-summary-calculation/$nino/$calculationId"
+        willGet(expectedUrl) returns Future.successful(outcome)
+
+        val result: DownstreamOutcome[RetrieveUkPropertyBsasResponse] = await(connector.retrieve(request))
+        result shouldBe outcome
+      }
+
+      "a valid request with queryParams is supplied for a TYS year" in new TysIfsTest with Test {
+        private def taxYear: TaxYear = TaxYear.fromMtd("2023-24")
+        private val request          = Def1_RetrieveUkPropertyBsasRequestData(nino, calculationId, Some(taxYear))
+        willGet(s"$baseUrl/income-tax/adjustable-summary-calculation/${taxYear.asTysDownstream}/$nino/$calculationId") returns Future
+          .successful(outcome)
+
+        val result: DownstreamOutcome[RetrieveUkPropertyBsasResponse] = await(connector.retrieve(request))
+        result shouldBe outcome
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveUkPropertyBsas/controllers/RetrieveUkPropertyBsasControllerSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/controllers/RetrieveUkPropertyBsasControllerSpec.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.controllers
+
+import play.api.libs.json.{JsObject, Json}
+import play.api.mvc.Result
+import shared.config.MockAppConfig
+import shared.controllers.{ControllerBaseSpec, ControllerTestRunner}
+import shared.hateoas.Method.GET
+import shared.hateoas.{HateoasWrapper, Link, MockHateoasFactory}
+import shared.models.domain.CalculationId
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.{MockEnrolmentsAuthService, MockMtdIdLookupService}
+import shared.utils.MockIdGenerator
+import v5.models.errors._
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyHateoasData
+import v5.retrieveUkPropertyBsas.models.def1.Def1_RetrieveUkPropertyBsasRequestData
+import v5.retrieveUkPropertyBsas.services.MockRetrieveUkPropertyBsasService
+import v5.retrieveUkPropertyBsas.validators.MockRetrieveUkPropertyBsasValidatorFactory
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class RetrieveUkPropertyBsasControllerSpec
+    extends ControllerBaseSpec
+    with ControllerTestRunner
+    with MockEnrolmentsAuthService
+    with MockMtdIdLookupService
+    with MockRetrieveUkPropertyBsasValidatorFactory
+    with MockRetrieveUkPropertyBsasService
+    with MockHateoasFactory
+    with MockIdGenerator
+    with MockAppConfig {
+
+  private val calculationId    = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+  private val requestData      = Def1_RetrieveUkPropertyBsasRequestData(parsedNino, calculationId, taxYear = None)
+  private val testHateoasLinks = List(Link(href = "/some/link", method = GET, rel = "someRel"))
+
+  private val hateoasFhlResponse = mtdRetrieveBsasResponseFhlJson
+    .as[JsObject] ++ Json
+    .parse("""{
+      |  "links": [ { "href":"/some/link", "method":"GET", "rel":"someRel" } ]
+      |}
+      |""".stripMargin)
+    .as[JsObject]
+
+  private val hateoasNonFhlResponse = mtdRetrieveBsasResponseNonFhlJson
+    .as[JsObject] ++ Json
+    .parse("""{
+      |  "links": [ { "href":"/some/link", "method":"GET", "rel":"someRel" } ]
+      |}
+      |""".stripMargin)
+    .as[JsObject]
+
+  "retrieve" should {
+    "return successful hateoas response for fhl with status OK" when {
+      "the request is valid" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockRetrieveUkPropertyBsasService
+          .retrieveBsas(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveBsasResponseFhlModel))))
+
+        MockHateoasFactory
+          .wrap(retrieveBsasResponseFhlModel, RetrieveUkPropertyHateoasData(validNino, calculationId.calculationId, None))
+          .returns(HateoasWrapper(retrieveBsasResponseFhlModel, testHateoasLinks))
+
+        runOkTest(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(hateoasFhlResponse)
+        )
+      }
+    }
+    "return OK" when {
+      "the request is valid" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockRetrieveUkPropertyBsasService
+          .retrieveBsas(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveBsasResponseNonFhlModel))))
+
+        MockHateoasFactory
+          .wrap(retrieveBsasResponseNonFhlModel, RetrieveUkPropertyHateoasData(validNino, calculationId.calculationId, None))
+          .returns(HateoasWrapper(retrieveBsasResponseNonFhlModel, testHateoasLinks))
+
+        runOkTest(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(hateoasNonFhlResponse)
+        )
+      }
+    }
+
+    "return the error as per spec" when {
+      "the parser validation fails" in new Test {
+        willUseValidator(returning(NinoFormatError))
+        runErrorTest(expectedError = NinoFormatError)
+      }
+
+      "the service returns an error" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockRetrieveUkPropertyBsasService
+          .retrieveBsas(requestData)
+          .returns(Future.successful(Left(ErrorWrapper(correlationId, RuleTypeOfBusinessIncorrectError))))
+
+        runErrorTest(expectedError = RuleTypeOfBusinessIncorrectError)
+      }
+    }
+  }
+
+  private trait Test extends ControllerTest {
+
+    val controller = new RetrieveUkPropertyBsasController(
+      authService = mockEnrolmentsAuthService,
+      lookupService = mockMtdIdLookupService,
+      validatorFactory = mockRetrieveUkPropertyBsasValidatorFactory,
+      service = mockService,
+      hateoasFactory = mockHateoasFactory,
+      cc = cc,
+      idGenerator = mockIdGenerator
+    )
+
+    protected def callController(): Future[Result] = controller.retrieve(validNino, calculationId.calculationId, taxYear = None)(fakeGetRequest)
+  }
+
+}

--- a/test/v5/retrieveUkPropertyBsas/fixtures/def1/RetrieveUkPropertyBsasFixtures.scala
+++ b/test/v5/retrieveUkPropertyBsas/fixtures/def1/RetrieveUkPropertyBsasFixtures.scala
@@ -1,0 +1,849 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.fixtures.def1
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import shared.models.domain.{Source, Status}
+import v5.models.domain.{IncomeSourceType, TypeOfBusiness}
+import v5.retrieveUkPropertyBsas.models.def1._
+
+object RetrieveUkPropertyBsasFixtures {
+
+  private val now          = "2019-04-06"
+  private val aYearFromNow = "2020-04-05"
+
+  val downstreamMetadataJson: JsValue = Json.parse(
+    """
+      |{
+      |  "calculationId": "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
+      |  "requestedDateTime": "2000-01-01T10:12:10Z",
+      |  "adjustedDateTime": "2000-01-01T10:12:10Z",
+      |  "taxableEntityId": "AA999999A",
+      |  "taxYear": 2021,
+      |  "status": "valid"
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSubmissionPeriodWithPeriodIdRegexJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "periodId": "1234567890123456",
+      |  "startDate": "$now",
+      |  "endDate": "$aYearFromNow",
+      |  "receivedDateTime": "2000-01-01T10:12:10Z"
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSubmissionPeriodWithInvalidPeriodIdRegexJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "periodId": "7038926d-d7a1-4399-8641-f278b438259c",
+       |  "startDate": "$now",
+       |  "endDate": "$aYearFromNow",
+       |  "receivedDateTime": "2000-01-01T10:12:10Z"
+       |}
+       |""".stripMargin
+  )
+
+  val downstreamInputsFhlJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "incomeSourceType": "04",
+      |  "incomeSourceId": "XAIS12345678910",
+      |  "incomeSourceName": "Business Name",
+      |  "accountingPeriodStartDate": "$now",
+      |  "accountingPeriodEndDate": "$aYearFromNow",
+      |  "source": "MTD-SA",
+      |  "submissionPeriods": [$downstreamSubmissionPeriodWithPeriodIdRegexJson, $downstreamSubmissionPeriodWithInvalidPeriodIdRegexJson]
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamInputsNonFhlJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "incomeSourceType": "02",
+      |  "incomeSourceId": "XAIS12345678910",
+      |  "incomeSourceName": "Business Name",
+      |  "accountingPeriodStartDate": "$now",
+      |  "accountingPeriodEndDate": "$aYearFromNow",
+      |  "source": "MTD-SA",
+      |  "submissionPeriods": [$downstreamSubmissionPeriodWithPeriodIdRegexJson, $downstreamSubmissionPeriodWithInvalidPeriodIdRegexJson]
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamInputsInvalidSourceJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "incomeSourceType": "01",
+      |  "incomeSourceId": "XAIS12345678910",
+      |  "incomeSourceName": "Business Name",
+      |  "accountingPeriodStartDate": "$now",
+      |  "accountingPeriodEndDate": "$aYearFromNow",
+      |  "source": "MTD-VAT",
+      |  "submissionPeriods": [$downstreamSubmissionPeriodWithPeriodIdRegexJson]
+      |}
+      |""".stripMargin
+  )
+
+  def downstreamInputsInvalidIncomeSourceTypeJson(incomeSourceType: IncomeSourceType): JsValue = Json.parse(
+    s"""
+      |{
+      |  "incomeSourceType": "$incomeSourceType",
+      |  "incomeSourceId": "XAIS12345678910",
+      |  "incomeSourceName": "Business Name",
+      |  "accountingPeriodStartDate": "$now",
+      |  "accountingPeriodEndDate": "$aYearFromNow",
+      |  "source": "MTD-SA",
+      |  "submissionPeriods": [$downstreamSubmissionPeriodWithPeriodIdRegexJson]
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSummaryCalculationIncomeJson: JsValue = Json.parse(
+    """
+      |{
+      |  "totalRentsReceived": 1.01,
+      |  "premiumsOfLeaseGrant": 1.02,
+      |  "reversePremiums": 1.03,
+      |  "otherPropertyIncome": 1.04,
+      |  "rentReceived": 1.05,
+      |  "rarRentReceived": 1.06
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSummaryCalculationExpensesJson: JsValue = Json.parse(
+    """
+       |{
+       |  "consolidatedExpenses": 2.01,
+       |  "premisesRunningCosts": 2.02,
+       |  "repairsAndMaintenance": 2.03,
+       |  "financialCosts": 2.04,
+       |  "professionalFees": 2.05,
+       |  "costOfServices": 2.06,
+       |  "residentialFinancialCost": 2.07,
+       |  "broughtFwdResidentialFinancialCost": 2.08,
+       |  "other": 2.09,
+       |  "travelCosts": 2.10
+       |}
+       |""".stripMargin
+  )
+
+  val downstreamSummaryCalculationAdditionsJson: JsValue = Json.parse(
+    """
+      |{
+      |  "privateUseAdjustment": 5.01,
+      |  "balancingCharge": 5.02,
+      |  "bpraBalancingCharge": 5.03
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSummaryCalculationDeductionsJson: JsValue = Json.parse(
+    """
+      |{
+      |  "zeroEmissionsGoodsVehicleAllowance": 6.01,
+      |  "annualInvestmentAllowance": 6.02,
+      |  "costOfReplacingDomesticItems": 6.03,
+      |  "businessPremisesRenovationAllowance": 6.04,
+      |  "propertyAllowance": 6.05,
+      |  "otherCapitalAllowance": 6.06,
+      |  "rarReliefClaimed": 6.07,
+      |  "electricChargePointAllowance": 6.08,
+      |  "structuredBuildingAllowance": 6.09,
+      |  "enhancedStructuredBuildingAllowance": 6.10,
+      |  "zeroEmissionsCarAllowance": 6.11
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamSummaryCalculationJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "totalIncome": 1.00,
+      |  "income": $downstreamSummaryCalculationIncomeJson,
+      |  "totalExpenses": 2.00,
+      |  "expenses": $downstreamSummaryCalculationExpensesJson,
+      |  "netProfit": 3.00,
+      |  "netLoss": 4.00,
+      |  "totalAdditions": 5.00,
+      |  "additions": $downstreamSummaryCalculationAdditionsJson,
+      |  "totalDeductions": 6.00,
+      |  "deductions": $downstreamSummaryCalculationDeductionsJson,
+      |  "taxableProfit": 7.00,
+      |  "adjustedIncomeTaxLoss": 8.00
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamAdjustmentsIncomeJson: JsValue = Json.parse(
+    """
+      |{
+      |  "totalRentsReceived": 1.01,
+      |  "premiumsOfLeaseGrant": 1.02,
+      |  "reversePremiums": 1.03,
+      |  "otherPropertyIncome": 1.04,
+      |  "rentReceived": 1.05
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamAdjustmentsExpensesJson: JsValue = Json.parse(
+    """
+      |{
+      |    "consolidatedExpenses": 2.01,
+      |    "premisesRunningCosts": 2.02,
+      |    "repairsAndMaintenance": 2.03,
+      |    "financialCosts": 2.04,
+      |    "professionalFees": 2.05,
+      |    "costOfServices": 2.06,
+      |    "residentialFinancialCost": 2.07,
+      |    "other": 2.08,
+      |    "travelCosts": 2.09
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamAdjustmentsJson: JsValue = Json.parse(
+    s"""
+      |{
+      |  "income": $downstreamAdjustmentsIncomeJson,
+      |  "expenses": $downstreamAdjustmentsExpensesJson
+      |}
+      |""".stripMargin
+  )
+
+  val downstreamRetrieveBsasFhlResponseJson: JsValue = Json.parse(s"""
+       |{
+       |  "metadata": $downstreamMetadataJson,
+       |  "inputs": $downstreamInputsFhlJson,
+       |  "adjustableSummaryCalculation": $downstreamSummaryCalculationJson,
+       |  "adjustments": $downstreamAdjustmentsJson,
+       |  "adjustedSummaryCalculation": $downstreamSummaryCalculationJson
+       |}
+       |""".stripMargin)
+
+  val downstreamRetrieveBsasNonFhlResponseJson: JsValue = Json.parse(s"""
+       |{
+       |  "metadata": $downstreamMetadataJson,
+       |  "inputs": $downstreamInputsNonFhlJson,
+       |  "adjustableSummaryCalculation": $downstreamSummaryCalculationJson,
+       |  "adjustments": $downstreamAdjustmentsJson,
+       |  "adjustedSummaryCalculation": $downstreamSummaryCalculationJson
+       |}
+       |""".stripMargin)
+
+  def downstreamRetrieveBsasResponseJsonInvalidIncomeSourceType(incomeSourceType: IncomeSourceType): JsValue = Json.parse(s"""
+       |{
+       |  "metadata": $downstreamMetadataJson,
+       |  "inputs": ${downstreamInputsInvalidIncomeSourceTypeJson(incomeSourceType)},
+       |  "adjustableSummaryCalculation": $downstreamSummaryCalculationJson,
+       |  "adjustments": $downstreamAdjustmentsJson,
+       |  "adjustedSummaryCalculation": $downstreamSummaryCalculationJson
+       |}
+       |""".stripMargin)
+
+  val mtdMetadataJson: JsValue = Json.parse(
+    """
+      |{
+      |  "calculationId": "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
+      |  "requestedDateTime": "2000-01-01T10:12:10Z",
+      |  "adjustedDateTime": "2000-01-01T10:12:10Z",
+      |  "nino": "AA999999A",
+      |  "taxYear": "2020-21",
+      |  "summaryStatus": "valid"
+      |}
+      |""".stripMargin
+  )
+
+  val mtdSubmissionPeriodWithPeriodIdJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "periodId": "1234567890123456",
+       |  "startDate": "$now",
+       |  "endDate": "$aYearFromNow",
+       |  "receivedDateTime": "2000-01-01T10:12:10Z"
+       |}
+       |""".stripMargin
+  )
+
+  val mtdSubmissionPeriodWithSubmissionIdJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "submissionId": "${now}_$aYearFromNow",
+       |  "startDate": "$now",
+       |  "endDate": "$aYearFromNow",
+       |  "receivedDateTime": "2000-01-01T10:12:10Z"
+       |}
+       |""".stripMargin
+  )
+
+  val mtdInputsFhlJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "typeOfBusiness": "uk-property-fhl",
+       |  "businessId": "XAIS12345678910",
+       |  "businessName": "Business Name",
+       |  "accountingPeriodStartDate": "$now",
+       |  "accountingPeriodEndDate": "$aYearFromNow",
+       |  "source": "MTD-SA",
+       |  "submissionPeriods": [$mtdSubmissionPeriodWithPeriodIdJson, $mtdSubmissionPeriodWithSubmissionIdJson]
+       |}
+       |""".stripMargin
+  )
+
+  val mtdInputsNonFhlJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "typeOfBusiness": "uk-property-non-fhl",
+       |  "businessId": "XAIS12345678910",
+       |  "businessName": "Business Name",
+       |  "accountingPeriodStartDate": "$now",
+       |  "accountingPeriodEndDate": "$aYearFromNow",
+       |  "source": "MTD-SA",
+       |  "submissionPeriods": [$mtdSubmissionPeriodWithPeriodIdJson, $mtdSubmissionPeriodWithSubmissionIdJson]
+       |}
+       |""".stripMargin
+  )
+
+  val mtdSummaryCalculationIncomeFhlJson: JsValue = Json.parse(
+    """
+      |{
+      |  "totalRentsReceived": 1.05,
+      |  "rarRentReceived": 1.06
+      |}
+      |""".stripMargin
+  )
+
+  val mtdSummaryCalculationIncomeNonFhlJson: JsValue = Json.parse(
+    """
+      |{
+      |  "totalRentsReceived": 1.01,
+      |  "premiumsOfLeaseGrant": 1.02,
+      |  "reversePremiums": 1.03,
+      |  "otherPropertyIncome": 1.04,
+      |  "rarRentReceived": 1.06
+      |}
+      |""".stripMargin
+  )
+
+  val mtdSummaryCalculationExpensesFhlJson: JsValue = Json.parse(
+    """
+       |{
+       |  "consolidatedExpenses": 2.01,
+       |  "premisesRunningCosts": 2.02,
+       |  "repairsAndMaintenance": 2.03,
+       |  "financialCosts": 2.04,
+       |  "professionalFees": 2.05,
+       |  "costOfServices": 2.06,
+       |  "other": 2.09,
+       |  "travelCosts": 2.10
+       |}
+       |""".stripMargin
+  )
+
+  val mtdSummaryCalculationExpensesNonFhlJson: JsValue = Json.parse(
+    """
+       |{
+       |  "consolidatedExpenses": 2.01,
+       |  "premisesRunningCosts": 2.02,
+       |  "repairsAndMaintenance": 2.03,
+       |  "financialCosts": 2.04,
+       |  "professionalFees": 2.05,
+       |  "costOfServices": 2.06,
+       |  "residentialFinancialCost": 2.07,
+       |  "broughtFwdResidentialFinancialCost": 2.08,
+       |  "other": 2.09,
+       |  "travelCosts": 2.10
+       |}
+       |""".stripMargin
+  )
+
+  val mtdSummaryCalculationAdditionsJson: JsValue = Json.parse(
+    """
+      |{
+      |  "privateUseAdjustment": 5.01,
+      |  "balancingCharge": 5.02,
+      |  "bpraBalancingCharge": 5.03
+      |}
+      |""".stripMargin
+  )
+
+  val mtdSummaryCalculationDeductionsFhlJson: JsValue = Json.parse(
+    """
+      |{
+      |  "annualInvestmentAllowance": 6.02,
+      |  "businessPremisesRenovationAllowance": 6.04,
+      |  "propertyAllowance": 6.05,
+      |  "otherCapitalAllowance": 6.06,
+      |  "rarReliefClaimed": 6.07,
+      |  "electricChargePointAllowance": 6.08,
+      |  "zeroEmissionsCarAllowance": 6.11
+      |}
+      |""".stripMargin
+  )
+
+  val mtdSummaryCalculationDeductionsNonFhlJson: JsValue = Json.parse(
+    """
+      |{
+      |  "zeroEmissionGoods": 6.01,
+      |  "annualInvestmentAllowance": 6.02,
+      |  "costOfReplacingDomesticItems": 6.03,
+      |  "businessPremisesRenovationAllowance": 6.04,
+      |  "propertyAllowance": 6.05,
+      |  "otherCapitalAllowance": 6.06,
+      |  "rarReliefClaimed": 6.07,
+      |  "electricChargePointAllowance": 6.08,
+      |  "structuredBuildingAllowance": 6.09,
+      |  "enhancedStructuredBuildingAllowance": 6.10,
+      |  "zeroEmissionsCarAllowance": 6.11
+      |}
+      |""".stripMargin
+  )
+
+  val mtdSummaryCalculationFhlJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "totalIncome": 1,
+       |  "income": $mtdSummaryCalculationIncomeFhlJson,
+       |  "totalExpenses": 2,
+       |  "expenses": $mtdSummaryCalculationExpensesFhlJson,
+       |  "netProfit": 3,
+       |  "netLoss": 4,
+       |  "totalAdditions": 5,
+       |  "additions": $mtdSummaryCalculationAdditionsJson,
+       |  "totalDeductions": 6,
+       |  "deductions": $mtdSummaryCalculationDeductionsFhlJson,
+       |  "taxableProfit": 7,
+       |  "adjustedIncomeTaxLoss": 8
+       |}
+       |""".stripMargin
+  )
+
+  val mtdSummaryCalculationNonFhlJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "totalIncome": 1,
+       |  "income": $mtdSummaryCalculationIncomeNonFhlJson,
+       |  "totalExpenses": 2,
+       |  "expenses": $mtdSummaryCalculationExpensesNonFhlJson,
+       |  "netProfit": 3,
+       |  "netLoss": 4,
+       |  "totalAdditions": 5,
+       |  "additions": $mtdSummaryCalculationAdditionsJson,
+       |  "totalDeductions": 6,
+       |  "deductions": $mtdSummaryCalculationDeductionsNonFhlJson,
+       |  "taxableProfit": 7,
+       |  "adjustedIncomeTaxLoss": 8
+       |}
+       |""".stripMargin
+  )
+
+  val mtdAdjustmentsIncomeFhlJson: JsValue = Json.parse(
+    """
+      |{
+      |  "totalRentsReceived": 1.05
+      |}
+      |""".stripMargin
+  )
+
+  val mtdAdjustmentsIncomeNonFhlJson: JsValue = Json.parse(
+    """
+      |{
+      |  "totalRentsReceived": 1.01,
+      |  "premiumsOfLeaseGrant": 1.02,
+      |  "reversePremiums": 1.03,
+      |  "otherPropertyIncome": 1.04
+      |}
+      |""".stripMargin
+  )
+
+  val mtdAdjustmentsExpensesFhlJson: JsValue = Json.parse(
+    """
+      |{
+      |    "consolidatedExpenses": 2.01,
+      |    "premisesRunningCosts": 2.02,
+      |    "repairsAndMaintenance": 2.03,
+      |    "financialCosts": 2.04,
+      |    "professionalFees": 2.05,
+      |    "costOfServices": 2.06,
+      |    "other": 2.08,
+      |    "travelCosts": 2.09
+      |}
+      |""".stripMargin
+  )
+
+  val mtdAdjustmentsExpensesNonFhlJson: JsValue = Json.parse(
+    """
+      |{
+      |    "consolidatedExpenses": 2.01,
+      |    "premisesRunningCosts": 2.02,
+      |    "repairsAndMaintenance": 2.03,
+      |    "financialCosts": 2.04,
+      |    "professionalFees": 2.05,
+      |    "costOfServices": 2.06,
+      |    "residentialFinancialCost": 2.07,
+      |    "other": 2.08,
+      |    "travelCosts": 2.09
+      |}
+      |""".stripMargin
+  )
+
+  val mtdAdjustmentsFhlJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "income": $mtdAdjustmentsIncomeFhlJson,
+       |  "expenses": $mtdAdjustmentsExpensesFhlJson
+       |}
+       |""".stripMargin
+  )
+
+  val mtdAdjustmentsNonFhlJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "income": $mtdAdjustmentsIncomeNonFhlJson,
+       |  "expenses": $mtdAdjustmentsExpensesNonFhlJson
+       |}
+       |""".stripMargin
+  )
+
+  val mtdRetrieveBsasResponseFhlJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "metadata": $mtdMetadataJson,
+       |  "inputs": $mtdInputsFhlJson,
+       |  "adjustableSummaryCalculation": $mtdSummaryCalculationFhlJson,
+       |  "adjustments": $mtdAdjustmentsFhlJson,
+       |  "adjustedSummaryCalculation": $mtdSummaryCalculationFhlJson
+       |}
+       |""".stripMargin
+  )
+
+  val mtdRetrieveBsasResponseNonFhlJson: JsValue = Json.parse(
+    s"""
+       |{
+       |  "metadata": $mtdMetadataJson,
+       |  "inputs": $mtdInputsNonFhlJson,
+       |  "adjustableSummaryCalculation": $mtdSummaryCalculationNonFhlJson,
+       |  "adjustments": $mtdAdjustmentsNonFhlJson,
+       |  "adjustedSummaryCalculation": $mtdSummaryCalculationNonFhlJson
+       |}
+       |""".stripMargin
+  )
+
+  def mtdRetrieveBsasReponseFhlJsonWithHateoas(nino: String, calculationId: String, taxYear: Option[String] = None): JsValue = {
+    val taxYearParam = taxYear.fold("")("?taxYear=" + _)
+
+    mtdRetrieveBsasResponseFhlJson.as[JsObject] ++ Json
+      .parse(s"""
+      |{
+      |  "links": [
+      |    {
+      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId$taxYearParam",
+      |      "method": "GET",
+      |      "rel": "self"
+      |    }, {
+      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId/adjust$taxYearParam",
+      |      "method": "POST",
+      |      "rel": "submit-uk-property-accounting-adjustments"
+      |    }
+      |  ]
+      |}
+      |""".stripMargin)
+      .as[JsObject]
+  }
+
+  def mtdRetrieveBsasReponseNonFhlJsonWithHateoas(nino: String, calculationId: String, taxYear: Option[String] = None): JsValue = {
+    val taxYearParam = taxYear.fold("")("?taxYear=" + _)
+
+    mtdRetrieveBsasResponseNonFhlJson.as[JsObject] ++ Json
+      .parse(s"""
+      |{
+      |  "links": [
+      |    {
+      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId$taxYearParam",
+      |      "method": "GET",
+      |      "rel": "self"
+      |    }, {
+      |      "href": "/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calculationId/adjust$taxYearParam",
+      |      "method": "POST",
+      |      "rel": "submit-uk-property-accounting-adjustments"
+      |    }
+      |  ]
+      |}
+      |""".stripMargin)
+      .as[JsObject]
+  }
+
+  val metadataModel: Metadata = Metadata(
+    calculationId = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
+    requestedDateTime = "2000-01-01T10:12:10Z",
+    adjustedDateTime = Some("2000-01-01T10:12:10Z"),
+    nino = "AA999999A",
+    taxYear = "2020-21",
+    summaryStatus = Status.`valid`
+  )
+
+  val submissionPeriodWithPeriodIdModel: SubmissionPeriod = SubmissionPeriod(
+    periodId = Some("1234567890123456"),
+    submissionId = None,
+    startDate = now,
+    endDate = aYearFromNow,
+    receivedDateTime = "2000-01-01T10:12:10Z"
+  )
+
+  val submissionPeriodWithSubmissionIdModel: SubmissionPeriod = SubmissionPeriod(
+    periodId = None,
+    submissionId = Some(s"${now}_$aYearFromNow"),
+    startDate = now,
+    endDate = aYearFromNow,
+    receivedDateTime = "2000-01-01T10:12:10Z"
+  )
+
+  val inputsFhlModel: Inputs = Inputs(
+    typeOfBusiness = TypeOfBusiness.`uk-property-fhl`,
+    businessId = "XAIS12345678910",
+    businessName = Some("Business Name"),
+    accountingPeriodStartDate = now,
+    accountingPeriodEndDate = aYearFromNow,
+    source = Source.`MTD-SA`,
+    submissionPeriods = Seq(submissionPeriodWithPeriodIdModel, submissionPeriodWithSubmissionIdModel)
+  )
+
+  val inputsNonFhlModel: Inputs = Inputs(
+    typeOfBusiness = TypeOfBusiness.`uk-property-non-fhl`,
+    businessId = "XAIS12345678910",
+    businessName = Some("Business Name"),
+    accountingPeriodStartDate = now,
+    accountingPeriodEndDate = aYearFromNow,
+    source = Source.`MTD-SA`,
+    submissionPeriods = Seq(submissionPeriodWithPeriodIdModel, submissionPeriodWithSubmissionIdModel)
+  )
+
+  val summaryCalculationIncomeFhlModel: SummaryCalculationIncome = SummaryCalculationIncome(
+    totalRentsReceived = Some(1.05),
+    premiumsOfLeaseGrant = None,
+    reversePremiums = None,
+    otherPropertyIncome = None,
+    rarRentReceived = Some(1.06)
+  )
+
+  val summaryCalculationIncomeNonFhlModel: SummaryCalculationIncome = SummaryCalculationIncome(
+    totalRentsReceived = Some(1.01),
+    premiumsOfLeaseGrant = Some(1.02),
+    reversePremiums = Some(1.03),
+    otherPropertyIncome = Some(1.04),
+    rarRentReceived = Some(1.06)
+  )
+
+  val summaryCalculationExpensesFhlModel: SummaryCalculationExpenses = SummaryCalculationExpenses(
+    consolidatedExpenses = Some(2.01),
+    premisesRunningCosts = Some(2.02),
+    repairsAndMaintenance = Some(2.03),
+    financialCosts = Some(2.04),
+    professionalFees = Some(2.05),
+    costOfServices = Some(2.06),
+    residentialFinancialCost = None,
+    broughtFwdResidentialFinancialCost = None,
+    other = Some(2.09),
+    travelCosts = Some(2.10)
+  )
+
+  val summaryCalculationExpensesNonFhlModel: SummaryCalculationExpenses = SummaryCalculationExpenses(
+    consolidatedExpenses = Some(2.01),
+    premisesRunningCosts = Some(2.02),
+    repairsAndMaintenance = Some(2.03),
+    financialCosts = Some(2.04),
+    professionalFees = Some(2.05),
+    costOfServices = Some(2.06),
+    residentialFinancialCost = Some(2.07),
+    broughtFwdResidentialFinancialCost = Some(2.08),
+    other = Some(2.09),
+    travelCosts = Some(2.10)
+  )
+
+  val summaryCalculationAdditionsModel: SummaryCalculationAdditions = SummaryCalculationAdditions(
+    privateUseAdjustment = Some(5.01),
+    balancingCharge = Some(5.02),
+    bpraBalancingCharge = Some(5.03)
+  )
+
+  val summaryCalculationDeductionsFhlModel: SummaryCalculationDeductions = SummaryCalculationDeductions(
+    zeroEmissionGoods = None,
+    annualInvestmentAllowance = Some(6.02),
+    costOfReplacingDomesticItems = None,
+    businessPremisesRenovationAllowance = Some(6.04),
+    propertyAllowance = Some(6.05),
+    otherCapitalAllowance = Some(6.06),
+    rarReliefClaimed = Some(6.07),
+    electricChargePointAllowance = Some(6.08),
+    structuredBuildingAllowance = None,
+    enhancedStructuredBuildingAllowance = None,
+    zeroEmissionsCarAllowance = Some(6.11)
+  )
+
+  val summaryCalculationDeductionsNonFhlModel: SummaryCalculationDeductions = SummaryCalculationDeductions(
+    zeroEmissionGoods = Some(6.01),
+    annualInvestmentAllowance = Some(6.02),
+    costOfReplacingDomesticItems = Some(6.03),
+    businessPremisesRenovationAllowance = Some(6.04),
+    propertyAllowance = Some(6.05),
+    otherCapitalAllowance = Some(6.06),
+    rarReliefClaimed = Some(6.07),
+    electricChargePointAllowance = Some(6.08),
+    structuredBuildingAllowance = Some(6.09),
+    enhancedStructuredBuildingAllowance = Some(6.10),
+    zeroEmissionsCarAllowance = Some(6.11)
+  )
+
+  val adjustableSummaryCalculationFhlModel: AdjustableSummaryCalculation = AdjustableSummaryCalculation(
+    totalIncome = Some(1),
+    income = Some(summaryCalculationIncomeFhlModel),
+    totalExpenses = Some(2),
+    expenses = Some(summaryCalculationExpensesFhlModel),
+    netProfit = Some(3),
+    netLoss = Some(4),
+    totalAdditions = Some(5),
+    additions = Some(summaryCalculationAdditionsModel),
+    totalDeductions = Some(6),
+    deductions = Some(summaryCalculationDeductionsFhlModel),
+    taxableProfit = Some(7),
+    adjustedIncomeTaxLoss = Some(8)
+  )
+
+  val adjustableSummaryCalculationNonFhlModel: AdjustableSummaryCalculation = AdjustableSummaryCalculation(
+    totalIncome = Some(1),
+    income = Some(summaryCalculationIncomeNonFhlModel),
+    totalExpenses = Some(2),
+    expenses = Some(summaryCalculationExpensesNonFhlModel),
+    netProfit = Some(3),
+    netLoss = Some(4),
+    totalAdditions = Some(5),
+    additions = Some(summaryCalculationAdditionsModel),
+    totalDeductions = Some(6),
+    deductions = Some(summaryCalculationDeductionsNonFhlModel),
+    taxableProfit = Some(7),
+    adjustedIncomeTaxLoss = Some(8)
+  )
+
+  val adjustmentsIncomeFhlModel: AdjustmentsIncome = AdjustmentsIncome(
+    totalRentsReceived = Some(1.05),
+    premiumsOfLeaseGrant = None,
+    reversePremiums = None,
+    otherPropertyIncome = None
+  )
+
+  val adjustmentsIncomeNonFhlModel: AdjustmentsIncome = AdjustmentsIncome(
+    totalRentsReceived = Some(1.01),
+    premiumsOfLeaseGrant = Some(1.02),
+    reversePremiums = Some(1.03),
+    otherPropertyIncome = Some(1.04)
+  )
+
+  val adjustmentsExpensesFhlModel: AdjustmentsExpenses = AdjustmentsExpenses(
+    consolidatedExpenses = Some(2.01),
+    premisesRunningCosts = Some(2.02),
+    repairsAndMaintenance = Some(2.03),
+    financialCosts = Some(2.04),
+    professionalFees = Some(2.05),
+    costOfServices = Some(2.06),
+    residentialFinancialCost = None,
+    other = Some(2.08),
+    travelCosts = Some(2.09)
+  )
+
+  val adjustmentsExpensesNonFhlModel: AdjustmentsExpenses = AdjustmentsExpenses(
+    consolidatedExpenses = Some(2.01),
+    premisesRunningCosts = Some(2.02),
+    repairsAndMaintenance = Some(2.03),
+    financialCosts = Some(2.04),
+    professionalFees = Some(2.05),
+    costOfServices = Some(2.06),
+    residentialFinancialCost = Some(2.07),
+    other = Some(2.08),
+    travelCosts = Some(2.09)
+  )
+
+  val adjustmentsFhlModel: Adjustments = Adjustments(
+    income = Some(adjustmentsIncomeFhlModel),
+    expenses = Some(adjustmentsExpensesFhlModel)
+  )
+
+  val adjustmentsNonFhlModel: Adjustments = Adjustments(
+    income = Some(adjustmentsIncomeNonFhlModel),
+    expenses = Some(adjustmentsExpensesNonFhlModel)
+  )
+
+  val adjustedSummaryCalculationFhlModel: AdjustedSummaryCalculation = AdjustedSummaryCalculation(
+    totalIncome = Some(1),
+    income = Some(summaryCalculationIncomeFhlModel),
+    totalExpenses = Some(2),
+    expenses = Some(summaryCalculationExpensesFhlModel),
+    netProfit = Some(3),
+    netLoss = Some(4),
+    totalAdditions = Some(5),
+    additions = Some(summaryCalculationAdditionsModel),
+    totalDeductions = Some(6),
+    deductions = Some(summaryCalculationDeductionsFhlModel),
+    taxableProfit = Some(7),
+    adjustedIncomeTaxLoss = Some(8)
+  )
+
+  val adjustedSummaryCalculationNonFhlModel: AdjustedSummaryCalculation = AdjustedSummaryCalculation(
+    totalIncome = Some(1),
+    income = Some(summaryCalculationIncomeNonFhlModel),
+    totalExpenses = Some(2),
+    expenses = Some(summaryCalculationExpensesNonFhlModel),
+    netProfit = Some(3),
+    netLoss = Some(4),
+    totalAdditions = Some(5),
+    additions = Some(summaryCalculationAdditionsModel),
+    totalDeductions = Some(6),
+    deductions = Some(summaryCalculationDeductionsNonFhlModel),
+    taxableProfit = Some(7),
+    adjustedIncomeTaxLoss = Some(8)
+  )
+
+  val retrieveBsasResponseFhlModel: Def1_RetrieveUkPropertyBsasResponse = Def1_RetrieveUkPropertyBsasResponse(
+    metadata = metadataModel,
+    inputs = inputsFhlModel,
+    adjustableSummaryCalculation = adjustableSummaryCalculationFhlModel,
+    adjustments = Some(adjustmentsFhlModel),
+    adjustedSummaryCalculation = Some(adjustedSummaryCalculationFhlModel)
+  )
+
+  val retrieveBsasResponseNonFhlModel: Def1_RetrieveUkPropertyBsasResponse = Def1_RetrieveUkPropertyBsasResponse(
+    metadata = metadataModel,
+    inputs = inputsNonFhlModel,
+    adjustableSummaryCalculation = adjustableSummaryCalculationNonFhlModel,
+    adjustments = Some(adjustmentsNonFhlModel),
+    adjustedSummaryCalculation = Some(adjustedSummaryCalculationNonFhlModel)
+  )
+
+  def retrieveBsasResponseInvalidTypeOfBusinessModel(typeOfBusiness: TypeOfBusiness): Def1_RetrieveUkPropertyBsasResponse = Def1_RetrieveUkPropertyBsasResponse(
+    metadata = metadataModel,
+    inputs = inputsFhlModel.copy(typeOfBusiness = typeOfBusiness),
+    adjustableSummaryCalculation = adjustableSummaryCalculationFhlModel,
+    adjustments = Some(adjustmentsFhlModel),
+    adjustedSummaryCalculation = Some(adjustedSummaryCalculationFhlModel)
+  )
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/RetrieveUkPropertyBsasResponseSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/RetrieveUkPropertyBsasResponseSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models
+
+import play.api.Configuration
+import shared.UnitSpec
+import shared.config.MockAppConfig
+import shared.hateoas.Method._
+import shared.hateoas.{HateoasFactory, HateoasWrapper, Link}
+import shared.models.domain.TaxYear
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class RetrieveUkPropertyBsasResponseSpec extends UnitSpec {
+
+  "HateoasFactory" should {
+    class Test extends MockAppConfig {
+      val hateoasFactory = new HateoasFactory(mockAppConfig)
+      val nino           = "someNino"
+      val calculationId  = "anId"
+      val context        = "individuals/self-assessment/adjustable-summary"
+      val taxYear        = Some(TaxYear.fromMtd("2023-24"))
+      val rawResponse: RetrieveUkPropertyBsasResponse = retrieveBsasResponseFhlModel
+
+      MockAppConfig.apiGatewayContext.returns(context).anyNumberOfTimes()
+    }
+
+    class TysDisabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> false)).anyNumberOfTimes()
+    }
+
+    class TysEnabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> true)).anyNumberOfTimes()
+    }
+
+    "return the correct links without tax year" in new TysDisabledTest {
+      private val result = hateoasFactory.wrap(rawResponse, RetrieveUkPropertyHateoasData(nino, calculationId, None))
+      private val expectedLinks = Seq(
+        Link(s"/$context/$nino/uk-property/$calculationId", GET, "self"),
+        Link(s"/$context/$nino/uk-property/$calculationId/adjust", POST, "submit-uk-property-accounting-adjustments")
+      )
+
+      result shouldBe HateoasWrapper(rawResponse, expectedLinks)
+    }
+
+    "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+      private val result = hateoasFactory.wrap(rawResponse, RetrieveUkPropertyHateoasData(nino, calculationId, taxYear))
+      private val expectedLinks = Seq(
+        Link(s"/$context/$nino/uk-property/$calculationId?taxYear=2023-24", GET, "self"),
+        Link(s"/$context/$nino/uk-property/$calculationId/adjust?taxYear=2023-24", POST, "submit-uk-property-accounting-adjustments")
+      )
+
+      result shouldBe HateoasWrapper(rawResponse, expectedLinks)
+    }
+  }
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/AdjustmentsExpensesSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/AdjustmentsExpensesSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class AdjustmentsExpensesSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  import AdjustmentsExpenses._
+
+  testRoundTrip("Adjustment expenses FHL", downstreamAdjustmentsExpensesJson, adjustmentsExpensesFhlModel, mtdAdjustmentsExpensesFhlJson)(readsFhl)
+
+  testRoundTrip("Adjustment expenses Non-FHL", downstreamAdjustmentsExpensesJson, adjustmentsExpensesNonFhlModel, mtdAdjustmentsExpensesNonFhlJson)(
+    readsNonFhl)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/AdjustmentsIncomeSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/AdjustmentsIncomeSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class AdjustmentsIncomeSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  import AdjustmentsIncome._
+
+  testRoundTrip("Adjustments Income FHL", downstreamAdjustmentsIncomeJson, adjustmentsIncomeFhlModel, mtdAdjustmentsIncomeFhlJson)(readsFhl)
+
+  testRoundTrip("Adjustments Income Non-FHL", downstreamAdjustmentsIncomeJson, adjustmentsIncomeNonFhlModel, mtdAdjustmentsIncomeNonFhlJson)(
+    readsNonFhl)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/AdjustmentsSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/AdjustmentsSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class AdjustmentsSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  import Adjustments._
+
+  testRoundTrip("Adjustments FHL", downstreamAdjustmentsJson, adjustmentsFhlModel, mtdAdjustmentsFhlJson)(readsFhl)
+  testRoundTrip("Adjustments Non-FHL", downstreamAdjustmentsJson, adjustmentsNonFhlModel, mtdAdjustmentsNonFhlJson)(readsNonFhl)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/Def1_RetrieveUkPropertyBsasResponseSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/Def1_RetrieveUkPropertyBsasResponseSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class Def1_RetrieveUkPropertyBsasResponseSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  import Def1_RetrieveUkPropertyBsasResponse._
+
+  testRoundTrip(
+    testName = "Retrieve UK Property FHL",
+    downstreamJson = downstreamRetrieveBsasFhlResponseJson,
+    model = retrieveBsasResponseFhlModel,
+    mtdJson = mtdRetrieveBsasResponseFhlJson
+  )(reads)
+
+  testRoundTrip(
+    testName = "Retrieve UK Property Non-FHL",
+    downstreamJson = downstreamRetrieveBsasNonFhlResponseJson,
+    model = retrieveBsasResponseNonFhlModel,
+    mtdJson = mtdRetrieveBsasResponseNonFhlJson
+  )(reads)
+
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/InputsSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/InputsSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import play.api.libs.json.JsResultException
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class InputsSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  "reads" should {
+    "return an error" when {
+      "passed JSON with an invalid source" in {
+        a[JsResultException] should be thrownBy downstreamInputsInvalidSourceJson.as[Inputs]
+
+        val thrown: JsResultException = the[JsResultException] thrownBy downstreamInputsInvalidSourceJson.as[Inputs]
+        thrown.errors
+          .map { case (path, errors) =>
+            (path, errors.map(_.messages))
+          }
+          .map { case (path, errors) =>
+            path.toString() shouldBe "/source"
+            errors.flatten.contains("error.expected.Source") shouldBe true
+          }
+      }
+    }
+  }
+
+  import Inputs._
+
+  testRoundTrip("Inputs FHL", downstreamInputsFhlJson, inputsFhlModel, mtdInputsFhlJson)(reads)
+  testRoundTrip("Inputs Non-FHL", downstreamInputsNonFhlJson, inputsNonFhlModel, mtdInputsNonFhlJson)(reads)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/MetadataSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/MetadataSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures.{downstreamMetadataJson, metadataModel, mtdMetadataJson}
+
+class MetadataSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  import Metadata._
+
+  testRoundTrip("Metadata", downstreamMetadataJson, metadataModel, mtdMetadataJson)(reads)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/SubmissionPeriodSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/SubmissionPeriodSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class SubmissionPeriodSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  import SubmissionPeriod._
+
+  testRoundTrip(
+    "Submission Period with valid periodId",
+    downstreamSubmissionPeriodWithPeriodIdRegexJson,
+    submissionPeriodWithPeriodIdModel,
+    mtdSubmissionPeriodWithPeriodIdJson
+  )(reads)
+
+  testRoundTrip(
+    "Submission Period with submissionId",
+    downstreamSubmissionPeriodWithInvalidPeriodIdRegexJson,
+    submissionPeriodWithSubmissionIdModel,
+    mtdSubmissionPeriodWithSubmissionIdJson
+  )(reads)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationAdditionsSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationAdditionsSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class SummaryCalculationAdditionsSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  import SummaryCalculationAdditions._
+
+  testRoundTrip(
+    "Summary Calculation Additions",
+    downstreamSummaryCalculationAdditionsJson,
+    summaryCalculationAdditionsModel,
+    mtdSummaryCalculationAdditionsJson)(reads)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationDeductionsSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationDeductionsSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class SummaryCalculationDeductionsSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  import SummaryCalculationDeductions._
+
+  testRoundTrip(
+    "Summary Calculation Deductions FHL",
+    downstreamSummaryCalculationDeductionsJson,
+    summaryCalculationDeductionsFhlModel,
+    mtdSummaryCalculationDeductionsFhlJson
+  )(readsFhl)
+
+  testRoundTrip(
+    "Summary Calculation Deductions Non-FHL",
+    downstreamSummaryCalculationDeductionsJson,
+    summaryCalculationDeductionsNonFhlModel,
+    mtdSummaryCalculationDeductionsNonFhlJson
+  )(readsNonFhl)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationExpensesSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationExpensesSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class SummaryCalculationExpensesSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  import SummaryCalculationExpenses._
+
+  testRoundTrip(
+    "Summary Calculation Expenses FHL",
+    downstreamSummaryCalculationExpensesJson,
+    summaryCalculationExpensesFhlModel,
+    mtdSummaryCalculationExpensesFhlJson
+  )(readsFhl)
+
+  testRoundTrip(
+    "Summary Calculation Expenses Non-FHL",
+    downstreamSummaryCalculationExpensesJson,
+    summaryCalculationExpensesNonFhlModel,
+    mtdSummaryCalculationExpensesNonFhlJson
+  )(readsNonFhl)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationIncomeSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationIncomeSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class SummaryCalculationIncomeSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  import SummaryCalculationIncome._
+
+  testRoundTrip(
+    "Summary Calculation Income FHL",
+    downstreamSummaryCalculationIncomeJson,
+    summaryCalculationIncomeFhlModel,
+    mtdSummaryCalculationIncomeFhlJson)(readsFhl)
+
+  testRoundTrip(
+    "Summary Calculation Income Non-FHL",
+    downstreamSummaryCalculationIncomeJson,
+    summaryCalculationIncomeNonFhlModel,
+    mtdSummaryCalculationIncomeNonFhlJson)(readsNonFhl)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/models/def1/SummaryCalculationSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.models.def1
+
+import shared.UnitSpec
+import shared.models.utils.JsonErrorValidators
+import v5.models.RoundTripTest
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+
+class SummaryCalculationSpec extends UnitSpec with JsonErrorValidators with RoundTripTest {
+
+  import AdjustableSummaryCalculation.{readsFhl => readsFhlAdjustable, readsNonFhl => readsNonFhlAdjustable, writes => writesAdjustable}
+
+  testRoundTrip(
+    "Adjustable Summary Calculation FHL",
+    downstreamSummaryCalculationJson,
+    adjustableSummaryCalculationFhlModel,
+    mtdSummaryCalculationFhlJson)(readsFhlAdjustable)
+
+  testRoundTrip(
+    "Adjustable Summary Calculation Non-FHL",
+    downstreamSummaryCalculationJson,
+    adjustableSummaryCalculationNonFhlModel,
+    mtdSummaryCalculationNonFhlJson)(readsNonFhlAdjustable)
+
+  import AdjustedSummaryCalculation.{readsFhl => readsFhlAdjusted, readsNonFhl => readsNonFhlAdjusted, writes => writesAdjusted}
+
+  testRoundTrip(
+    "Adjusted Summary Calculation FHL",
+    downstreamSummaryCalculationJson,
+    adjustedSummaryCalculationFhlModel,
+    mtdSummaryCalculationFhlJson)(readsFhlAdjusted)
+
+  testRoundTrip(
+    "Adjusted Summary Calculation Non-FHL",
+    downstreamSummaryCalculationJson,
+    adjustedSummaryCalculationNonFhlModel,
+    mtdSummaryCalculationNonFhlJson)(readsNonFhlAdjusted)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/schema/RetrieveUkPropertyBsasSchemaSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/schema/RetrieveUkPropertyBsasSchemaSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.schema
+
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import shared.UnitSpec
+import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+
+import scala.math.Ordered.orderingToOrdered
+
+class RetrieveUkPropertyBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
+
+  "schema lookup" when {
+    "a tax year is present" must {
+      "use Def1 for tax years from 2023-24" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
+            RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveUkPropertyBsasSchema.Def1
+          }
+        }
+      }
+
+      "use Def1 for other tax years" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
+            RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveUkPropertyBsasSchema.Def1
+          }
+        }
+      }
+    }
+
+    "the tax year is present but not valid" must {
+      "use a default of Def1" in {
+        RetrieveUkPropertyBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe RetrieveUkPropertyBsasSchema.Def1
+      }
+    }
+
+    "no tax year is present" must {
+      "use a default of Def1" in {
+        RetrieveUkPropertyBsasSchema.schemaFor(None) shouldBe RetrieveUkPropertyBsasSchema.Def1
+      }
+    }
+  }
+
+}

--- a/test/v5/retrieveUkPropertyBsas/schema/RetrieveUkPropertyBsasSchemaSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/schema/RetrieveUkPropertyBsasSchemaSpec.scala
@@ -20,25 +20,19 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import shared.UnitSpec
 import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
 
-import scala.math.Ordered.orderingToOrdered
-
 class RetrieveUkPropertyBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
 
   "schema lookup" when {
     "a tax year is present" must {
       "use Def1 for tax years from 2023-24" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
-            RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveUkPropertyBsasSchema.Def1
-          }
+        forTaxYearsFrom(TaxYear.fromMtd("2023-24")) { taxYear =>
+          RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveUkPropertyBsasSchema.Def1
         }
       }
 
-      "use Def1 for other tax years" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
-            RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveUkPropertyBsasSchema.Def1
-          }
+      "use Def1 for pre-TYS tax years" in {
+        forPreTysTaxYears { taxYear =>
+          RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveUkPropertyBsasSchema.Def1
         }
       }
     }

--- a/test/v5/retrieveUkPropertyBsas/services/MockRetrieveUkPropertyBsasService.scala
+++ b/test/v5/retrieveUkPropertyBsas/services/MockRetrieveUkPropertyBsasService.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.services
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.controllers.RequestContext
+import shared.services.ServiceOutcome
+import v5.retrieveUkPropertyBsas.models.{RetrieveUkPropertyBsasRequestData, RetrieveUkPropertyBsasResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockRetrieveUkPropertyBsasService extends MockFactory {
+
+  val mockService: RetrieveUkPropertyBsasService = mock[RetrieveUkPropertyBsasService]
+
+  object MockRetrieveUkPropertyBsasService {
+
+    def retrieveBsas(requestData: RetrieveUkPropertyBsasRequestData): CallHandler[Future[ServiceOutcome[RetrieveUkPropertyBsasResponse]]] = {
+      (mockService
+        .retrieve(_: RetrieveUkPropertyBsasRequestData)(_: RequestContext, _: ExecutionContext))
+        .expects(requestData, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/retrieveUkPropertyBsas/services/RetrieveUkPropertyBsasServiceSpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/services/RetrieveUkPropertyBsasServiceSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.services
+
+import shared.controllers.EndpointLogContext
+import shared.models.domain.{CalculationId, Nino}
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.ServiceSpec
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.models.domain.TypeOfBusiness
+import v5.models.errors._
+import v5.retrieveUkPropertyBsas.connectors.MockRetrieveUkPropertyBsasConnector
+import v5.retrieveUkPropertyBsas.fixtures.def1.RetrieveUkPropertyBsasFixtures._
+import v5.retrieveUkPropertyBsas.models.def1.Def1_RetrieveUkPropertyBsasRequestData
+import v5.retrieveUkPropertyBsas.models.{RetrieveUkPropertyBsasRequestData, RetrieveUkPropertyBsasResponse}
+
+import scala.concurrent.Future
+
+class RetrieveUkPropertyBsasServiceSpec extends ServiceSpec {
+
+  private val nino = Nino("AA123456A")
+  private val id   = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+
+  val request: RetrieveUkPropertyBsasRequestData = Def1_RetrieveUkPropertyBsasRequestData(nino, id, taxYear = None)
+
+  trait Test extends MockRetrieveUkPropertyBsasConnector {
+    implicit val hc: HeaderCarrier              = HeaderCarrier()
+    implicit val logContext: EndpointLogContext = EndpointLogContext("RetrieveUkPropertyBsasConnector", "retrieve")
+
+    val service = new RetrieveUkPropertyBsasService(mockConnector)
+  }
+
+  "retrieve" should {
+    "return a valid response" when {
+      "a valid request is supplied" in new Test {
+        MockRetrievePropertyBsasConnector
+          .retrievePropertyBsas(request)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, retrieveBsasResponseFhlModel))))
+
+        await(service.retrieve(request)) shouldBe Right(ResponseWrapper(correlationId, retrieveBsasResponseFhlModel))
+      }
+    }
+
+    "return error response" when {
+      "downstream returns a success response with invalid type of business" should {
+        import TypeOfBusiness._
+        Seq(`self-employment`, `foreign-property`, `foreign-property-fhl-eea`).foreach(typeOfBusiness =>
+          s"return an error for $typeOfBusiness" in new Test {
+            val response: RetrieveUkPropertyBsasResponse = retrieveBsasResponseInvalidTypeOfBusinessModel(typeOfBusiness = typeOfBusiness)
+
+            MockRetrievePropertyBsasConnector
+              .retrievePropertyBsas(request)
+              .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
+
+            await(service.retrieve(request)) shouldBe Left(ErrorWrapper(correlationId, RuleTypeOfBusinessIncorrectError))
+          })
+      }
+
+      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
+        s"$downstreamErrorCode is returned from the service" in new Test {
+
+          MockRetrievePropertyBsasConnector
+            .retrievePropertyBsas(request)
+            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+
+          await(service.retrieve(request)) shouldBe Left(ErrorWrapper(correlationId, error))
+        }
+
+      val errors = Seq(
+        ("INVALID_TAXABLE_ENTITY_ID", NinoFormatError),
+        ("INVALID_CALCULATION_ID", CalculationIdFormatError),
+        ("INVAlID_CORRELATIONID", InternalError),
+        ("INVALID_RETURN", InternalError),
+        ("UNPROCESSABLE_ENTITY", InternalError),
+        ("NO_DATA_FOUND", NotFoundError),
+        ("SERVER_ERROR", InternalError),
+        ("SERVICE_UNAVAILABLE", InternalError)
+      )
+
+      val extraTysErrors = Seq(
+        ("INVALID_TAX_YEAR", TaxYearFormatError),
+        ("NOT_FOUND", NotFoundError),
+        ("TAX_YEAR_NOT_SUPPORTED", RuleTaxYearNotSupportedError)
+      )
+
+      (errors ++ extraTysErrors).foreach(args => (serviceError _).tupled(args))
+    }
+  }
+
+}

--- a/test/v5/retrieveUkPropertyBsas/validators/MockRetrieveUkPropertyBsasValidatorFactory.scala
+++ b/test/v5/retrieveUkPropertyBsas/validators/MockRetrieveUkPropertyBsasValidatorFactory.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.validators
+
+import org.scalamock.handlers.CallHandler
+import shared.controllers.validators.{MockValidatorFactory, Validator}
+import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyBsasRequestData
+import v5.retrieveUkPropertyBsas.schema.RetrieveUkPropertyBsasSchema
+
+trait MockRetrieveUkPropertyBsasValidatorFactory extends MockValidatorFactory[RetrieveUkPropertyBsasRequestData] {
+
+  val mockRetrieveUkPropertyBsasValidatorFactory: RetrieveUkPropertyBsasValidatorFactory = mock[RetrieveUkPropertyBsasValidatorFactory]
+
+  def validator(): CallHandler[Validator[RetrieveUkPropertyBsasRequestData]] =
+    (mockRetrieveUkPropertyBsasValidatorFactory
+      .validator(_: String, _: String, _: Option[String], _: RetrieveUkPropertyBsasSchema))
+      .expects(*, *, *, *)
+
+}

--- a/test/v5/retrieveUkPropertyBsas/validators/def1/Def1_RetrieveUkPropertyBsasValidatorFactorySpec.scala
+++ b/test/v5/retrieveUkPropertyBsas/validators/def1/Def1_RetrieveUkPropertyBsasValidatorFactorySpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.retrieveUkPropertyBsas.validators.def1
+
+import shared.UnitSpec
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.errors._
+import v5.retrieveUkPropertyBsas.models.def1.Def1_RetrieveUkPropertyBsasRequestData
+
+class Def1_RetrieveUkPropertyBsasValidatorFactorySpec extends UnitSpec {
+
+  private implicit val correlationId: String = "1234"
+
+  private val validNino          = "AA123456A"
+  private val validCalculationId = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c"
+  private val validTaxYear       = "2023-24"
+
+  private val parsedNino          = Nino(validNino)
+  private val parsedCalculationId = CalculationId(validCalculationId)
+  private val parsedTaxYear       = TaxYear.fromMtd(validTaxYear)
+
+  private def validator(nino: String, calculationId: String, taxYear: Option[String]) =
+    new Def1_RetrieveUkPropertyBsasValidator(nino, calculationId, taxYear)
+
+  "validator" should {
+    "return the parsed domain object" when {
+      "passed a valid request" in {
+        val result = validator(validNino, validCalculationId, None).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_RetrieveUkPropertyBsasRequestData(parsedNino, parsedCalculationId, None)
+        )
+      }
+
+      "passed a valid request with a tax year" in {
+        val result = validator(validNino, validCalculationId, Some(validTaxYear)).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_RetrieveUkPropertyBsasRequestData(parsedNino, parsedCalculationId, Some(parsedTaxYear))
+        )
+      }
+    }
+
+    "return a single error" when {
+      "passed an invalid nino" in {
+        val result = validator("A12344A", validCalculationId, None).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, NinoFormatError)
+        )
+      }
+
+      "passed an invalid calculation ID" in {
+        val result = validator(validNino, "12345", None).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, CalculationIdFormatError)
+        )
+      }
+    }
+
+    "return multiple errors" when {
+      "passed multiple invalid fields" in {
+        val result = validator("not-a-nino", "not-a-calculation-id", None).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            BadRequestError,
+            Some(List(CalculationIdFormatError, NinoFormatError))
+          )
+        )
+      }
+    }
+
+    "return InvalidTaxYearParameterError" when {
+      "passed an invalid taxYear (i.e. earlier than 2023-24)" in {
+        val result = validator(validNino, validCalculationId, Some("2022-23")).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, InvalidTaxYearParameterError)
+        )
+      }
+    }
+
+    "return TaxYearFormatError" when {
+      "passed an incorrectly formatted taxYear" in {
+        val result = validator(validNino, validCalculationId, Some("202324")).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, TaxYearFormatError)
+        )
+      }
+    }
+
+    "return RuleTaxYearRangeInvalidError" when {
+      "passed a tax year range of more than one year" in {
+        val result = validator(validNino, validCalculationId, Some("2022-24")).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleTaxYearRangeInvalidError)
+        )
+      }
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/connectors/MockSubmitForeignPropertyBsasConnector.scala
+++ b/test/v5/submitForeignPropertyBsas/connectors/MockSubmitForeignPropertyBsasConnector.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.connectors
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.connectors.DownstreamOutcome
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.submitForeignPropertyBsas.models.SubmitForeignPropertyBsasRequestData
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockSubmitForeignPropertyBsasConnector extends MockFactory {
+
+  val mockConnector: SubmitForeignPropertyBsasConnector = mock[SubmitForeignPropertyBsasConnector]
+
+  object MockSubmitForeignPropertyBsasConnector {
+
+    def submitForeignPropertyBsas(requestData: SubmitForeignPropertyBsasRequestData): CallHandler[Future[DownstreamOutcome[Unit]]] = {
+      (mockConnector
+        .submitForeignPropertyBsas(_: SubmitForeignPropertyBsasRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(requestData, *, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/connectors/SubmitForeignPropertyBsasConnectorSpec.scala
+++ b/test/v5/submitForeignPropertyBsas/connectors/SubmitForeignPropertyBsasConnectorSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.connectors
+
+import shared.connectors.{ConnectorSpec, DownstreamOutcome}
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.outcomes.ResponseWrapper
+import v5.submitForeignPropertyBsas.models.SubmitForeignPropertyBsasRequestData
+import v5.submitForeignPropertyBsas.models.def1.{Def1_SubmitForeignPropertyBsasRequestBody, Def1_SubmitForeignPropertyBsasRequestData}
+
+import scala.concurrent.Future
+
+class SubmitForeignPropertyBsasConnectorSpec extends ConnectorSpec {
+
+  private val nino          = Nino("AA123456A")
+  private val calculationId = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+
+  private val submitForeignPropertyBsasRequestBodyModel = Def1_SubmitForeignPropertyBsasRequestBody(None, None)
+
+  trait Test {
+    _: ConnectorTest =>
+    val connector: SubmitForeignPropertyBsasConnector = new SubmitForeignPropertyBsasConnector(http = mockHttpClient, appConfig = mockAppConfig)
+
+    def requestWith(taxYear: Option[TaxYear]): SubmitForeignPropertyBsasRequestData =
+      Def1_SubmitForeignPropertyBsasRequestData(nino, calculationId, taxYear, submitForeignPropertyBsasRequestBodyModel)
+
+  }
+
+  "submitBsas" must {
+
+    "post a SubmitBsasRequest body and return the result for a request without a tax year" in new IfsTest with Test {
+      val request: SubmitForeignPropertyBsasRequestData = requestWith(taxYear = None)
+      val outcome                                       = Right(ResponseWrapper(correlationId, ()))
+
+      willPut(url = s"$baseUrl/income-tax/adjustable-summary-calculation/$nino/$calculationId", body = submitForeignPropertyBsasRequestBodyModel)
+        .returns(Future.successful(outcome))
+
+      val result: DownstreamOutcome[Unit] = await(connector.submitForeignPropertyBsas(request))
+      result shouldBe outcome
+    }
+
+    "post a SubmitBsasRequest body and return the result for a pre-TYS tax year request" in new IfsTest with Test {
+      val request: SubmitForeignPropertyBsasRequestData = requestWith(Some(TaxYear.fromMtd("2022-23")))
+      val outcome                                       = Right(ResponseWrapper(correlationId, ()))
+
+      willPut(url = s"$baseUrl/income-tax/adjustable-summary-calculation/$nino/$calculationId", body = submitForeignPropertyBsasRequestBodyModel)
+        .returns(Future.successful(outcome))
+
+      val result: DownstreamOutcome[Unit] = await(connector.submitForeignPropertyBsas(request))
+      result shouldBe outcome
+    }
+
+    "post a SubmitBsasRequest body and return the result for a post-TYS tax year request" in new TysIfsTest with Test {
+      val request: SubmitForeignPropertyBsasRequestData = requestWith(Some(TaxYear.fromMtd("2023-24")))
+      val outcome                                       = Right(ResponseWrapper(correlationId, ()))
+
+      willPut(
+        url = s"$baseUrl/income-tax/adjustable-summary-calculation/23-24/$nino/$calculationId",
+        body = submitForeignPropertyBsasRequestBodyModel)
+        .returns(Future.successful(outcome))
+
+      val result: DownstreamOutcome[Unit] = await(connector.submitForeignPropertyBsas(request))
+      result shouldBe outcome
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/controllers/SubmitForeignPropertyBsasControllerSpec.scala
+++ b/test/v5/submitForeignPropertyBsas/controllers/SubmitForeignPropertyBsasControllerSpec.scala
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.controllers
+
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Result
+import shared.config.MockAppConfig
+import shared.controllers.{ControllerBaseSpec, ControllerTestRunner}
+import shared.hateoas.Method.GET
+import shared.hateoas.{HateoasWrapper, Link, MockHateoasFactory}
+import shared.models.audit.{AuditEvent, AuditResponse, GenericAuditDetail}
+import shared.models.domain.{CalculationId, TaxYear}
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.{MockAuditService, MockEnrolmentsAuthService, MockMtdIdLookupService}
+import shared.utils.MockIdGenerator
+import v5.models.errors._
+import v5.submitForeignPropertyBsas.models._
+import v5.submitForeignPropertyBsas.models.def1.{Def1_SubmitForeignPropertyBsasRequestBody, Def1_SubmitForeignPropertyBsasRequestData, ForeignProperty, ForeignPropertyExpenses, ForeignPropertyIncome}
+import v5.submitForeignPropertyBsas.services.MockSubmitForeignPropertyBsasService
+import v5.submitForeignPropertyBsas.validators.MockSubmitForeignPropertyBsasValidatorFactory
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class SubmitForeignPropertyBsasControllerSpec
+    extends ControllerBaseSpec
+    with ControllerTestRunner
+    with MockEnrolmentsAuthService
+    with MockMtdIdLookupService
+    with MockSubmitForeignPropertyBsasValidatorFactory
+    with MockSubmitForeignPropertyBsasService
+    with MockHateoasFactory
+    with MockAuditService
+    with MockIdGenerator
+    with MockAppConfig {
+
+  private val calculationId = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+  private val rawTaxYear    = "2023-24"
+  private val taxYear       = TaxYear.fromMtd(rawTaxYear)
+
+  private val testHateoasLink =
+    Link(href = s"individuals/self-assessment/adjustable-summary/$validNino/foreign-property/$calculationId/adjust", method = GET, rel = "self")
+
+  private val requestJson = Json.parse(
+    """|{
+       |    "foreignProperty": {
+       |        "income": {
+       |            "rentIncome": 123.12,
+       |            "premiumsOfLeaseGrant": 123.12,
+       |            "otherPropertyIncome": 123.12
+       |        },
+       |        "expenses": {
+       |            "premisesRunningCosts": 123.12,
+       |            "repairsAndMaintenance": 123.12,
+       |            "financialCosts": 123.12,
+       |            "professionalFees": 123.12,
+       |            "travelCosts": 123.12,
+       |            "costOfServices": 123.12,
+       |            "residentialFinancialCost": 123.12,
+       |            "other": 123.12
+       |        }
+       |    }
+       |}
+       |""".stripMargin
+  )
+
+  private val foreignProperty: ForeignProperty =
+    ForeignProperty(
+      "FRA",
+      Some(ForeignPropertyIncome(Some(123.12), Some(123.12), Some(123.12))),
+      Some(
+        ForeignPropertyExpenses(
+          Some(123.12),
+          Some(123.12),
+          Some(123.12),
+          Some(123.12),
+          Some(123.12),
+          Some(123.12),
+          Some(123.12),
+          Some(123.12),
+          None
+        ))
+    )
+
+  val requestBody: Def1_SubmitForeignPropertyBsasRequestBody =
+    Def1_SubmitForeignPropertyBsasRequestBody(Some(List(foreignProperty)), None)
+
+  private val requestData =
+    Def1_SubmitForeignPropertyBsasRequestData(parsedNino, calculationId, Some(taxYear), requestBody)
+
+  val mtdResponseJson: JsValue = Json.parse(s"""
+       |{
+       |  "links":[
+       |    {
+       |      "href":"individuals/self-assessment/adjustable-summary/$validNino/foreign-property/$calculationId/adjust",
+       |      "rel":"self",
+       |      "method":"GET"
+       |    }
+       |  ]
+       |}
+       |""".stripMargin)
+
+  "handleRequest" should {
+    "return OK" when {
+      "the request is valid" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockSubmitForeignPropertyBsasService
+          .submitForeignPropertyBsas(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
+
+        MockHateoasFactory
+          .wrap((), SubmitForeignPropertyBsasHateoasData(validNino, calculationId.calculationId, requestData.taxYear))
+          .returns(HateoasWrapper((), List(testHateoasLink)))
+
+        runOkTestWithAudit(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(mtdResponseJson),
+          maybeAuditRequestBody = Some(requestJson),
+          maybeAuditResponseBody = Some(mtdResponseJson)
+        )
+      }
+    }
+
+    "return the error as per spec" when {
+      "the parser validation fails" in new Test {
+        willUseValidator(returning(NinoFormatError))
+        runErrorTestWithAudit(NinoFormatError, maybeAuditRequestBody = Some(requestJson))
+      }
+
+      "the service returns an error" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockSubmitForeignPropertyBsasService
+          .submitForeignPropertyBsas(requestData)
+          .returns(Future.successful(Left(ErrorWrapper(correlationId, RuleSummaryStatusSuperseded))))
+
+        runErrorTestWithAudit(RuleSummaryStatusSuperseded, maybeAuditRequestBody = Some(requestJson))
+      }
+    }
+  }
+
+  private trait Test extends ControllerTest with AuditEventChecking {
+
+    val controller = new SubmitForeignPropertyBsasController(
+      authService = mockEnrolmentsAuthService,
+      lookupService = mockMtdIdLookupService,
+      validatorFactory = mockSubmitForeignPropertyBsasValidatorFactory,
+      service = mockService,
+      hateoasFactory = mockHateoasFactory,
+      auditService = mockAuditService,
+      cc = cc,
+      idGenerator = mockIdGenerator
+    )
+
+    override protected def callController(): Future[Result] =
+      controller.handleRequest(validNino, calculationId.calculationId, Some(rawTaxYear))(fakePostRequest(requestJson))
+
+    override protected def event(auditResponse: AuditResponse, maybeRequestBody: Option[JsValue]): AuditEvent[GenericAuditDetail] =
+      AuditEvent(
+        auditType = "SubmitForeignPropertyAccountingAdjustments",
+        transactionName = "submit-foreign-property-accounting-adjustments",
+        detail = GenericAuditDetail(
+          versionNumber = apiVersion.name,
+          userType = "Individual",
+          agentReferenceNumber = None,
+          params = Map("nino" -> validNino, "calculationId" -> calculationId.calculationId),
+          requestBody = maybeRequestBody,
+          `X-CorrelationId` = correlationId,
+          auditResponse = auditResponse
+        )
+      )
+
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/fixtures/def1/SubmitForeignPropertyBsasFixtures.scala
+++ b/test/v5/submitForeignPropertyBsas/fixtures/def1/SubmitForeignPropertyBsasFixtures.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.fixtures.def1
+
+import play.api.libs.json.{JsValue, Json}
+import v5.submitForeignPropertyBsas.models.def1._
+
+object SubmitForeignPropertyBsasFixtures {
+
+  val mtdRequestNonFhlFull: JsValue = Json.parse("""
+      |{
+      |   "nonFurnishedHolidayLet":  [
+      |       {
+      |          "countryCode": "FRA",
+      |          "income": {
+      |              "totalRentsReceived": 1.12,
+      |              "premiumsOfLeaseGrant": 2.12,
+      |              "otherPropertyIncome": 3.12
+      |          },
+      |          "expenses": {
+      |              "consolidatedExpenses": 4.12,
+      |              "premisesRunningCosts": 5.12,
+      |              "repairsAndMaintenance": 6.12,
+      |              "financialCosts": 7.12,
+      |              "professionalFees": 8.12,
+      |              "costOfServices": 9.12,
+      |              "residentialFinancialCost": 10.12,
+      |              "other": 11.12,
+      |              "travelCosts": 12.12
+      |          }
+      |       }
+      |    ]
+      |}
+      |""".stripMargin)
+
+  val downstreamRequestNonFhlFull: JsValue = Json.parse("""
+      |{
+      |   "incomeSourceType": "15",
+      |   "adjustments":  [
+      |       {
+      |          "countryCode": "FRA",
+      |          "income": {
+      |              "rent": 1.12,
+      |              "premiumsOfLeaseGrant": 2.12,
+      |              "otherPropertyIncome": 3.12
+      |          },
+      |          "expenses": {
+      |              "consolidatedExpenses": 4.12,
+      |              "premisesRunningCosts": 5.12,
+      |              "repairsAndMaintenance": 6.12,
+      |              "financialCosts": 7.12,
+      |              "professionalFees": 8.12,
+      |              "costOfServices": 9.12,
+      |              "residentialFinancialCost": 10.12,
+      |              "other": 11.12,
+      |              "travelCosts": 12.12
+      |          }
+      |       }
+      |    ]
+      |}
+      |""".stripMargin)
+
+  val requestNonFhlFullModel: Def1_SubmitForeignPropertyBsasRequestBody = Def1_SubmitForeignPropertyBsasRequestBody(
+    nonFurnishedHolidayLet = Some(
+      Seq(
+        ForeignProperty(
+          countryCode = "FRA",
+          income = Some(
+            ForeignPropertyIncome(
+              totalRentsReceived = Some(1.12),
+              premiumsOfLeaseGrant = Some(2.12),
+              otherPropertyIncome = Some(3.12)
+            )),
+          expenses = Some(ForeignPropertyExpenses(
+            consolidatedExpenses = Some(4.12),
+            premisesRunningCosts = Some(5.12),
+            repairsAndMaintenance = Some(6.12),
+            financialCosts = Some(7.12),
+            professionalFees = Some(8.12),
+            costOfServices = Some(9.12),
+            residentialFinancialCost = Some(10.12),
+            other = Some(11.12),
+            travelCosts = Some(12.12)
+          ))
+        )
+      )),
+    foreignFhlEea = None
+  )
+
+  val mtdRequestFhlFull: JsValue = Json.parse("""
+      |{
+      |   "foreignFhlEea": {
+      |      "income": {
+      |         "totalRentsReceived": 1.12
+      |      },
+      |      "expenses": {
+      |         "consolidatedExpenses": 2.12,
+      |         "premisesRunningCosts": 3.12,
+      |         "repairsAndMaintenance": 4.12,
+      |         "financialCosts": 5.12,
+      |         "professionalFees": 6.12,
+      |         "costOfServices": 7.12,
+      |         "other": 8.12,
+      |         "travelCosts": 9.12
+      |      }
+      |   }
+      |}
+      |""".stripMargin)
+
+  val downstreamRequestFhlFull: JsValue = Json.parse("""
+      |{
+      |   "incomeSourceType": "03",
+      |   "adjustments": {
+      |      "income": {
+      |         "rentAmount": 1.12
+      |      },
+      |      "expenses": {
+      |         "consolidatedExpenses": 2.12,
+      |         "premisesRunningCosts": 3.12,
+      |         "repairsAndMaintenance": 4.12,
+      |         "financialCosts": 5.12,
+      |         "professionalFees": 6.12,
+      |         "costOfServices": 7.12,
+      |         "other": 8.12,
+      |         "travelCosts": 9.12
+      |      }
+      |   }
+      |}
+      |""".stripMargin)
+
+  val requestFhlFullModel: Def1_SubmitForeignPropertyBsasRequestBody = Def1_SubmitForeignPropertyBsasRequestBody(
+    nonFurnishedHolidayLet = None,
+    foreignFhlEea = Some(
+      FhlEea(
+        income = Some(
+          FhlIncome(
+            totalRentsReceived = Some(1.12)
+          )),
+        expenses = Some(
+          FhlEeaExpenses(
+            consolidatedExpenses = Some(2.12),
+            premisesRunningCosts = Some(3.12),
+            repairsAndMaintenance = Some(4.12),
+            financialCosts = Some(5.12),
+            professionalFees = Some(6.12),
+            costOfServices = Some(7.12),
+            other = Some(8.12),
+            travelCosts = Some(9.12)
+          ))
+      )
+    )
+  )
+
+  val mtdRequestValid: JsValue = Json.parse("""
+      |{
+      |   "foreignFhlEea": {
+      |      "income": {
+      |         "totalRentsReceived": 1.12
+      |      },
+      |      "expenses": {
+      |         "premisesRunningCosts": 3.12,
+      |         "repairsAndMaintenance": 4.12,
+      |         "financialCosts": 5.12,
+      |         "professionalFees": 6.12,
+      |         "costOfServices": 7.12,
+      |         "other": 8.12,
+      |         "travelCosts": 9.12
+      |      }
+      |   }
+      |}
+      |""".stripMargin)
+
+  val downstreamRequestValid: JsValue = Json.parse("""
+      |{
+      |   "incomeSourceType": "03",
+      |   "adjustments": {
+      |      "income": {
+      |         "rentAmount": 1.12
+      |      },
+      |      "expenses": {
+      |         "premisesRunningCosts": 3.12,
+      |         "repairsAndMaintenance": 4.12,
+      |         "financialCosts": 5.12,
+      |         "professionalFees": 6.12,
+      |         "costOfServices": 7.12,
+      |         "other": 8.12,
+      |         "travelCosts": 9.12
+      |      }
+      |   }
+      |}
+      |""".stripMargin)
+
+}

--- a/test/v5/submitForeignPropertyBsas/models/SubmitForeignPropertyBsasHateoasDataSpec.scala
+++ b/test/v5/submitForeignPropertyBsas/models/SubmitForeignPropertyBsasHateoasDataSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models
+
+import play.api.Configuration
+import shared.UnitSpec
+import shared.config.MockAppConfig
+import shared.hateoas.Link
+import shared.hateoas.Method.GET
+import shared.models.domain.TaxYear
+
+class SubmitForeignPropertyBsasHateoasDataSpec extends UnitSpec with MockAppConfig {
+
+  class Test extends MockAppConfig {
+    val nino    = "someNino"
+    val bsasId  = "anId"
+    val taxYear = Some(TaxYear.fromMtd("2023-24"))
+    val context = "individuals/self-assessment/adjustable-summary"
+
+    MockAppConfig.apiGatewayContext.returns(context).anyNumberOfTimes()
+  }
+
+  class TysDisabledTest extends Test {
+    MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> false)).anyNumberOfTimes()
+  }
+
+  class TysEnabledTest extends Test {
+    MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> true)).anyNumberOfTimes()
+  }
+
+  "LinksFactory" should {
+    "return the correct links without tax year" in new TysDisabledTest {
+      private val data         = SubmitForeignPropertyBsasHateoasData(nino, bsasId, None)
+      private val result       = SubmitForeignPropertyBsasHateoasData.SubmitForeignPropertyAdjustmentHateoasFactory.links(mockAppConfig, data)
+      private val expectedLink = Link(s"/$context/$nino/foreign-property/$bsasId", GET, "self")
+
+      result shouldBe Seq(expectedLink)
+    }
+
+    "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+      private val data         = SubmitForeignPropertyBsasHateoasData(nino, bsasId, taxYear)
+      private val result       = SubmitForeignPropertyBsasHateoasData.SubmitForeignPropertyAdjustmentHateoasFactory.links(mockAppConfig, data)
+      private val expectedLink = Link(s"/$context/$nino/foreign-property/$bsasId?taxYear=2023-24", GET, "self")
+
+      result shouldBe Seq(expectedLink)
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/models/def1/Def1_SubmitForeignPropertyBsasRequestBodySpec.scala
+++ b/test/v5/submitForeignPropertyBsas/models/def1/Def1_SubmitForeignPropertyBsasRequestBodySpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, Json}
+import shared.UnitSpec
+import v5.submitForeignPropertyBsas.fixtures.def1.SubmitForeignPropertyBsasFixtures._
+
+class Def1_SubmitForeignPropertyBsasRequestBodySpec extends UnitSpec {
+
+  val emptyModel: Def1_SubmitForeignPropertyBsasRequestBody = Def1_SubmitForeignPropertyBsasRequestBody(None, None)
+
+  val nonFhlModel: Def1_SubmitForeignPropertyBsasRequestBody = Def1_SubmitForeignPropertyBsasRequestBody(Some(Seq(ForeignProperty("FRA", None, None))), None)
+
+  val fhlModel: Def1_SubmitForeignPropertyBsasRequestBody = Def1_SubmitForeignPropertyBsasRequestBody(None, Some(FhlEea(None, None)))
+
+  "reads" when {
+    "reading a simple non-fhl body" should {
+      "return the expected non-fhl model" in {
+        Json
+          .parse("""
+            |{
+            |  "nonFurnishedHolidayLet": [
+            |    {
+            |      "countryCode": "FRA"
+            |    }
+            |  ]
+            |}
+            |""".stripMargin)
+          .as[Def1_SubmitForeignPropertyBsasRequestBody] shouldBe nonFhlModel
+      }
+    }
+
+    "reading a simple fhl body" should {
+      "return the expected fhl model" in {
+        Json
+          .parse(
+            """
+            |{
+            |  "foreignFhlEea": {
+            |  }
+            |}
+            |""".stripMargin
+          )
+          .as[Def1_SubmitForeignPropertyBsasRequestBody] shouldBe fhlModel
+      }
+    }
+
+    "reading a full non-fhl body" should {
+      "return the expected non-fhl model" in {
+        mtdRequestNonFhlFull.as[Def1_SubmitForeignPropertyBsasRequestBody] shouldBe requestNonFhlFullModel
+      }
+    }
+
+    "reading a full fhl body" should {
+      "return the expected fhl model" in {
+        mtdRequestFhlFull.as[Def1_SubmitForeignPropertyBsasRequestBody] shouldBe requestFhlFullModel
+      }
+    }
+
+    "reading an empty body" should {
+      "return an empty model" in {
+        JsObject.empty.as[Def1_SubmitForeignPropertyBsasRequestBody] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "writing a simple non-fhl model" should {
+      "return the downstream JSON" in {
+        Json.toJson(nonFhlModel) shouldBe Json.parse("""
+            |{
+            |  "incomeSourceType": "15",
+            |  "adjustments": [
+            |    {
+            |      "countryCode": "FRA"
+            |    }
+            |  ]
+            |}
+            |""".stripMargin)
+      }
+    }
+
+    "writing a simple fhl model" should {
+      "return the downstream JSON" in {
+        Json.toJson(fhlModel) shouldBe Json.parse(
+          """
+            |{
+            |  "incomeSourceType": "03",
+            |  "adjustments": {
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+    }
+
+    "writing a full non-fhl model" should {
+      "return the downstream JSON" in {
+        Json.toJson(requestNonFhlFullModel) shouldBe downstreamRequestNonFhlFull
+      }
+    }
+
+    "writing a full fhl model" should {
+      "return the downstream JSON" in {
+        Json.toJson(requestFhlFullModel) shouldBe downstreamRequestFhlFull
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/models/def1/FhlEeaExpensesSpec.scala
+++ b/test/v5/submitForeignPropertyBsas/models/def1/FhlEeaExpensesSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import shared.UnitSpec
+
+class FhlEeaExpensesSpec extends UnitSpec {
+
+  val json: JsValue = Json.parse("""
+      |{
+      |  "premisesRunningCosts": 1.12,
+      |  "repairsAndMaintenance": 2.12,
+      |  "financialCosts": 3.12,
+      |  "professionalFees": 4.12,
+      |  "travelCosts": 5.12,
+      |  "costOfServices": 6.12,
+      |  "other": 7.12,
+      |  "consolidatedExpenses": 8.12
+      |}
+      |""".stripMargin)
+
+  val model: FhlEeaExpenses = FhlEeaExpenses(
+    premisesRunningCosts = Some(1.12),
+    repairsAndMaintenance = Some(2.12),
+    financialCosts = Some(3.12),
+    professionalFees = Some(4.12),
+    travelCosts = Some(5.12),
+    costOfServices = Some(6.12),
+    other = Some(7.12),
+    consolidatedExpenses = Some(8.12)
+  )
+
+  val emptyModel: FhlEeaExpenses = FhlEeaExpenses(None, None, None, None, None, None, None, None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        json.as[FhlEeaExpenses] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        JsObject.empty.as[FhlEeaExpenses] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe json
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/models/def1/FhlEeaSpec.scala
+++ b/test/v5/submitForeignPropertyBsas/models/def1/FhlEeaSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import shared.UnitSpec
+
+class FhlEeaSpec extends UnitSpec {
+
+  // Use simple case as formats for contents of income/expenses are tested elsewhere...
+  val json: JsValue = Json.parse("""
+      |{
+      |  "income": {
+      |  },
+      |  "expenses": {
+      |  }
+      |}
+      |""".stripMargin)
+
+  val model: FhlEea = FhlEea(
+    Some(FhlIncome(None)),
+    Some(FhlEeaExpenses(None, None, None, None, None, None, None, None))
+  )
+
+  val emptyModel: FhlEea = FhlEea(None, None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        json.as[FhlEea] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        JsObject.empty.as[FhlEea] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe json
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/models/def1/FhlIncomeSpec.scala
+++ b/test/v5/submitForeignPropertyBsas/models/def1/FhlIncomeSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, Json}
+import shared.UnitSpec
+
+class FhlIncomeSpec extends UnitSpec {
+
+  val model: FhlIncome = FhlIncome(Some(123.12))
+
+  val emptyModel: FhlIncome = FhlIncome(None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        Json
+          .parse("""
+              |{
+              |   "totalRentsReceived": 123.12
+              |}
+              |""".stripMargin)
+          .as[FhlIncome] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        JsObject.empty.as[FhlIncome] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe
+          Json.parse("""
+              |{
+              |   "rentAmount": 123.12
+              |}
+              |""".stripMargin)
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/models/def1/ForeignPropertyExpensesSpec.scala
+++ b/test/v5/submitForeignPropertyBsas/models/def1/ForeignPropertyExpensesSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, Json}
+import shared.UnitSpec
+
+class ForeignPropertyExpensesSpec extends UnitSpec {
+
+  val model: ForeignPropertyExpenses = ForeignPropertyExpenses(
+    premisesRunningCosts = Some(1.12),
+    repairsAndMaintenance = Some(2.12),
+    financialCosts = Some(3.12),
+    professionalFees = Some(4.12),
+    travelCosts = Some(5.12),
+    costOfServices = Some(6.12),
+    residentialFinancialCost = Some(7.12),
+    other = Some(8.12),
+    consolidatedExpenses = Some(9.12)
+  )
+
+  val emptyModel: ForeignPropertyExpenses = ForeignPropertyExpenses(None, None, None, None, None, None, None, None, None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        Json
+          .parse("""
+            |{
+            |  "premisesRunningCosts": 1.12,
+            |  "repairsAndMaintenance": 2.12,
+            |  "financialCosts": 3.12,
+            |  "professionalFees": 4.12,
+            |  "travelCosts": 5.12,
+            |  "costOfServices": 6.12,
+            |  "residentialFinancialCost": 7.12,
+            |  "other": 8.12,
+            |  "consolidatedExpenses": 9.12
+            |}
+            |""".stripMargin)
+          .as[ForeignPropertyExpenses] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        JsObject.empty.as[ForeignPropertyExpenses] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe Json.parse("""
+            |{
+            |  "premisesRunningCosts": 1.12,
+            |  "repairsAndMaintenance": 2.12,
+            |  "financialCosts": 3.12,
+            |  "professionalFees": 4.12,
+            |  "travelCosts": 5.12,
+            |  "costOfServices": 6.12,
+            |  "residentialFinancialCost": 7.12,
+            |  "other": 8.12,
+            |  "consolidatedExpenses": 9.12
+            |}
+            |""".stripMargin)
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/models/def1/ForeignPropertyIncomeSpec.scala
+++ b/test/v5/submitForeignPropertyBsas/models/def1/ForeignPropertyIncomeSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, Json}
+import shared.UnitSpec
+
+class ForeignPropertyIncomeSpec extends UnitSpec {
+
+  val model: ForeignPropertyIncome =
+    ForeignPropertyIncome(totalRentsReceived = Some(1.12), premiumsOfLeaseGrant = Some(2.12), otherPropertyIncome = Some(3.12))
+
+  val emptyModel: ForeignPropertyIncome = ForeignPropertyIncome(None, None, None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        Json
+          .parse("""
+              |{
+              |   "totalRentsReceived": 1.12,
+              |   "premiumsOfLeaseGrant": 2.12,
+              |   "otherPropertyIncome": 3.12
+              |}
+              |""".stripMargin)
+          .as[ForeignPropertyIncome] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        JsObject.empty.as[ForeignPropertyIncome] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe
+          Json.parse("""
+              |{
+              |   "rent": 1.12,
+              |   "premiumsOfLeaseGrant": 2.12,
+              |   "otherPropertyIncome": 3.12
+              |}
+              |""".stripMargin)
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/models/def1/ForeignPropertySpec.scala
+++ b/test/v5/submitForeignPropertyBsas/models/def1/ForeignPropertySpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.models.def1
+
+import play.api.libs.json.{JsValue, Json}
+import shared.UnitSpec
+
+class ForeignPropertySpec extends UnitSpec {
+
+  // Use simple case as formats for contents of income/expenses are tested elsewhere...
+  val json: JsValue = Json.parse("""
+      |{
+      |  "countryCode": "FRA",
+      |  "income": {
+      |  },
+      |  "expenses": {
+      |  }
+      |}
+      |""".stripMargin)
+
+  val minimalJson: JsValue = Json.parse("""{
+      |  "countryCode": "FRA"
+      |}""".stripMargin)
+
+  val model: ForeignProperty = ForeignProperty(
+    "FRA",
+    Some(ForeignPropertyIncome(None, None, None)),
+    Some(ForeignPropertyExpenses(None, None, None, None, None, None, None, None, None))
+  )
+
+  val minimalModel: ForeignProperty = ForeignProperty("FRA", None, None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        json.as[ForeignProperty] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        minimalJson.as[ForeignProperty] shouldBe minimalModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe json
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(minimalModel) shouldBe minimalJson
+      }
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/schema/SubmitForeignPropertyBsasSchemaSpec.scala
+++ b/test/v5/submitForeignPropertyBsas/schema/SubmitForeignPropertyBsasSchemaSpec.scala
@@ -20,25 +20,19 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import shared.UnitSpec
 import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
 
-import scala.math.Ordered.orderingToOrdered
-
 class SubmitForeignPropertyBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
 
   "schema lookup" when {
     "a tax year is present" must {
       "use Def1 for tax years from 2023-24" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
-            SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitForeignPropertyBsasSchema.Def1
-          }
+        forTaxYearsFrom(TaxYear.fromMtd("2023-24")) { taxYear =>
+          SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitForeignPropertyBsasSchema.Def1
         }
       }
 
-      "use Def1 for other tax years" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
-            SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitForeignPropertyBsasSchema.Def1
-          }
+      "use Def1 for pre-TYS tax years" in {
+        forPreTysTaxYears { taxYear =>
+          SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitForeignPropertyBsasSchema.Def1
         }
       }
     }

--- a/test/v5/submitForeignPropertyBsas/schema/SubmitForeignPropertyBsasSchemaSpec.scala
+++ b/test/v5/submitForeignPropertyBsas/schema/SubmitForeignPropertyBsasSchemaSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.schema
+
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import shared.UnitSpec
+import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+
+import scala.math.Ordered.orderingToOrdered
+
+class SubmitForeignPropertyBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
+
+  "schema lookup" when {
+    "a tax year is present" must {
+      "use Def1 for tax years from 2023-24" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
+            SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitForeignPropertyBsasSchema.Def1
+          }
+        }
+      }
+
+      "use Def1 for other tax years" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
+            SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitForeignPropertyBsasSchema.Def1
+          }
+        }
+      }
+    }
+
+    "the tax year is present but not valid" must {
+      "use a default of Def1" in {
+        SubmitForeignPropertyBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe SubmitForeignPropertyBsasSchema.Def1
+      }
+    }
+
+    "no tax year is present" must {
+      "use a default of Def1" in {
+        SubmitForeignPropertyBsasSchema.schemaFor(None) shouldBe SubmitForeignPropertyBsasSchema.Def1
+      }
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/services/MockSubmitForeignPropertyBsasService.scala
+++ b/test/v5/submitForeignPropertyBsas/services/MockSubmitForeignPropertyBsasService.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.services
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.controllers.RequestContext
+import shared.services.ServiceOutcome
+import v5.submitForeignPropertyBsas.models.SubmitForeignPropertyBsasRequestData
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockSubmitForeignPropertyBsasService extends MockFactory {
+
+  val mockService: SubmitForeignPropertyBsasService = mock[SubmitForeignPropertyBsasService]
+
+  object MockSubmitForeignPropertyBsasService {
+
+    def submitForeignPropertyBsas(requestData: SubmitForeignPropertyBsasRequestData): CallHandler[Future[ServiceOutcome[Unit]]] = {
+      (mockService
+        .submitForeignPropertyBsas(_: SubmitForeignPropertyBsasRequestData)(_: RequestContext, _: ExecutionContext))
+        .expects(requestData, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/services/SubmitForeignPropertyBsasServiceSpec.scala
+++ b/test/v5/submitForeignPropertyBsas/services/SubmitForeignPropertyBsasServiceSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.services
+
+import shared.controllers.EndpointLogContext
+import shared.models.domain.{CalculationId, Nino}
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.ServiceSpec
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.models.errors._
+import v5.submitForeignPropertyBsas.connectors.MockSubmitForeignPropertyBsasConnector
+import v5.submitForeignPropertyBsas.models.def1._
+
+import scala.concurrent.Future
+
+class SubmitForeignPropertyBsasServiceSpec extends ServiceSpec {
+
+  private val nino = Nino("AA123456A")
+  private val id   = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+
+  private val fhlEeaBody =
+    Def1_SubmitForeignPropertyBsasRequestBody(
+      nonFurnishedHolidayLet = None,
+      foreignFhlEea = Some(
+        FhlEea(
+          Some(
+            FhlIncome(
+              Some(123.12)
+            )),
+          Some(
+            FhlEeaExpenses(
+              Some(123.12),
+              Some(123.12),
+              Some(123.12),
+              Some(123.12),
+              Some(123.12),
+              Some(123.12),
+              Some(123.12),
+              consolidatedExpenses = None
+            ))
+        ))
+    )
+
+  private val request = Def1_SubmitForeignPropertyBsasRequestData(nino, id, None, fhlEeaBody)
+
+  trait Test extends MockSubmitForeignPropertyBsasConnector {
+    implicit val hc: HeaderCarrier              = HeaderCarrier()
+    implicit val logContext: EndpointLogContext = EndpointLogContext("controller", "submitForeignPropertyBsas")
+
+    val service = new SubmitForeignPropertyBsasService(mockConnector)
+  }
+
+  "submitForeignPropertyBsas" should {
+    "return a valid response" when {
+      "a valid request is supplied" in new Test {
+        MockSubmitForeignPropertyBsasConnector
+          .submitForeignPropertyBsas(request)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
+
+        await(service.submitForeignPropertyBsas(request)) shouldBe Right(ResponseWrapper(correlationId, ()))
+      }
+    }
+
+    "return error response" when {
+
+      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
+        s"a $downstreamErrorCode error is returned from the service" in new Test {
+
+          MockSubmitForeignPropertyBsasConnector
+            .submitForeignPropertyBsas(request)
+            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+
+          await(service.submitForeignPropertyBsas(request)) shouldBe Left(ErrorWrapper(correlationId, error))
+        }
+
+      val errors = Seq(
+        ("INVALID_TAXABLE_ENTITY_ID", NinoFormatError),
+        ("INVALID_CALCULATION_ID", CalculationIdFormatError),
+        ("INVALID_CORRELATIONID", InternalError),
+        ("INVALID_PAYLOAD", InternalError),
+        ("BVR_FAILURE_C15320", InternalError),
+        ("BVR_FAILURE_C55508", InternalError),
+        ("BVR_FAILURE_C55509", InternalError),
+        ("BVR_FAILURE_C559107", RulePropertyIncomeAllowanceClaimed),
+        ("BVR_FAILURE_C559103", RulePropertyIncomeAllowanceClaimed),
+        ("BVR_FAILURE_C559099", RuleOverConsolidatedExpensesThreshold),
+        ("BVR_FAILURE_C55503", InternalError),
+        ("BVR_FAILURE_C55316", InternalError),
+        ("NO_DATA_FOUND", NotFoundError),
+        ("ASC_ALREADY_SUPERSEDED", RuleSummaryStatusSuperseded),
+        ("ASC_ALREADY_ADJUSTED", RuleAlreadyAdjusted),
+        ("UNALLOWABLE_VALUE", RuleResultingValueNotPermitted),
+        ("ASC_ID_INVALID", RuleSummaryStatusInvalid),
+        ("INCOMESOURCE_TYPE_NOT_MATCHED", RuleTypeOfBusinessIncorrectError),
+        ("SERVER_ERROR", InternalError),
+        ("SERVICE_UNAVAILABLE", InternalError)
+      )
+
+      val extraTysErrors = Seq(
+        ("INVALID_TAX_YEAR", TaxYearFormatError),
+        ("NOT_FOUND", NotFoundError),
+        ("TAX_YEAR_NOT_SUPPORTED", RuleTaxYearNotSupportedError),
+        ("INCOME_SOURCE_TYPE_NOT_MATCHED", RuleTypeOfBusinessIncorrectError)
+      )
+
+      (errors ++ extraTysErrors).foreach(args => (serviceError _).tupled(args))
+    }
+  }
+
+}

--- a/test/v5/submitForeignPropertyBsas/validators/MockSubmitForeignPropertyBsasValidatorFactory.scala
+++ b/test/v5/submitForeignPropertyBsas/validators/MockSubmitForeignPropertyBsasValidatorFactory.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.validators
+
+import org.scalamock.handlers.CallHandler
+import play.api.libs.json.JsValue
+import shared.controllers.validators.{MockValidatorFactory, Validator}
+import v5.submitForeignPropertyBsas.models.SubmitForeignPropertyBsasRequestData
+import v5.submitForeignPropertyBsas.schema.SubmitForeignPropertyBsasSchema
+
+trait MockSubmitForeignPropertyBsasValidatorFactory extends MockValidatorFactory[SubmitForeignPropertyBsasRequestData] {
+
+  val mockSubmitForeignPropertyBsasValidatorFactory: SubmitForeignPropertyBsasValidatorFactory = mock[SubmitForeignPropertyBsasValidatorFactory]
+
+  def validator(): CallHandler[Validator[SubmitForeignPropertyBsasRequestData]] =
+    (mockSubmitForeignPropertyBsasValidatorFactory
+      .validator(_: String, _: String, _: Option[String], _: JsValue, _: SubmitForeignPropertyBsasSchema))
+      .expects(*, *, *, *, *)
+
+}

--- a/test/v5/submitForeignPropertyBsas/validators/def1/Def1_SubmitForeignPropertyBsasValidatorFactorySpec.scala
+++ b/test/v5/submitForeignPropertyBsas/validators/def1/Def1_SubmitForeignPropertyBsasValidatorFactorySpec.scala
@@ -279,6 +279,7 @@ class Def1_SubmitForeignPropertyBsasValidatorFactorySpec extends UnitSpec with J
       }
 
       "passed both fhl and non-fhl even if they are empty" in {
+        // Note: no other errors should be returned
         val body = Json.parse(
           s"""
                |{
@@ -290,15 +291,7 @@ class Def1_SubmitForeignPropertyBsasValidatorFactorySpec extends UnitSpec with J
         val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
 
         result shouldBe Left(
-          ErrorWrapper(
-            correlationId,
-            BadRequestError,
-            Some(
-              List(
-                RuleBothPropertiesSuppliedError,
-                RuleIncorrectOrEmptyBodyError.withPaths(List("/nonFurnishedHolidayLet", "/foreignFhlEea"))
-              ))
-          )
+          ErrorWrapper(correlationId, RuleBothPropertiesSuppliedError)
         )
       }
     }

--- a/test/v5/submitForeignPropertyBsas/validators/def1/Def1_SubmitForeignPropertyBsasValidatorFactorySpec.scala
+++ b/test/v5/submitForeignPropertyBsas/validators/def1/Def1_SubmitForeignPropertyBsasValidatorFactorySpec.scala
@@ -1,0 +1,546 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitForeignPropertyBsas.validators.def1
+
+import play.api.libs.json._
+import shared.UnitSpec
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.errors._
+import shared.models.utils.JsonErrorValidators
+import v5.models.errors.{RuleBothExpensesError, RuleBothPropertiesSuppliedError, RuleDuplicateCountryCodeError}
+import v5.submitForeignPropertyBsas.models.def1.{Def1_SubmitForeignPropertyBsasRequestBody, Def1_SubmitForeignPropertyBsasRequestData}
+
+class Def1_SubmitForeignPropertyBsasValidatorFactorySpec extends UnitSpec with JsonErrorValidators {
+
+  private implicit val correlationId: String = "1234"
+
+  private val validNino          = "AA123456A"
+  private val validCalculationId = "a54ba782-5ef4-47f4-ab72-495406665ca9"
+  private val validTaxYear       = "2023-24"
+
+  private val parsedNino          = Nino(validNino)
+  private val parsedCalculationId = CalculationId(validCalculationId)
+  private val parsedTaxYear       = TaxYear.fromMtd(validTaxYear)
+
+  private def entryWith(countryCode: String) =
+    Json.parse(s"""
+      |{
+      |  "countryCode": "$countryCode",
+      |  "income": {
+      |    "totalRentsReceived": 1000.45,
+      |    "premiumsOfLeaseGrant": -99.99,
+      |    "otherPropertyIncome": 1000.00
+      |  },
+      |  "expenses": {
+      |    "premisesRunningCosts": 1000.45,
+      |    "repairsAndMaintenance": -99999.99,
+      |    "financialCosts": 5000.45,
+      |    "professionalFees": 300.99,
+      |    "costOfServices": 500.00,
+      |    "residentialFinancialCost": 9000.00,
+      |    "other": 1000.00,
+      |    "travelCosts": 99.99
+      |  }
+      |}""".stripMargin)
+
+  private val entry = entryWith(countryCode = "AFG")
+
+  private val entryConsolidated =
+    Json.parse("""
+      |{
+      |  "countryCode": "AFG",
+      |  "income": {
+      |    "totalRentsReceived": 1000.45,
+      |    "premiumsOfLeaseGrant": -99.99,
+      |    "otherPropertyIncome": 1000.00
+      |  },
+      |  "expenses": {
+      |    "consolidatedExpenses": 332.78
+      |  }
+      |}""".stripMargin)
+
+  private def nonFhlBodyWith(nonFhlEntries: JsValue*): JsObject =
+    Json
+      .parse(
+        s"""{
+         |  "nonFurnishedHolidayLet": ${JsArray(nonFhlEntries)}
+         |}
+         |""".stripMargin
+      )
+      .as[JsObject]
+
+  private val nonFhlBody: JsValue = nonFhlBodyWith(entry)
+  private val parsedNonFhlBody    = nonFhlBody.as[Def1_SubmitForeignPropertyBsasRequestBody]
+
+  private val fhlBodyJson =
+    Json
+      .parse(
+        s"""
+         |{
+         |  "foreignFhlEea": {
+         |    "income": {
+         |      "totalRentsReceived": 1000.45
+         |    },
+         |    "expenses": {
+         |      "premisesRunningCosts": 1001.00,
+         |      "repairsAndMaintenance": -99999.99,
+         |      "financialCosts": 200.50,
+         |      "professionalFees": -99999.99,
+         |      "costOfServices": -1000.45,
+         |      "other": 500.00,
+         |      "travelCosts": 100.00
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+      )
+      .as[JsObject]
+
+  private val parsedFhlBody = fhlBodyJson.as[Def1_SubmitForeignPropertyBsasRequestBody]
+
+  private val fhlBodyConsolidated = Json.parse(
+    s"""{
+       |  "foreignFhlEea": {
+       |    "income": {
+       |      "totalRentsReceived": 1000.45
+       |    },
+       |    "expenses": {
+       |      "consolidatedExpenses": 1000.45
+       |    }
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  private val parsedFhlBodyConsolidated = fhlBodyConsolidated.as[Def1_SubmitForeignPropertyBsasRequestBody]
+
+  private def validator(nino: String, calculationId: String, taxYear: Option[String], body: JsValue) =
+    new Def1_SubmitForeignPropertyBsasValidator(nino, calculationId, taxYear, body)
+
+  "running a validation" should {
+    "return the parsed domain object" when {
+
+      "passed a valid fhl request" in {
+        val result = validator(validNino, validCalculationId, None, fhlBodyJson).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitForeignPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedFhlBody)
+        )
+      }
+
+      "passed a valid non-fhl request" in {
+        val result = validator(validNino, validCalculationId, None, nonFhlBody).validateAndWrapResult()
+        result shouldBe Right(
+          Def1_SubmitForeignPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedNonFhlBody)
+        )
+      }
+
+      "passed a valid fhl consolidated expenses request" in {
+        val result = validator(validNino, validCalculationId, None, fhlBodyConsolidated).validateAndWrapResult()
+        result shouldBe Right(
+          Def1_SubmitForeignPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedFhlBodyConsolidated)
+        )
+      }
+
+      "passed a valid non-fhl consolidated expenses request" in {
+        val nonFhlBodyConsolidated       = nonFhlBodyWith(entryConsolidated)
+        val parsedNonFhlBodyConsolidated = nonFhlBodyConsolidated.as[Def1_SubmitForeignPropertyBsasRequestBody]
+
+        val result = validator(validNino, validCalculationId, None, nonFhlBodyConsolidated).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitForeignPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedNonFhlBodyConsolidated)
+        )
+      }
+
+      "a minimal fhl request is supplied" in {
+        val minimalFhlBody =
+          Json.parse(
+            """
+            |{
+            |  "foreignFhlEea": {
+            |    "income": {
+            |      "totalRentsReceived": 1000.45
+            |    }
+            |  }
+            |}
+            |""".stripMargin
+          )
+        val parsedMinimalFhlBody = minimalFhlBody.as[Def1_SubmitForeignPropertyBsasRequestBody]
+
+        val result = validator(validNino, validCalculationId, None, minimalFhlBody).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitForeignPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedMinimalFhlBody)
+        )
+      }
+
+      "a minimal non-fhl request is supplied" in {
+        val minimalNonFhlBody = Json.parse("""
+          |{
+          |   "nonFurnishedHolidayLet":  [
+          |       {
+          |          "countryCode": "FRA",
+          |          "income": {
+          |              "totalRentsReceived": 1000.45
+          |          }
+          |       }
+          |    ]
+          |}
+          |""".stripMargin)
+        val parsedMinimalNonFhlBody = minimalNonFhlBody.as[Def1_SubmitForeignPropertyBsasRequestBody]
+
+        val result = validator(validNino, validCalculationId, None, minimalNonFhlBody).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitForeignPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedMinimalNonFhlBody)
+        )
+      }
+
+      "a valid request with a taxYear is supplied" in {
+        val nonFhlBodyWithConsolidatedEntry       = nonFhlBodyWith(entryConsolidated)
+        val parsedNonFhlBodyWithConsolidatedEntry = nonFhlBodyWithConsolidatedEntry.as[Def1_SubmitForeignPropertyBsasRequestBody]
+
+        val result = validator(validNino, validCalculationId, Some(validTaxYear), nonFhlBodyWithConsolidatedEntry).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitForeignPropertyBsasRequestData(parsedNino, parsedCalculationId, Some(parsedTaxYear), parsedNonFhlBodyWithConsolidatedEntry)
+        )
+      }
+    }
+
+    "return NinoFormatError" when {
+      "passed an invalid nino" in {
+        val result = validator("A12344A", validCalculationId, None, fhlBodyJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, NinoFormatError)
+        )
+      }
+    }
+
+    "return CalculationIdFormatError" when {
+      "passed an invalid calculationId" in {
+        val result = validator(validNino, "12345", None, fhlBodyJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, CalculationIdFormatError)
+        )
+      }
+    }
+
+    "return InvalidTaxYearParameterError" when {
+      "passed a tax year before TYS" in {
+        val result = validator(validNino, validCalculationId, Some("2022-23"), fhlBodyJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, InvalidTaxYearParameterError)
+        )
+      }
+    }
+
+    "return TaxYearFormatError" when {
+      "passed a badly formatted tax year" in {
+        val result = validator(validNino, validCalculationId, Some("not-a-tax-year"), fhlBodyJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, TaxYearFormatError)
+        )
+      }
+    }
+
+    "return RuleTaxYearRangeInvalidError" when {
+      "passed a tax year range of more than one year" in {
+        val result = validator(validNino, validCalculationId, Some("2022-24"), fhlBodyJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleTaxYearRangeInvalidError)
+        )
+      }
+    }
+
+    "return RuleBothPropertiesSuppliedError" when {
+      "passed both fhl and non-fhl" in {
+        val body   = fhlBodyJson ++ nonFhlBodyWith(entry)
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleBothPropertiesSuppliedError)
+        )
+      }
+
+      "passed both fhl and non-fhl even if they are empty" in {
+        val body = Json.parse(
+          s"""
+               |{
+               |  "foreignFhlEea": {},
+               |  "nonFurnishedHolidayLet": []
+               |}
+               |""".stripMargin
+        )
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            BadRequestError,
+            Some(
+              List(
+                RuleBothPropertiesSuppliedError,
+                RuleIncorrectOrEmptyBodyError.withPaths(List("/nonFurnishedHolidayLet", "/foreignFhlEea"))
+              ))
+          )
+        )
+      }
+    }
+
+    "return RuleIncorrectOrEmptyBodyError" when {
+      "passed an empty body" in {
+        val body   = Json.parse("{}")
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError)
+        )
+      }
+
+      "an object/array is empty or a mandatory field is missing" when {
+        List(
+          "/foreignFhlEea",
+          "/foreignFhlEea/income",
+          "/foreignFhlEea/expenses"
+        ).foreach(path => testWith(fhlBodyJson.replaceWithEmptyObject(path), path))
+
+        List(
+          (nonFhlBodyWith(), "/nonFurnishedHolidayLet"),
+          (nonFhlBodyWith(entry.replaceWithEmptyObject("/income")), "/nonFurnishedHolidayLet/0/income"),
+          (nonFhlBodyWith(entry.replaceWithEmptyObject("/expenses")), "/nonFurnishedHolidayLet/0/expenses"),
+          (nonFhlBodyWith(entry.removeProperty("/countryCode")), "/nonFurnishedHolidayLet/0/countryCode"),
+          (nonFhlBodyWith(entry.removeProperty("/income").removeProperty("/expenses")), "/nonFurnishedHolidayLet/0")
+        ).foreach((testWith _).tupled)
+
+        def testWith(body: JsValue, expectedPath: String): Unit =
+          s"for $expectedPath" in {
+            val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+            result shouldBe Left(
+              ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError.withPath(expectedPath))
+            )
+          }
+      }
+
+      "an object is empty except for an additional (non-schema) property" in {
+        val body = Json.parse("""
+          |{
+          |    "foreignFhlEea":{
+          |       "unknownField": 999.99
+          |    }
+          |}""".stripMargin)
+
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError.withPath("/foreignFhlEea"))
+        )
+      }
+
+      "return ValueFormatError" when {
+        "income or (non-consolidated) expenses is invalid" when {
+          List(
+            "/foreignFhlEea/income/totalRentsReceived",
+            "/foreignFhlEea/expenses/premisesRunningCosts",
+            "/foreignFhlEea/expenses/repairsAndMaintenance",
+            "/foreignFhlEea/expenses/financialCosts",
+            "/foreignFhlEea/expenses/professionalFees",
+            "/foreignFhlEea/expenses/costOfServices",
+            "/foreignFhlEea/expenses/other",
+            "/foreignFhlEea/expenses/travelCosts"
+          ).foreach(path => testWith(fhlBodyJson.update(path, _), path))
+
+          List(
+            ((v: JsNumber) => nonFhlBodyWith(entry.update("/income/totalRentsReceived", v)), "/nonFurnishedHolidayLet/0/income/totalRentsReceived"),
+            (
+              (v: JsNumber) => nonFhlBodyWith(entry.update("/income/premiumsOfLeaseGrant", v)),
+              "/nonFurnishedHolidayLet/0/income/premiumsOfLeaseGrant"),
+            ((v: JsNumber) => nonFhlBodyWith(entry.update("/income/otherPropertyIncome", v)), "/nonFurnishedHolidayLet/0/income/otherPropertyIncome"),
+            (
+              (v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/premisesRunningCosts", v)),
+              "/nonFurnishedHolidayLet/0/expenses/premisesRunningCosts"),
+            (
+              (v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/repairsAndMaintenance", v)),
+              "/nonFurnishedHolidayLet/0/expenses/repairsAndMaintenance"),
+            ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/financialCosts", v)), "/nonFurnishedHolidayLet/0/expenses/financialCosts"),
+            ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/professionalFees", v)), "/nonFurnishedHolidayLet/0/expenses/professionalFees"),
+            ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/costOfServices", v)), "/nonFurnishedHolidayLet/0/expenses/costOfServices"),
+            (
+              (v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/residentialFinancialCost", v)),
+              "/nonFurnishedHolidayLet/0/expenses/residentialFinancialCost"),
+            ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/other", v)), "/nonFurnishedHolidayLet/0/expenses/other"),
+            ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/travelCosts", v)), "/nonFurnishedHolidayLet/0/expenses/travelCosts")
+          ).foreach((testWith _).tupled)
+        }
+
+        "consolidated expenses is invalid" when {
+          List(
+            "/foreignFhlEea/expenses/consolidatedExpenses"
+          ).foreach(path => testWith(fhlBodyConsolidated.update(path, _), path))
+
+          List(
+            (
+              (v: JsNumber) => nonFhlBodyWith(entryConsolidated.update("/expenses/consolidatedExpenses", v)),
+              "/nonFurnishedHolidayLet/0/expenses/consolidatedExpenses")
+          ).foreach(p => (testWith _).tupled(p))
+        }
+
+        "multiple fields are invalid" in {
+          val path1 = "/nonFurnishedHolidayLet/0/expenses/travelCosts"
+          val path2 = "/nonFurnishedHolidayLet/1/income/totalRentsReceived"
+
+          val json =
+            nonFhlBodyWith(
+              entryWith(countryCode = "ZWE").update("/expenses/travelCosts", JsNumber(0)),
+              entryWith(countryCode = "AFG").update("/income/totalRentsReceived", JsNumber(123.123))
+            )
+
+          val result = validator(validNino, validCalculationId, None, json).validateAndWrapResult()
+
+          result shouldBe Left(
+            ErrorWrapper(
+              correlationId,
+              ValueFormatError.copy(paths = Some(List(path1, path2)), message = "The value must be between -99999999999.99 and 99999999999.99")
+            )
+          )
+        }
+
+        def testWith(body: JsNumber => JsValue, expectedPath: String): Unit = s"for $expectedPath" when {
+          def doTest(value: JsNumber) = {
+            val result = validator(validNino, validCalculationId, None, body(value)).validateAndWrapResult()
+
+            result shouldBe Left(
+              ErrorWrapper(
+                correlationId,
+                ValueFormatError.forPathAndRange(expectedPath, "-99999999999.99", "99999999999.99")
+              )
+            )
+          }
+
+          "value is out of range" in doTest(JsNumber(99999999999.99 + 0.01))
+
+          "value is zero" in doTest(JsNumber(0))
+        }
+      }
+
+      "return RuleCountryCodeError" when {
+        "passed an invalid country code" in {
+          val body   = nonFhlBodyWith(entryWith(countryCode = "QQQ"))
+          val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+          result shouldBe Left(
+            ErrorWrapper(correlationId, RuleCountryCodeError.withPath("/nonFurnishedHolidayLet/0/countryCode"))
+          )
+        }
+
+        "passed multiple invalid country codes" in {
+          val body   = nonFhlBodyWith(entryWith(countryCode = "QQQ"), entryWith(countryCode = "AAA"))
+          val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+          result shouldBe Left(
+            ErrorWrapper(
+              correlationId,
+              RuleCountryCodeError.withPaths(List("/nonFurnishedHolidayLet/0/countryCode", "/nonFurnishedHolidayLet/1/countryCode")))
+          )
+        }
+      }
+
+      "return RuleDuplicateCountryCodeError" when {
+        "a country code is duplicated" in {
+          val code   = "ZWE"
+          val body   = nonFhlBodyWith(entryWith(code), entryWith(code))
+          val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+          result shouldBe Left(
+            ErrorWrapper(
+              correlationId,
+              RuleDuplicateCountryCodeError.forDuplicatedCodesAndPaths(
+                code = code,
+                paths = Seq("/nonFurnishedHolidayLet/0/countryCode", "/nonFurnishedHolidayLet/1/countryCode"))
+            )
+          )
+        }
+
+        "multiple country codes are duplicated" in {
+          val code1  = "AFG"
+          val code2  = "ZWE"
+          val body   = nonFhlBodyWith(entryWith(code1), entryWith(code2), entryWith(code1), entryWith(code2))
+          val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+          result shouldBe Left(
+            ErrorWrapper(
+              correlationId,
+              BadRequestError,
+              Some(List(
+                RuleDuplicateCountryCodeError
+                  .forDuplicatedCodesAndPaths(
+                    code = code1,
+                    paths = Seq("/nonFurnishedHolidayLet/0/countryCode", "/nonFurnishedHolidayLet/2/countryCode")),
+                RuleDuplicateCountryCodeError
+                  .forDuplicatedCodesAndPaths(
+                    code = code2,
+                    paths = Seq("/nonFurnishedHolidayLet/1/countryCode", "/nonFurnishedHolidayLet/3/countryCode"))
+              ))
+            )
+          )
+        }
+      }
+
+      "return RuleBothExpensesSuppliedError" when {
+        "passed consolidated and separate fhl expenses" in {
+          val body   = fhlBodyJson.update("foreignFhlEea/expenses/consolidatedExpenses", JsNumber(123.45))
+          val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+          result shouldBe Left(
+            ErrorWrapper(correlationId, RuleBothExpensesError.withPath("/foreignFhlEea/expenses"))
+          )
+        }
+
+        "passed consolidated and separate non-fhl expenses" in {
+          val body = nonFhlBodyWith(
+            entryWith(countryCode = "ZWE").update("expenses/consolidatedExpenses", JsNumber(123.45)),
+            entryWith(countryCode = "AFG").update("expenses/consolidatedExpenses", JsNumber(123.45))
+          )
+          val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+          result shouldBe Left(
+            ErrorWrapper(
+              correlationId,
+              RuleBothExpensesError.withPaths(List("/nonFurnishedHolidayLet/0/expenses", "/nonFurnishedHolidayLet/1/expenses"))
+            )
+          )
+        }
+      }
+
+      "return multiple errors" when {
+        "passed a request containing multiple errors" in {
+          val result = validator("A12344A", "not-a-calculation-id", None, fhlBodyJson).validateAndWrapResult()
+
+          result shouldBe Left(
+            ErrorWrapper(
+              correlationId,
+              BadRequestError,
+              Some(List(CalculationIdFormatError, NinoFormatError))
+            )
+          )
+        }
+      }
+    }
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/connectors/MockSubmitSelfEmploymentBsasConnector.scala
+++ b/test/v5/submitSelfEmploymentBsas/connectors/MockSubmitSelfEmploymentBsasConnector.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.connectors
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.connectors.DownstreamOutcome
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestData
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockSubmitSelfEmploymentBsasConnector extends MockFactory {
+
+  val mockConnector: SubmitSelfEmploymentBsasConnector = mock[SubmitSelfEmploymentBsasConnector]
+
+  object MockSubmitSelfEmploymentBsasConnector {
+
+    def submitSelfEmploymentBsas(requestData: SubmitSelfEmploymentBsasRequestData): CallHandler[Future[DownstreamOutcome[Unit]]] = {
+      (mockConnector
+        .submitSelfEmploymentBsas(_: SubmitSelfEmploymentBsasRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(requestData, *, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/connectors/SubmitSelfEmploymentBsasConnectorSpec.scala
+++ b/test/v5/submitSelfEmploymentBsas/connectors/SubmitSelfEmploymentBsasConnectorSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.connectors
+
+import shared.connectors.{ConnectorSpec, DownstreamOutcome}
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.outcomes.ResponseWrapper
+import v5.submitSelfEmploymentBsas.fixtures.def1.AdditionsFixture.additionsModel
+import v5.submitSelfEmploymentBsas.fixtures.def1.ExpensesFixture.expensesModel
+import v5.submitSelfEmploymentBsas.fixtures.def1.IncomeFixture.incomeModel
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestData
+import v5.submitSelfEmploymentBsas.models.def1.{Def1_SubmitSelfEmploymentBsasRequestBody, Def1_SubmitSelfEmploymentBsasRequestData}
+
+import scala.concurrent.Future
+
+class SubmitSelfEmploymentBsasConnectorSpec extends ConnectorSpec {
+
+  val submitSelfEmploymentBsasRequestBodyModel: Def1_SubmitSelfEmploymentBsasRequestBody =
+    Def1_SubmitSelfEmploymentBsasRequestBody(
+      income = Some(incomeModel),
+      additions = Some(additionsModel),
+      expenses = Some(expensesModel)
+    )
+
+  private val nino          = Nino("AA123456A")
+  private val calculationId = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+
+  trait Test {
+    _: ConnectorTest =>
+    val connector: SubmitSelfEmploymentBsasConnector = new SubmitSelfEmploymentBsasConnector(http = mockHttpClient, appConfig = mockAppConfig)
+  }
+
+  "submitBsas" must {
+
+    "post a SubmitBsasRequest body and return the result" in new IfsTest with Test {
+      val request: SubmitSelfEmploymentBsasRequestData =
+        Def1_SubmitSelfEmploymentBsasRequestData(nino, calculationId, None, submitSelfEmploymentBsasRequestBodyModel)
+
+      val outcome: Right[Nothing, ResponseWrapper[Unit]] = Right(ResponseWrapper(correlationId, ()))
+
+      willPut(
+        url = s"$baseUrl/income-tax/adjustable-summary-calculation/$nino/$calculationId",
+        body = submitSelfEmploymentBsasRequestBodyModel
+      ).returns(Future.successful(outcome))
+
+      val result: DownstreamOutcome[Unit] = await(connector.submitSelfEmploymentBsas(request))
+      result shouldBe outcome
+    }
+
+    "post a SubmitBsasRequest body and return the result for a TYS tax year" in new TysIfsTest with Test {
+      val request: SubmitSelfEmploymentBsasRequestData =
+        Def1_SubmitSelfEmploymentBsasRequestData(nino, calculationId, Some(TaxYear.fromMtd("2023-24")), submitSelfEmploymentBsasRequestBodyModel)
+
+      val outcome = Right(ResponseWrapper(correlationId, ()))
+
+      willPut(
+        url = s"$baseUrl/income-tax/adjustable-summary-calculation/23-24/$nino/$calculationId",
+        body = submitSelfEmploymentBsasRequestBodyModel
+      ).returns(Future.successful(outcome))
+
+      val result: DownstreamOutcome[Unit] = await(connector.submitSelfEmploymentBsas(request))
+      result shouldBe outcome
+    }
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/controllers/SubmitSelfEmploymentBsasControllerSpec.scala
+++ b/test/v5/submitSelfEmploymentBsas/controllers/SubmitSelfEmploymentBsasControllerSpec.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.controllers
+
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Result
+import shared.config.MockAppConfig
+import shared.controllers.{ControllerBaseSpec, ControllerTestRunner}
+import shared.hateoas.Method.GET
+import shared.hateoas.{HateoasWrapper, Link, MockHateoasFactory}
+import shared.models.audit.{AuditEvent, AuditResponse, GenericAuditDetail}
+import shared.models.domain.CalculationId
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.{MockAuditService, MockEnrolmentsAuthService, MockMtdIdLookupService}
+import shared.utils.MockIdGenerator
+import v5.models.errors._
+import v5.submitSelfEmploymentBsas.fixtures.def1.SubmitSelfEmploymentBsasFixtures._
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasHateoasData
+import v5.submitSelfEmploymentBsas.models.def1.Def1_SubmitSelfEmploymentBsasRequestData
+import v5.submitSelfEmploymentBsas.services.MockSubmitSelfEmploymentBsasService
+import v5.submitSelfEmploymentBsas.validators.MockSubmitSelfEmploymentBsasValidatorFactory
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class SubmitSelfEmploymentBsasControllerSpec
+    extends ControllerBaseSpec
+    with ControllerTestRunner
+    with MockEnrolmentsAuthService
+    with MockMtdIdLookupService
+    with MockSubmitSelfEmploymentBsasValidatorFactory
+    with MockSubmitSelfEmploymentBsasService
+    with MockHateoasFactory
+    with MockAuditService
+    with MockIdGenerator
+    with MockAppConfig {
+
+  private val calculationId   = CalculationId("c75f40a6-a3df-4429-a697-471eeec46435")
+  private val requestData     = Def1_SubmitSelfEmploymentBsasRequestData(parsedNino, calculationId, None, submitSelfEmploymentBsasRequestBodyModel)
+  private val mtdResponseJson = Json.parse(hateoasResponse(parsedNino, calculationId))
+
+  val testHateoasLinks: Seq[Link] = Seq(
+    Link(
+      href = s"/individuals/self-assessment/adjustable-summary/$validNino/self-employment/$calculationId",
+      method = GET,
+      rel = "self"
+    )
+  )
+
+  "submitSelfEmploymentBsas" should {
+    "return OK" when {
+      "the request is valid" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockSubmitSelfEmploymentBsasService
+          .submitSelfEmploymentBsas(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
+
+        MockHateoasFactory
+          .wrap((), SubmitSelfEmploymentBsasHateoasData(validNino, calculationId.calculationId, requestData.taxYear))
+          .returns(HateoasWrapper((), testHateoasLinks))
+
+        runOkTestWithAudit(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(mtdResponseJson),
+          maybeAuditRequestBody = Some(mtdRequestJson),
+          maybeAuditResponseBody = Some(mtdResponseJson)
+        )
+      }
+    }
+
+    "return the error as per spec" when {
+
+      "the parser validation fails" in new Test {
+        willUseValidator(returning(NinoFormatError))
+        runErrorTestWithAudit(NinoFormatError, maybeAuditRequestBody = Some(mtdRequestJson))
+      }
+
+      "multiple parser errors occur" in new Test {
+        private val errors = List(CalculationIdFormatError, NinoFormatError)
+        willUseValidator(returningErrors(errors))
+        runMultipleErrorsTestWithAudit(errors, maybeAuditRequestBody = Some(mtdRequestJson))
+      }
+
+      "multiple errors occur for the customised errors" in new Test {
+        val errors = List(
+          ValueFormatError.copy(paths = Some(List("turnover"))),
+          RuleBothExpensesError.copy(paths = Some(List("expenses")))
+        )
+
+        willUseValidator(returningErrors(errors))
+        runMultipleErrorsTestWithAudit(errors, maybeAuditRequestBody = Some(mtdRequestJson))
+      }
+
+      "the service returns an error" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockSubmitSelfEmploymentBsasService
+          .submitSelfEmploymentBsas(requestData)
+          .returns(Future.successful(Left(ErrorWrapper(correlationId, RuleTypeOfBusinessIncorrectError))))
+
+        runErrorTestWithAudit(RuleTypeOfBusinessIncorrectError, maybeAuditRequestBody = Some(mtdRequestJson))
+      }
+    }
+  }
+
+  trait Test extends ControllerTest with AuditEventChecking {
+
+    val controller = new SubmitSelfEmploymentBsasController(
+      authService = mockEnrolmentsAuthService,
+      lookupService = mockMtdIdLookupService,
+      validatorFactory = mockSubmitSelfEmploymentBsasValidatorFactory,
+      service = mockService,
+      hateoasFactory = mockHateoasFactory,
+      auditService = mockAuditService,
+      cc = cc,
+      idGenerator = mockIdGenerator
+    )
+
+    protected def callController(): Future[Result] =
+      controller.submitSelfEmploymentBsas(validNino, calculationId.calculationId, None)(fakePostRequest(mtdRequestJson))
+
+    protected def event(auditResponse: AuditResponse, maybeRequestBody: Option[JsValue]): AuditEvent[GenericAuditDetail] =
+      AuditEvent(
+        auditType = "SubmitSelfEmploymentAccountingAdjustments",
+        transactionName = "submit-self-employment-accounting-adjustments",
+        detail = GenericAuditDetail(
+          versionNumber = apiVersion.name,
+          userType = "Individual",
+          agentReferenceNumber = None,
+          params = Map("nino" -> validNino, "calculationId" -> calculationId.calculationId),
+          requestBody = maybeRequestBody,
+          `X-CorrelationId` = correlationId,
+          auditResponse = auditResponse
+        )
+      )
+
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/fixtures/def1/AdditionsFixture.scala
+++ b/test/v5/submitSelfEmploymentBsas/fixtures/def1/AdditionsFixture.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.fixtures.def1
+
+import play.api.libs.json.{JsValue, Json}
+import v5.submitSelfEmploymentBsas.models.def1.{Additions, queryMap}
+
+object AdditionsFixture {
+
+  val additionsModel: Additions =
+    Additions(
+      costOfGoodsDisallowable = Some(3000.1),
+      paymentsToSubcontractorsDisallowable = Some(3000.2),
+      wagesAndStaffCostsDisallowable = Some(3000.3),
+      carVanTravelExpensesDisallowable = Some(3000.4),
+      premisesRunningCostsDisallowable = Some(3000.5),
+      maintenanceCostsDisallowable = Some(-3000.1),
+      adminCostsDisallowable = Some(-3000.2),
+      advertisingCostsDisallowable = Some(-3000.3),
+      businessEntertainmentCostsDisallowable = Some(-3000.4),
+      interestOnBankOtherLoansDisallowable = Some(-3000.5),
+      financeChargesDisallowable = Some(3000.6),
+      irrecoverableDebtsDisallowable = Some(-3000.6),
+      professionalFeesDisallowable = Some(3000.7),
+      depreciationDisallowable = Some(-3000.7),
+      otherExpensesDisallowable = Some(3000.8)
+    )
+
+  def additionsToDesJson(model: Additions): JsValue = {
+    import model._
+
+    val desFields: Map[String, Option[BigDecimal]] =
+      Map(
+        "costOfGoodsDisallowable"                -> costOfGoodsDisallowable,
+        "paymentsToSubcontractorsDisallowable"   -> paymentsToSubcontractorsDisallowable,
+        "wagesAndStaffCostsDisallowable"         -> wagesAndStaffCostsDisallowable,
+        "carVanTravelExpensesDisallowable"       -> carVanTravelExpensesDisallowable,
+        "premisesRunningCostsDisallowable"       -> premisesRunningCostsDisallowable,
+        "maintenanceCostsDisallowable"           -> maintenanceCostsDisallowable,
+        "adminCostsDisallowable"                 -> adminCostsDisallowable,
+        "advertisingCostsDisallowable"           -> advertisingCostsDisallowable,
+        "businessEntertainmentCostsDisallowable" -> businessEntertainmentCostsDisallowable,
+        "interestOnBankOtherLoansDisallowable"   -> interestOnBankOtherLoansDisallowable,
+        "financeChargesDisallowable"             -> financeChargesDisallowable,
+        "irrecoverableDebtsDisallowable"         -> irrecoverableDebtsDisallowable,
+        "professionalFeesDisallowable"           -> professionalFeesDisallowable,
+        "depreciationDisallowable"               -> depreciationDisallowable,
+        "otherExpensesDisallowable"              -> otherExpensesDisallowable
+      )
+
+    Json.toJsObject(queryMap(desFields))
+  }
+
+  def additionsFromVendorJson(model: Additions): JsValue = {
+    import model._
+
+    val vendorSuppliedFields: Map[String, Option[BigDecimal]] =
+      Map(
+        "costOfGoodsDisallowable"                -> costOfGoodsDisallowable,
+        "paymentsToSubcontractorsDisallowable"   -> paymentsToSubcontractorsDisallowable,
+        "wagesAndStaffCostsDisallowable"         -> wagesAndStaffCostsDisallowable,
+        "carVanTravelExpensesDisallowable"       -> carVanTravelExpensesDisallowable,
+        "premisesRunningCostsDisallowable"       -> premisesRunningCostsDisallowable,
+        "maintenanceCostsDisallowable"           -> maintenanceCostsDisallowable,
+        "adminCostsDisallowable"                 -> adminCostsDisallowable,
+        "advertisingCostsDisallowable"           -> advertisingCostsDisallowable,
+        "businessEntertainmentCostsDisallowable" -> businessEntertainmentCostsDisallowable,
+        "interestOnBankOtherLoansDisallowable"   -> interestOnBankOtherLoansDisallowable,
+        "financeChargesDisallowable"             -> financeChargesDisallowable,
+        "irrecoverableDebtsDisallowable"         -> irrecoverableDebtsDisallowable,
+        "professionalFeesDisallowable"           -> professionalFeesDisallowable,
+        "depreciationDisallowable"               -> depreciationDisallowable,
+        "otherExpensesDisallowable"              -> otherExpensesDisallowable
+      )
+
+    Json.toJsObject(queryMap(vendorSuppliedFields))
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/fixtures/def1/ExpensesFixture.scala
+++ b/test/v5/submitSelfEmploymentBsas/fixtures/def1/ExpensesFixture.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.fixtures.def1
+
+import play.api.libs.json.{JsValue, Json}
+import v5.submitSelfEmploymentBsas.models.def1.{Expenses, queryMap}
+
+object ExpensesFixture {
+
+  val expensesModel: Expenses =
+    Expenses(
+      costOfGoodsAllowable = Some(2000.25),
+      paymentsToSubcontractorsAllowable = Some(2000.50),
+      wagesAndStaffCostsAllowable = Some(2000.75),
+      carVanTravelExpensesAllowable = Some(-2000.25),
+      premisesRunningCostsAllowable = Some(-2000.50),
+      maintenanceCostsAllowable = Some(-2000.75),
+      adminCostsAllowable = Some(2001.25),
+      advertisingCostsAllowable = Some(2001.50),
+      businessEntertainmentCostsAllowable = Some(2001.75),
+      interestOnBankOtherLoansAllowable = Some(-2001.25),
+      financeChargesAllowable = Some(-2001.50),
+      irrecoverableDebtsAllowable = Some(-2001.75),
+      professionalFeesAllowable = Some(2002.25),
+      depreciationAllowable = Some(2002.50),
+      otherExpensesAllowable = Some(2002.75),
+      consolidatedExpenses = None
+    )
+
+  def expensesToDesJson(model: Expenses): JsValue = {
+    import model._
+
+    val desFields: Map[String, Option[BigDecimal]] =
+      Map(
+        "costOfGoodsAllowable"                -> costOfGoodsAllowable,
+        "paymentsToSubcontractorsAllowable"   -> paymentsToSubcontractorsAllowable,
+        "wagesAndStaffCostsAllowable"         -> wagesAndStaffCostsAllowable,
+        "carVanTravelExpensesAllowable"       -> carVanTravelExpensesAllowable,
+        "premisesRunningCostsAllowable"       -> premisesRunningCostsAllowable,
+        "maintenanceCostsAllowable"           -> maintenanceCostsAllowable,
+        "adminCostsAllowable"                 -> adminCostsAllowable,
+        "advertisingCostsAllowable"           -> advertisingCostsAllowable,
+        "businessEntertainmentCostsAllowable" -> businessEntertainmentCostsAllowable,
+        "interestOnBankOtherLoansAllowable"   -> interestOnBankOtherLoansAllowable,
+        "financeChargesAllowable"             -> financeChargesAllowable,
+        "irrecoverableDebtsAllowable"         -> irrecoverableDebtsAllowable,
+        "professionalFeesAllowable"           -> professionalFeesAllowable,
+        "depreciationAllowable"               -> depreciationAllowable,
+        "otherExpensesAllowable"              -> otherExpensesAllowable
+      )
+
+    Json.toJsObject(queryMap(desFields))
+  }
+
+  def expensesFromMtdJson(model: Expenses): JsValue = {
+    import model._
+
+    val vendorSuppliedFields: Map[String, Option[BigDecimal]] =
+      Map(
+        "costOfGoodsAllowable"                -> costOfGoodsAllowable,
+        "paymentsToSubcontractorsAllowable"   -> paymentsToSubcontractorsAllowable,
+        "wagesAndStaffCostsAllowable"         -> wagesAndStaffCostsAllowable,
+        "carVanTravelExpensesAllowable"       -> carVanTravelExpensesAllowable,
+        "premisesRunningCostsAllowable"       -> premisesRunningCostsAllowable,
+        "maintenanceCostsAllowable"           -> maintenanceCostsAllowable,
+        "adminCostsAllowable"                 -> adminCostsAllowable,
+        "advertisingCostsAllowable"           -> advertisingCostsAllowable,
+        "businessEntertainmentCostsAllowable" -> businessEntertainmentCostsAllowable,
+        "interestOnBankOtherLoansAllowable"   -> interestOnBankOtherLoansAllowable,
+        "financeChargesAllowable"             -> financeChargesAllowable,
+        "irrecoverableDebtsAllowable"         -> irrecoverableDebtsAllowable,
+        "professionalFeesAllowable"           -> professionalFeesAllowable,
+        "depreciationAllowable"               -> depreciationAllowable,
+        "otherExpensesAllowable"              -> otherExpensesAllowable
+      )
+
+    Json.toJsObject(queryMap(vendorSuppliedFields))
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/fixtures/def1/IncomeFixture.scala
+++ b/test/v5/submitSelfEmploymentBsas/fixtures/def1/IncomeFixture.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.fixtures.def1
+
+import play.api.libs.json.{JsValue, Json}
+import v5.submitSelfEmploymentBsas.models.def1.{Income, queryMap}
+
+object IncomeFixture {
+
+  val incomeModel: Income =
+    Income(
+      turnover = Some(1000.25),
+      other = Some(1000.50)
+    )
+
+  def incomeJson(model: Income): JsValue = {
+    import model._
+
+    val fields: Map[String, Option[BigDecimal]] =
+      Map(
+        "turnover" -> turnover,
+        "other"    -> other
+      )
+
+    Json.toJsObject(queryMap(fields))
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/fixtures/def1/SubmitSelfEmploymentBsasFixtures.scala
+++ b/test/v5/submitSelfEmploymentBsas/fixtures/def1/SubmitSelfEmploymentBsasFixtures.scala
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.fixtures.def1
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import shared.models.domain.{CalculationId, Nino}
+import v5.submitSelfEmploymentBsas.fixtures.def1.AdditionsFixture.{additionsFromVendorJson, additionsModel, additionsToDesJson}
+import v5.submitSelfEmploymentBsas.fixtures.def1.ExpensesFixture.{expensesFromMtdJson, expensesModel, expensesToDesJson}
+import v5.submitSelfEmploymentBsas.fixtures.def1.IncomeFixture.{incomeJson, incomeModel}
+import v5.submitSelfEmploymentBsas.models.def1.Def1_SubmitSelfEmploymentBsasRequestBody
+
+import scala.collection.mutable.ListBuffer
+
+object SubmitSelfEmploymentBsasFixtures {
+
+  val submitSelfEmploymentBsasRequestBodyModel: Def1_SubmitSelfEmploymentBsasRequestBody =
+    Def1_SubmitSelfEmploymentBsasRequestBody(
+      income = Some(incomeModel),
+      additions = Some(additionsModel),
+      expenses = Some(expensesModel)
+    )
+
+  val submitSelfEmploymentBsasRequestBodyModelWithoutIncome: Def1_SubmitSelfEmploymentBsasRequestBody =
+    Def1_SubmitSelfEmploymentBsasRequestBody(
+      income = None,
+      additions = Some(additionsModel),
+      expenses = Some(expensesModel)
+    )
+
+  val emptySubmitSelfEmploymentBsasRequestBodyModel: Def1_SubmitSelfEmploymentBsasRequestBody =
+    Def1_SubmitSelfEmploymentBsasRequestBody(
+      income = None,
+      additions = None,
+      expenses = None
+    )
+
+  val mtdRequestJson: JsValue = Json.parse(
+    """
+      |{
+      |   "income":{
+      |      "turnover":1000.25,
+      |      "other":1000.5
+      |   },
+      |   "expenses":{
+      |     "costOfGoodsAllowable":2000.25,
+      |     "paymentsToSubcontractorsAllowable":2000.5,
+      |     "wagesAndStaffCostsAllowable":2000.75,
+      |     "carVanTravelExpensesAllowable":-2000.25,
+      |     "premisesRunningCostsAllowable":-2000.5,
+      |     "maintenanceCostsAllowable":-2000.75,
+      |     "adminCostsAllowable":2001.25,
+      |     "interestOnBankOtherLoansAllowable":-2001.25,
+      |     "financeChargesAllowable":-2001.5,
+      |     "irrecoverableDebtsAllowable":-2001.75,
+      |     "professionalFeesAllowable":2002.25,
+      |     "depreciationAllowable":2002.5,
+      |     "otherExpensesAllowable":2002.75,
+      |     "advertisingCostsAllowable":2001.5,
+      |     "businessEntertainmentCostsAllowable":2001.75
+      |   },
+      |   "additions":{
+      |     "costOfGoodsDisallowable":3000.1,
+      |     "paymentsToSubcontractorsDisallowable":3000.2,
+      |     "wagesAndStaffCostsDisallowable":3000.3,
+      |     "carVanTravelExpensesDisallowable":3000.4,
+      |     "premisesRunningCostsDisallowable":3000.5,
+      |     "maintenanceCostsDisallowable":-3000.1,
+      |     "adminCostsDisallowable":-3000.2,
+      |     "interestOnBankOtherLoansDisallowable":-3000.5,
+      |     "financeChargesDisallowable":3000.6,
+      |     "irrecoverableDebtsDisallowable":-3000.6,
+      |     "professionalFeesDisallowable":3000.7,
+      |     "depreciationDisallowable":-3000.7,
+      |     "otherExpensesDisallowable":3000.8,
+      |     "advertisingCostsDisallowable":-3000.3,
+      |     "businessEntertainmentCostsDisallowable":-3000.4
+      |   }
+      |}
+      |""".stripMargin
+  )
+
+  val parsedMtdRequestBody: Def1_SubmitSelfEmploymentBsasRequestBody =
+    mtdRequestJson.as[Def1_SubmitSelfEmploymentBsasRequestBody]
+
+  val mtdRequestWithOnlyConsolidatedExpenses: JsValue = Json.parse("""
+      |{
+      |  "income": {
+      |    "turnover": 1000.25,
+      |    "other": 1000.5
+      |  },
+      |  "expenses": {
+      |    "consolidatedExpenses": 2002.75
+      |  }
+      |}
+      |""".stripMargin)
+
+  val parsedMtdRequestWithOnlyConsolidatedExpensesBody: Def1_SubmitSelfEmploymentBsasRequestBody =
+    mtdRequestWithOnlyConsolidatedExpenses.as[Def1_SubmitSelfEmploymentBsasRequestBody]
+
+  val mtdRequestWithOnlyAdditionsExpenses: JsValue = Json.parse("""
+      |{
+      |  "income": {
+      |    "turnover": 1000.25,
+      |    "other": 1000.5
+      |  },
+      |  "additions":{
+      |    "costOfGoodsDisallowable":3000.1,
+      |    "paymentsToSubcontractorsDisallowable":3000.2,
+      |    "wagesAndStaffCostsDisallowable":3000.3,
+      |    "carVanTravelExpensesDisallowable":3000.4,
+      |    "premisesRunningCostsDisallowable":3000.5,
+      |    "maintenanceCostsDisallowable":-3000.1,
+      |    "adminCostsDisallowable":-3000.2,
+      |    "interestOnBankOtherLoansDisallowable":-3000.5,
+      |    "financeChargesDisallowable":3000.6,
+      |    "irrecoverableDebtsDisallowable":-3000.6,
+      |    "professionalFeesDisallowable":3000.7,
+      |    "depreciationDisallowable":-3000.7,
+      |    "otherExpensesDisallowable":3000.8,
+      |    "advertisingCostsDisallowable":-3000.3,
+      |    "businessEntertainmentCostsDisallowable":-3000.4
+      |  }
+      |}
+      |""".stripMargin)
+
+  val parsedMtdRequestWithOnlyAdditionsExpenses: Def1_SubmitSelfEmploymentBsasRequestBody =
+    mtdRequestWithOnlyAdditionsExpenses.as[Def1_SubmitSelfEmploymentBsasRequestBody]
+
+  val mtdRequestWithAdditionsAndExpenses: JsValue = Json.parse("""
+      |{
+      |  "income": {
+      |    "turnover": 1000.25,
+      |    "other": 1000.5
+      |  },
+      |  "additions":{
+      |    "costOfGoodsDisallowable":3000.1,
+      |    "paymentsToSubcontractorsDisallowable":3000.2,
+      |    "wagesAndStaffCostsDisallowable":3000.3,
+      |    "carVanTravelExpensesDisallowable":3000.4,
+      |    "premisesRunningCostsDisallowable":3000.5,
+      |    "maintenanceCostsDisallowable":-3000.1,
+      |    "adminCostsDisallowable":-3000.2,
+      |    "interestOnBankOtherLoansDisallowable":-3000.5,
+      |    "financeChargesDisallowable":3000.6,
+      |    "irrecoverableDebtsDisallowable":-3000.6,
+      |    "professionalFeesDisallowable":3000.7,
+      |    "depreciationDisallowable":-3000.7,
+      |    "otherExpensesDisallowable":3000.8,
+      |    "advertisingCostsDisallowable":-3000.3,
+      |    "businessEntertainmentCostsDisallowable":-3000.4
+      |   },
+      |  "expenses": {
+      |    "consolidatedExpenses": 2002.75
+      |  }
+      |}
+      |""".stripMargin)
+
+  val mtdRequestWithBothExpenses: JsValue = Json.parse("""
+      |{
+      |  "income": {
+      |    "turnover": 1000.25,
+      |    "other": 1000.5
+      |  },
+      |  "additions":{
+      |    "costOfGoodsDisallowable":3000.1,
+      |    "paymentsToSubcontractorsDisallowable":3000.2,
+      |    "wagesAndStaffCostsDisallowable":3000.3,
+      |    "carVanTravelExpensesDisallowable":3000.4,
+      |    "premisesRunningCostsDisallowable":3000.5,
+      |    "maintenanceCostsDisallowable":-3000.1,
+      |    "adminCostsDisallowable":-3000.2,
+      |    "advertisingCostsDisallowable":-3000.3,
+      |    "businessEntertainmentCostsDisallowable":-3000.4,
+      |    "interestOnBankOtherLoansDisallowable":-3000.5,
+      |    "financeChargesDisallowable":3000.6,
+      |    "irrecoverableDebtsDisallowable":-3000.6,
+      |    "professionalFeesDisallowable":3000.7,
+      |    "depreciationDisallowable":-3000.7,
+      |    "otherExpensesDisallowable":3000.8
+      |  },
+      |  "expenses":{
+      |    "costOfGoodsAllowable":2000.25,
+      |    "paymentsToSubcontractorsAllowable":2000.5,
+      |    "wagesAndStaffCostsAllowable":2000.75,
+      |    "carVanTravelExpensesAllowable":-2000.25,
+      |    "premisesRunningCostsAllowable":-2000.5,
+      |    "maintenanceCostsAllowable":-2000.75,
+      |    "adminCostsAllowable":2001.25,
+      |    "advertisingCostsAllowable":2001.5,
+      |    "businessEntertainmentCostsAllowable":2001.75,
+      |    "interestOnBankOtherLoansAllowable":-2001.25,
+      |    "financeChargesAllowable":-2001.5,
+      |    "irrecoverableDebtsAllowable":-2001.75,
+      |    "professionalFeesAllowable":2002.25,
+      |    "depreciationAllowable":2002.5,
+      |    "otherExpensesAllowable":2002.75,
+      |    "consolidatedExpenses": -2002.25
+      |   }
+      |}""".stripMargin)
+
+  val requestToIfs: JsValue = Json.parse("""
+      |{
+      | "incomeSourceType": "01",
+      | "adjustments": {
+      |    "income": {
+      |      "turnover": 1000.25,
+      |      "other": 1000.5
+      |    },
+      |    "expenses": {
+      |      "costOfGoodsAllowable": 2000.25,
+      |      "paymentsToSubcontractorsAllowable": 2000.5,
+      |      "wagesAndStaffCostsAllowable": 2000.75,
+      |      "carVanTravelExpensesAllowable": -2000.25,
+      |      "premisesRunningCostsAllowable": -2000.5,
+      |      "maintenanceCostsAllowable": -2000.75,
+      |      "adminCostsAllowable": 2001.25,
+      |      "advertisingCostsAllowable": 2001.5,
+      |      "businessEntertainmentCostsAllowable": 2001.75,
+      |      "interestOnBankOtherLoansAllowable": -2001.25,
+      |      "financeChargesAllowable": -2001.5,
+      |      "irrecoverableDebtsAllowable": -2001.75,
+      |      "professionalFeesAllowable": 2002.25,
+      |      "depreciationAllowable": 2002.5,
+      |      "otherExpensesAllowable": 2002.75
+      |    },
+      |    "additions": {
+      |      "costOfGoodsDisallowable": 3000.1,
+      |      "paymentsToSubcontractorsDisallowable": 3000.2,
+      |      "wagesAndStaffCostsDisallowable": 3000.3,
+      |      "carVanTravelExpensesDisallowable": 3000.4,
+      |      "premisesRunningCostsDisallowable": 3000.5,
+      |      "maintenanceCostsDisallowable": -3000.1,
+      |      "adminCostsDisallowable": -3000.2,
+      |      "advertisingCostsDisallowable": -3000.3,
+      |      "businessEntertainmentCostsDisallowable": -3000.4,
+      |      "interestOnBankOtherLoansDisallowable": -3000.5,
+      |      "financeChargesDisallowable": 3000.6,
+      |      "irrecoverableDebtsDisallowable": -3000.6,
+      |      "professionalFeesDisallowable": 3000.7,
+      |      "depreciationDisallowable": -3000.7,
+      |      "otherExpensesDisallowable": 3000.8
+      |    }
+      |  }
+      |}""".stripMargin)
+
+  val ifsResponse: (String, String) => String = (calcId: String, typeOfBusiness: String) => s"""
+       |{
+       |      "metadata":{
+       |        "calculationId":"$calcId",
+       |        "requestedDateTime":"2019-12-01T12:00:00.000Z",
+       |        "taxableEntityId":"AB123456C",
+       |        "taxYear":2020,
+       |        "status":"valid"
+       |      },
+       |      "inputs":{
+       |        "incomeSourceId":"X2IS01234512345",
+       |        "incomeSourceType": "$typeOfBusiness",
+       |        "accountingPeriodStartDate":"2019-04-06",
+       |        "accountingPeriodEndDate":"2020-04-05",
+       |        "source":"MTD-SA",
+       |        "submissionPeriods":[
+       |          {
+       |            "periodId":"2019040620190705",
+       |            "startDate":"2019-04-06",
+       |            "endDate":"2019-07-05",
+       |            "receivedDateTime":"2019-08-01T12:00:00.000Z"
+       |          }
+       |        ]
+       |      }
+       |}
+       |""".stripMargin
+
+  def submitSelfEmploymentBsasRequestBodyDesJson(model: Def1_SubmitSelfEmploymentBsasRequestBody): JsValue = {
+    import model._
+
+    val jsObjects: ListBuffer[JsObject] = ListBuffer.empty[JsObject]
+
+    if (income.nonEmpty) {
+      jsObjects += Json.obj("income" -> incomeJson(income.get))
+    }
+
+    if (additions.nonEmpty) {
+      jsObjects += Json.obj("additions" -> additionsFromVendorJson(additions.get))
+    }
+
+    if (expenses.nonEmpty) {
+      jsObjects += Json.obj("expenses" -> expensesFromMtdJson(expenses.get))
+    }
+
+    val json = jsObjects.fold(Json.parse("""{}""").as[JsObject])((a: JsObject, b: JsObject) => a ++ b)
+    json
+  }
+
+  def submitSelfEmploymentBsasRequestBodyMtdJson(model: Def1_SubmitSelfEmploymentBsasRequestBody): JsValue = {
+    import model._
+
+    val jsObjects: ListBuffer[JsObject] = ListBuffer.empty[JsObject]
+
+    if (income.nonEmpty) {
+      jsObjects += Json.obj("income" -> incomeJson(income.get))
+    }
+
+    if (additions.nonEmpty) {
+      jsObjects += Json.obj("additions" -> additionsToDesJson(additions.get))
+    }
+
+    if (expenses.nonEmpty) {
+      jsObjects += Json.obj("expenses" -> expensesToDesJson(expenses.get))
+    }
+
+    val json = jsObjects.fold(Json.parse("""{}""").as[JsObject])((a: JsObject, b: JsObject) => a ++ b)
+    json
+  }
+
+  def hateoasResponse(nino: Nino, calcId: CalculationId, taxYear: Option[String] = None): String = {
+    val taxYearParam = taxYear.map("?taxYear=" + _).getOrElse("")
+
+    s"""
+       |{
+       |  "links":[
+       |    {
+       |      "href":"/individuals/self-assessment/adjustable-summary/$nino/self-employment/$calcId$taxYearParam",
+       |      "rel":"self",
+       |      "method":"GET"
+       |    }
+       |  ]
+       |}
+    """.stripMargin
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/models/SubmitSelfEmploymentBsasHateoasDataSpec.scala
+++ b/test/v5/submitSelfEmploymentBsas/models/SubmitSelfEmploymentBsasHateoasDataSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models
+
+import play.api.Configuration
+import shared.UnitSpec
+import shared.config.MockAppConfig
+import shared.hateoas.Link
+import shared.hateoas.Method.GET
+import shared.models.domain.TaxYear
+
+class SubmitSelfEmploymentBsasHateoasDataSpec extends UnitSpec with MockAppConfig {
+
+  class Test extends MockAppConfig {
+    val nino          = "someNino"
+    val calculationId = "anId"
+    val taxYear       = Some(TaxYear.fromMtd("2023-24"))
+    val context       = "individuals/self-assessment/adjustable-summary"
+
+    MockAppConfig.apiGatewayContext.returns(context).anyNumberOfTimes()
+  }
+
+  class TysDisabledTest extends Test {
+    MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> false)).anyNumberOfTimes()
+  }
+
+  class TysEnabledTest extends Test {
+    MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> true)).anyNumberOfTimes()
+  }
+
+  "LinksFactory" should {
+    "return the correct links without tax year" in new TysDisabledTest {
+      private val data         = SubmitSelfEmploymentBsasHateoasData(nino, calculationId, None)
+      private val expectedLink = Link(href = s"/$context/$nino/self-employment/$calculationId", method = GET, rel = "self")
+
+      val result: Seq[Link] =
+        SubmitSelfEmploymentBsasHateoasData.SubmitSelfEmploymentAdjustmentHateoasFactory.links(mockAppConfig, data)
+
+      result shouldBe Seq(expectedLink)
+    }
+
+    "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+      private val data         = SubmitSelfEmploymentBsasHateoasData(nino, calculationId, taxYear)
+      private val result       = SubmitSelfEmploymentBsasHateoasData.SubmitSelfEmploymentAdjustmentHateoasFactory.links(mockAppConfig, data)
+      private val expectedLink = Link(href = s"/$context/$nino/self-employment/$calculationId?taxYear=2023-24", method = GET, rel = "self")
+
+      result shouldBe Seq(expectedLink)
+    }
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/models/def1/AdditionsSpec.scala
+++ b/test/v5/submitSelfEmploymentBsas/models/def1/AdditionsSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.domain.EmptyJsonBody
+import v5.submitSelfEmploymentBsas.fixtures.def1.AdditionsFixture._
+
+class AdditionsSpec extends UnitSpec {
+
+  val additionsModelWithoutCosts: Additions =
+    Additions(
+      costOfGoodsDisallowable = None,
+      paymentsToSubcontractorsDisallowable = Some(3000.2),
+      wagesAndStaffCostsDisallowable = None,
+      carVanTravelExpensesDisallowable = None,
+      premisesRunningCostsDisallowable = None,
+      maintenanceCostsDisallowable = None,
+      adminCostsDisallowable = None,
+      advertisingCostsDisallowable = None,
+      businessEntertainmentCostsDisallowable = None,
+      interestOnBankOtherLoansDisallowable = Some(-3000.5),
+      financeChargesDisallowable = Some(3000.6),
+      irrecoverableDebtsDisallowable = Some(-3000.6),
+      professionalFeesDisallowable = Some(3000.7),
+      depreciationDisallowable = Some(-3000.7),
+      otherExpensesDisallowable = Some(3000.8)
+    )
+
+  val emptyAdditionsModel: Additions =
+    Additions(
+      costOfGoodsDisallowable = None,
+      paymentsToSubcontractorsDisallowable = None,
+      wagesAndStaffCostsDisallowable = None,
+      carVanTravelExpensesDisallowable = None,
+      premisesRunningCostsDisallowable = None,
+      maintenanceCostsDisallowable = None,
+      adminCostsDisallowable = None,
+      advertisingCostsDisallowable = None,
+      businessEntertainmentCostsDisallowable = None,
+      interestOnBankOtherLoansDisallowable = None,
+      financeChargesDisallowable = None,
+      irrecoverableDebtsDisallowable = None,
+      professionalFeesDisallowable = None,
+      depreciationDisallowable = None,
+      otherExpensesDisallowable = None
+    )
+
+  "Additions" when {
+    "read from valid vendor JSON" should {
+      "produce the expected Additions object" in {
+        additionsFromVendorJson(additionsModel).as[Additions] shouldBe additionsModel
+      }
+    }
+
+    "written to DES JSON" should {
+      "produce the expected JsObject" in {
+        Json.toJson(additionsModel) shouldBe additionsToDesJson(additionsModel)
+      }
+    }
+
+    "some optional fields as not supplied" should {
+      "read those fields as 'None'" in {
+        additionsFromVendorJson(additionsModelWithoutCosts).as[Additions] shouldBe additionsModelWithoutCosts
+      }
+
+      "not write those fields to JSON" in {
+        Json.toJson(additionsModelWithoutCosts) shouldBe additionsToDesJson(additionsModelWithoutCosts)
+      }
+    }
+
+    "no fields as supplied" should {
+      "read to an empty Additions object" in {
+        additionsFromVendorJson(emptyAdditionsModel).as[Additions] shouldBe emptyAdditionsModel
+      }
+
+      "write to empty JSON" in {
+        Json.toJson(emptyAdditionsModel) shouldBe Json.toJson(EmptyJsonBody)
+      }
+    }
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/models/def1/Def1_SubmitSelfEmploymentBsasRequestBodySpec.scala
+++ b/test/v5/submitSelfEmploymentBsas/models/def1/Def1_SubmitSelfEmploymentBsasRequestBodySpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.domain.EmptyJsonBody
+import v5.submitSelfEmploymentBsas.fixtures.def1.SubmitSelfEmploymentBsasFixtures._
+
+class Def1_SubmitSelfEmploymentBsasRequestBodySpec extends UnitSpec {
+
+  "SubmitSelfEmploymentBsasRequestBody" when {
+    "read from valid JSON" should {
+      "produce the expected SubmitSelfEmploymentBsasRequestBody object" in {
+        submitSelfEmploymentBsasRequestBodyDesJson(submitSelfEmploymentBsasRequestBodyModel).as[Def1_SubmitSelfEmploymentBsasRequestBody] shouldBe
+          submitSelfEmploymentBsasRequestBodyModel
+      }
+    }
+
+    "written to JSON" should {
+      "produce the expected JsObject" in {
+        Json.toJson(submitSelfEmploymentBsasRequestBodyModel) shouldBe requestToIfs
+      }
+    }
+
+    "some optional fields as not supplied" should {
+      "read those fields as 'None'" in {
+        submitSelfEmploymentBsasRequestBodyDesJson(submitSelfEmploymentBsasRequestBodyModelWithoutIncome)
+          .as[Def1_SubmitSelfEmploymentBsasRequestBody] shouldBe
+          submitSelfEmploymentBsasRequestBodyModelWithoutIncome
+      }
+
+      "not write those fields to JSON" in {
+        Json.toJson(submitSelfEmploymentBsasRequestBodyModel) shouldBe requestToIfs
+      }
+    }
+
+    "no fields as supplied" should {
+      "read to an empty SubmitSelfEmploymentBsasRequestBody object" in {
+        submitSelfEmploymentBsasRequestBodyDesJson(emptySubmitSelfEmploymentBsasRequestBodyModel).as[Def1_SubmitSelfEmploymentBsasRequestBody] shouldBe
+          emptySubmitSelfEmploymentBsasRequestBodyModel
+      }
+
+      "write to empty JSON" in {
+        Json.toJson(emptySubmitSelfEmploymentBsasRequestBodyModel) shouldBe Json.toJson(EmptyJsonBody)
+      }
+    }
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/models/def1/ExpensesSpec.scala
+++ b/test/v5/submitSelfEmploymentBsas/models/def1/ExpensesSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.domain.EmptyJsonBody
+import v5.submitSelfEmploymentBsas.fixtures.def1.ExpensesFixture._
+
+class ExpensesSpec extends UnitSpec {
+
+  val expensesModelWithoutCosts: Expenses =
+    Expenses(
+      costOfGoodsAllowable = None,
+      paymentsToSubcontractorsAllowable = Some(2000.50),
+      wagesAndStaffCostsAllowable = None,
+      carVanTravelExpensesAllowable = None,
+      premisesRunningCostsAllowable = None,
+      maintenanceCostsAllowable = None,
+      adminCostsAllowable = None,
+      advertisingCostsAllowable = None,
+      businessEntertainmentCostsAllowable = None,
+      interestOnBankOtherLoansAllowable = Some(-2001.25),
+      financeChargesAllowable = Some(-2001.50),
+      irrecoverableDebtsAllowable = Some(-2001.75),
+      professionalFeesAllowable = Some(2002.25),
+      depreciationAllowable = Some(2002.50),
+      otherExpensesAllowable = Some(2002.75),
+      consolidatedExpenses = None
+    )
+
+  val emptyExpensesModel: Expenses =
+    Expenses(
+      costOfGoodsAllowable = None,
+      paymentsToSubcontractorsAllowable = None,
+      wagesAndStaffCostsAllowable = None,
+      carVanTravelExpensesAllowable = None,
+      premisesRunningCostsAllowable = None,
+      maintenanceCostsAllowable = None,
+      adminCostsAllowable = None,
+      advertisingCostsAllowable = None,
+      businessEntertainmentCostsAllowable = None,
+      interestOnBankOtherLoansAllowable = None,
+      financeChargesAllowable = None,
+      irrecoverableDebtsAllowable = None,
+      professionalFeesAllowable = None,
+      depreciationAllowable = None,
+      otherExpensesAllowable = None,
+      consolidatedExpenses = None
+    )
+
+  "Expenses" when {
+    "read from valid vendor JSON" should {
+      "produce the expected Expenses object" in {
+        expensesFromMtdJson(expensesModel).as[Expenses] shouldBe expensesModel
+      }
+    }
+
+    "written to DES JSON" should {
+      "produce the expected JsObject" in {
+        Json.toJson(expensesModel) shouldBe expensesToDesJson(expensesModel)
+      }
+    }
+
+    "some optional fields as not supplied" should {
+      "read those fields as 'None'" in {
+        expensesFromMtdJson(expensesModelWithoutCosts).as[Expenses] shouldBe expensesModelWithoutCosts
+      }
+
+      "not write those fields to JSON" in {
+        Json.toJson(expensesModelWithoutCosts) shouldBe expensesToDesJson(expensesModelWithoutCosts)
+      }
+    }
+
+    "no fields as supplied" should {
+      "read to an empty Expenses object" in {
+        expensesFromMtdJson(emptyExpensesModel).as[Expenses] shouldBe emptyExpensesModel
+      }
+
+      "write to empty JSON" in {
+        Json.toJson(emptyExpensesModel) shouldBe Json.toJson(EmptyJsonBody)
+      }
+    }
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/models/def1/IncomeSpec.scala
+++ b/test/v5/submitSelfEmploymentBsas/models/def1/IncomeSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import shared.models.domain.EmptyJsonBody
+import v5.submitSelfEmploymentBsas.fixtures.def1.IncomeFixture._
+
+class IncomeSpec extends UnitSpec {
+
+  val incomeModelWithoutOther: Income =
+    Income(
+      turnover = Some(1000.75),
+      other = None
+    )
+
+  val incomeModelEmpty: Income =
+    Income(
+      turnover = None,
+      other = None
+    )
+
+  "Income" when {
+    "read from valid JSON" should {
+      "produce the expected Income object" in {
+        incomeJson(incomeModel).as[Income] shouldBe incomeModel
+      }
+    }
+
+    "written to JSON" should {
+      "produce the expected JsObject" in {
+        Json.toJson(incomeModel) shouldBe incomeJson(incomeModel)
+      }
+    }
+
+    "some optional fields as not supplied" should {
+      "read those fields as 'None'" in {
+        incomeJson(incomeModelWithoutOther).as[Income] shouldBe incomeModelWithoutOther
+      }
+
+      "not write those fields to JSON" in {
+        Json.toJson(incomeModelWithoutOther) shouldBe incomeJson(incomeModelWithoutOther)
+      }
+    }
+
+    "no fields as supplied" should {
+      "read to an empty Income object" in {
+        incomeJson(incomeModelEmpty).as[Income] shouldBe incomeModelEmpty
+      }
+
+      "write to empty JSON" in {
+        Json.toJson(incomeModelEmpty) shouldBe Json.toJson(EmptyJsonBody)
+      }
+    }
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/models/def1/package.scala
+++ b/test/v5/submitSelfEmploymentBsas/models/def1/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.models
+
+package object def1 {
+
+  def queryMap[A](as: Map[String, Option[A]]): Map[String, A] =
+    as.filterNot {
+      case (_, None) => true
+      case _         => false
+    }.collect { case (k: String, Some(v)) =>
+      (k, v)
+    }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/schema/SubmitSelfEmploymentBsasSchemaSpec.scala
+++ b/test/v5/submitSelfEmploymentBsas/schema/SubmitSelfEmploymentBsasSchemaSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.schema
+
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import shared.UnitSpec
+import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+
+import scala.math.Ordered.orderingToOrdered
+
+class SubmitSelfEmploymentBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
+
+  "schema lookup" when {
+    "a tax year is present" must {
+      "use Def1 for tax years from 2023-24" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
+            SubmitSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitSelfEmploymentBsasSchema.Def1
+          }
+        }
+      }
+
+      "use Def1 for other tax years" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
+            SubmitSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitSelfEmploymentBsasSchema.Def1
+          }
+        }
+      }
+    }
+
+    "the tax year is present but not valid" must {
+      "use a default of Def1" in {
+        SubmitSelfEmploymentBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe SubmitSelfEmploymentBsasSchema.Def1
+      }
+    }
+
+    "no tax year is present" must {
+      "use a default of Def1" in {
+        SubmitSelfEmploymentBsasSchema.schemaFor(None) shouldBe SubmitSelfEmploymentBsasSchema.Def1
+      }
+    }
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/schema/SubmitSelfEmploymentBsasSchemaSpec.scala
+++ b/test/v5/submitSelfEmploymentBsas/schema/SubmitSelfEmploymentBsasSchemaSpec.scala
@@ -20,25 +20,19 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import shared.UnitSpec
 import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
 
-import scala.math.Ordered.orderingToOrdered
-
 class SubmitSelfEmploymentBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
 
   "schema lookup" when {
     "a tax year is present" must {
       "use Def1 for tax years from 2023-24" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
-            SubmitSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitSelfEmploymentBsasSchema.Def1
-          }
+        forTaxYearsFrom(TaxYear.fromMtd("2023-24")) { taxYear =>
+          SubmitSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitSelfEmploymentBsasSchema.Def1
         }
       }
 
-      "use Def1 for other tax years" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
-            SubmitSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitSelfEmploymentBsasSchema.Def1
-          }
+      "use Def1 for pre-TYS tax years" in {
+        forPreTysTaxYears{ taxYear =>
+          SubmitSelfEmploymentBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitSelfEmploymentBsasSchema.Def1
         }
       }
     }

--- a/test/v5/submitSelfEmploymentBsas/services/MockSubmitSelfEmploymentBsasService.scala
+++ b/test/v5/submitSelfEmploymentBsas/services/MockSubmitSelfEmploymentBsasService.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.services
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.controllers.RequestContext
+import shared.services.ServiceOutcome
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestData
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockSubmitSelfEmploymentBsasService extends MockFactory {
+
+  val mockService: SubmitSelfEmploymentBsasService = mock[SubmitSelfEmploymentBsasService]
+
+  object MockSubmitSelfEmploymentBsasService {
+
+    def submitSelfEmploymentBsas(requestData: SubmitSelfEmploymentBsasRequestData): CallHandler[Future[ServiceOutcome[Unit]]] = {
+      (mockService
+        .submitSelfEmploymentBsas(_: SubmitSelfEmploymentBsasRequestData)(_: RequestContext, _: ExecutionContext))
+        .expects(requestData, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/services/SubmitSelfEmploymentBsasServiceSpec.scala
+++ b/test/v5/submitSelfEmploymentBsas/services/SubmitSelfEmploymentBsasServiceSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.services
+
+import shared.controllers.EndpointLogContext
+import shared.models.domain.{CalculationId, Nino}
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.ServiceSpec
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.models.errors._
+import v5.submitSelfEmploymentBsas.connectors.MockSubmitSelfEmploymentBsasConnector
+import v5.submitSelfEmploymentBsas.fixtures.def1.SubmitSelfEmploymentBsasFixtures._
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestData
+import v5.submitSelfEmploymentBsas.models.def1.Def1_SubmitSelfEmploymentBsasRequestData
+
+import scala.concurrent.Future
+
+class SubmitSelfEmploymentBsasServiceSpec extends ServiceSpec {
+
+  private val nino = Nino("AA123456A")
+  private val id   = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+
+  val request: SubmitSelfEmploymentBsasRequestData = Def1_SubmitSelfEmploymentBsasRequestData(nino, id, None, submitSelfEmploymentBsasRequestBodyModel)
+
+  trait Test extends MockSubmitSelfEmploymentBsasConnector {
+    implicit val hc: HeaderCarrier              = HeaderCarrier()
+    implicit val logContext: EndpointLogContext = EndpointLogContext("controller", "submitSelfEmploymentBsas")
+
+    val service = new SubmitSelfEmploymentBsasService(mockConnector)
+  }
+
+  "submitSelfEmploymentBsas" should {
+    "return a valid response" when {
+      "a valid request is supplied" in new Test {
+        MockSubmitSelfEmploymentBsasConnector
+          .submitSelfEmploymentBsas(request)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
+
+        await(service.submitSelfEmploymentBsas(request)) shouldBe Right(ResponseWrapper(correlationId, ()))
+      }
+    }
+
+    "return error response" when {
+
+      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
+        s"$downstreamErrorCode is returned from the service" in new Test {
+
+          MockSubmitSelfEmploymentBsasConnector
+            .submitSelfEmploymentBsas(request)
+            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+
+          await(service.submitSelfEmploymentBsas(request)) shouldBe Left(ErrorWrapper(correlationId, error))
+        }
+
+      val input = Seq(
+        ("INVALID_TAXABLE_ENTITY_ID", NinoFormatError),
+        ("INVALID_CALCULATION_ID", CalculationIdFormatError),
+        ("INVALID_PAYLOAD", InternalError),
+        ("ASC_ID_INVALID", RuleSummaryStatusInvalid),
+        ("ASC_ALREADY_SUPERSEDED", RuleSummaryStatusSuperseded),
+        ("ASC_ALREADY_ADJUSTED", RuleAlreadyAdjusted),
+        ("UNALLOWABLE_VALUE", RuleResultingValueNotPermitted),
+        ("INCOMESOURCE_TYPE_NOT_MATCHED", RuleTypeOfBusinessIncorrectError),
+        ("BVR_FAILURE_C55316", RuleOverConsolidatedExpensesThreshold),
+        ("BVR_FAILURE_C15320", RuleTradingIncomeAllowanceClaimed),
+        ("BVR_FAILURE_C55503", InternalError),
+        ("BVR_FAILURE_C55508", InternalError),
+        ("BVR_FAILURE_C55509", InternalError),
+        ("BVR_FAILURE_C559107", InternalError),
+        ("BVR_FAILURE_C559103", InternalError),
+        ("BVR_FAILURE_C559099", InternalError),
+        ("NO_DATA_FOUND", NotFoundError),
+        ("INVALID_CORRELATIONID", InternalError),
+        ("SERVER_ERROR", InternalError),
+        ("SERVICE_UNAVAILABLE", InternalError)
+      )
+
+      val extraTysErrors = Seq(
+        ("INCOME_SOURCE_TYPE_NOT_MATCHED", RuleTypeOfBusinessIncorrectError),
+        ("INVALID_TAX_YEAR", TaxYearFormatError),
+        ("NOT_FOUND", NotFoundError),
+        ("TAX_YEAR_NOT_SUPPORTED", RuleTaxYearNotSupportedError)
+      )
+
+      (input ++ extraTysErrors).foreach(args => (serviceError _).tupled(args))
+    }
+  }
+
+}

--- a/test/v5/submitSelfEmploymentBsas/validators/MockSubmitSelfEmploymentBsasValidatorFactory.scala
+++ b/test/v5/submitSelfEmploymentBsas/validators/MockSubmitSelfEmploymentBsasValidatorFactory.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.validators
+
+import org.scalamock.handlers.CallHandler
+import play.api.libs.json.JsValue
+import shared.controllers.validators.{MockValidatorFactory, Validator}
+import v5.submitSelfEmploymentBsas.models.SubmitSelfEmploymentBsasRequestData
+import v5.submitSelfEmploymentBsas.schema.SubmitSelfEmploymentBsasSchema
+
+trait MockSubmitSelfEmploymentBsasValidatorFactory extends MockValidatorFactory[SubmitSelfEmploymentBsasRequestData] {
+
+  val mockSubmitSelfEmploymentBsasValidatorFactory: SubmitSelfEmploymentBsasValidatorFactory = mock[SubmitSelfEmploymentBsasValidatorFactory]
+
+  def validator(): CallHandler[Validator[SubmitSelfEmploymentBsasRequestData]] =
+    (mockSubmitSelfEmploymentBsasValidatorFactory
+      .validator(_: String, _: String, _: Option[String], _: JsValue, _: SubmitSelfEmploymentBsasSchema))
+      .expects(*, *, *, *, *)
+
+}

--- a/test/v5/submitSelfEmploymentBsas/validators/def1/Def1_SubmitSelfEmploymentBsasValidatorSpec.scala
+++ b/test/v5/submitSelfEmploymentBsas/validators/def1/Def1_SubmitSelfEmploymentBsasValidatorSpec.scala
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitSelfEmploymentBsas.validators.def1
+
+import org.scalatest.Assertion
+import play.api.libs.json._
+import shared.UnitSpec
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.errors._
+import shared.models.utils.JsonErrorValidators
+import v5.models.errors._
+import v5.submitSelfEmploymentBsas.fixtures.def1.SubmitSelfEmploymentBsasFixtures._
+import v5.submitSelfEmploymentBsas.models.def1.Def1_SubmitSelfEmploymentBsasRequestData
+
+class Def1_SubmitSelfEmploymentBsasValidatorSpec extends UnitSpec with JsonErrorValidators {
+
+  private implicit val correlationId: String = "1234"
+
+  private val validNino          = "AA123456A"
+  private val validCalculationId = "a54ba782-5ef4-47f4-ab72-495406665ca9"
+  private val validTaxYear       = "2023-24"
+
+  private val parsedNino          = Nino(validNino)
+  private val parsedCalculationId = CalculationId(validCalculationId)
+  private val parsedTaxYear       = TaxYear.fromMtd(validTaxYear)
+
+  private def validator(nino: String, calculationId: String, taxYear: Option[String], body: JsValue) =
+    new Def1_SubmitSelfEmploymentBsasValidator(nino, calculationId, taxYear, body)
+
+  "running a validation" should {
+    "return the parsed domain object" when {
+
+      "passed a valid request" in {
+        val result = validator(validNino, validCalculationId, None, mtdRequestJson).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitSelfEmploymentBsasRequestData(parsedNino, parsedCalculationId, None, parsedMtdRequestBody)
+        )
+      }
+
+      "passed a valid request with only consolidated expenses" in {
+        val result =
+          validator(validNino, validCalculationId, None, mtdRequestWithOnlyConsolidatedExpenses).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitSelfEmploymentBsasRequestData(parsedNino, parsedCalculationId, None, parsedMtdRequestWithOnlyConsolidatedExpensesBody)
+        )
+      }
+
+      "passed valid parameters with only additions expenses" in {
+        val result =
+          validator(validNino, validCalculationId, None, mtdRequestWithOnlyAdditionsExpenses)
+            .validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitSelfEmploymentBsasRequestData(parsedNino, parsedCalculationId, None, parsedMtdRequestWithOnlyAdditionsExpenses)
+        )
+      }
+
+      "passed a valid TYS tax year" in {
+        val result =
+          validator(validNino, validCalculationId, Some(validTaxYear), mtdRequestWithOnlyAdditionsExpenses)
+            .validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitSelfEmploymentBsasRequestData(parsedNino, parsedCalculationId, Some(parsedTaxYear), parsedMtdRequestWithOnlyAdditionsExpenses)
+        )
+      }
+    }
+
+    "return NinoFormatError" when {
+      "passed an invalid nino" in {
+        val result = validator("A12344A", validCalculationId, None, mtdRequestJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, NinoFormatError)
+        )
+      }
+    }
+
+    "return CalculationIdFormatError error" when {
+      "passed an invalid calculationId" in {
+        val result = validator(validNino, "12345", None, mtdRequestJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, CalculationIdFormatError)
+        )
+      }
+    }
+
+    "return RuleIncorrectOrEmptyBodyError" when {
+      "passed an empty body" in {
+        val body   = Json.parse("{}")
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError)
+        )
+      }
+
+      "an object/array is empty or mandatory field is missing" when {
+        List(
+          "/income",
+          "/income/turnover",
+          "/income/other"
+        ).foreach(path => testWith(mtdRequestJson.replaceWithEmptyObject(path), path))
+
+        List(
+          "/expenses",
+          "/expenses/costOfGoodsAllowable",
+          "/expenses/paymentsToSubcontractorsAllowable",
+          "/expenses/wagesAndStaffCostsAllowable"
+        ).foreach(path => testWith(mtdRequestJson.replaceWithEmptyObject(path), path))
+
+        List(
+          "/additions",
+          "/additions/costOfGoodsDisallowable",
+          "/additions/paymentsToSubcontractorsDisallowable"
+        ).foreach(path => testWith(mtdRequestJson.replaceWithEmptyObject(path), path))
+
+        def testWith(body: JsValue, expectedPath: String): Unit =
+          s"for $expectedPath" in {
+            val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+            result shouldBe Left(
+              ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError.withPath(expectedPath))
+            )
+          }
+      }
+
+      "income object is empty" in {
+        val body   = Json.parse(""" { "income": {} }""")
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError.withPath("/income"))
+        )
+      }
+
+      "expenses object is empty" in {
+        val body   = Json.parse(""" { "expenses": {} }""")
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError.withPath("/expenses"))
+        )
+      }
+
+      "additions object is empty" in {
+        val body   = Json.parse(""" { "additions": {} }""")
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError.withPath("/additions"))
+        )
+      }
+
+      "a field is empty" in {
+        val body   = Json.parse(""" { "wagesAndStaffCostsDisallowable": {} }""")
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError)
+        )
+      }
+
+      "an object is invalid" in {
+        val body   = Json.parse(""" { "income": "not-an-object" }""")
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError.withPath("/income"))
+        )
+      }
+    }
+
+    "return ValueFormatError" when {
+      "single fields are invalid" when {
+        List(
+          "/income/turnover",
+          "/income/other",
+          "/expenses/costOfGoodsAllowable",
+          "/expenses/paymentsToSubcontractorsAllowable",
+          "/expenses/wagesAndStaffCostsAllowable",
+          "/expenses/carVanTravelExpensesAllowable",
+          "/expenses/premisesRunningCostsAllowable",
+          "/expenses/maintenanceCostsAllowable",
+          "/expenses/adminCostsAllowable",
+          "/expenses/interestOnBankOtherLoansAllowable",
+          "/expenses/financeChargesAllowable",
+          "/expenses/irrecoverableDebtsAllowable",
+          "/expenses/professionalFeesAllowable",
+          "/expenses/depreciationAllowable",
+          "/expenses/otherExpensesAllowable",
+          "/expenses/advertisingCostsAllowable",
+          "/expenses/businessEntertainmentCostsAllowable",
+          "/additions/costOfGoodsDisallowable",
+          "/additions/paymentsToSubcontractorsDisallowable",
+          "/additions/wagesAndStaffCostsDisallowable",
+          "/additions/carVanTravelExpensesDisallowable",
+          "/additions/premisesRunningCostsDisallowable",
+          "/additions/maintenanceCostsDisallowable",
+          "/additions/adminCostsDisallowable",
+          "/additions/interestOnBankOtherLoansDisallowable",
+          "/additions/financeChargesDisallowable",
+          "/additions/irrecoverableDebtsDisallowable",
+          "/additions/professionalFeesDisallowable",
+          "/additions/depreciationDisallowable",
+          "/additions/otherExpensesDisallowable",
+          "/additions/advertisingCostsDisallowable",
+          "/additions/businessEntertainmentCostsDisallowable"
+        ).foreach(path => testWith(mtdRequestJson.update(path, _), path))
+      }
+
+      "consolidated expenses is invalid" when {
+        List(
+          "/expenses/consolidatedExpenses"
+        ).foreach(path => testWith(mtdRequestWithOnlyConsolidatedExpenses.update(path, _), path))
+      }
+
+      "multiple fields are invalid" in {
+        val path1 = "/income/turnover"
+        val path2 = "/expenses/consolidatedExpenses"
+        val path3 = "/additions/costOfGoodsDisallowable"
+
+        val body = Json.parse(
+          s"""{
+             |	"income": {
+             |		"turnover": 0
+             |	},
+             |	"expenses": {
+             |		"consolidatedExpenses": 123.123
+             |	},
+             |  "additions": {
+             |    "costOfGoodsDisallowable": 999999999999.99
+             | }
+             |}
+             |""".stripMargin
+        )
+
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            BadRequestError,
+            Some(List(
+              ValueFormatError
+                .copy(paths = Some(List(path1, path2, path3)), message = "The value must be between -99999999999.99 and 99999999999.99"),
+              RuleBothExpensesError.withPath("/expenses") // because there's consolidatedExpenses + an addition
+            ))
+          )
+        )
+      }
+
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit = s"for $expectedPath" when {
+        def doTest(value: JsNumber): Assertion = {
+          val result = validator(validNino, validCalculationId, None, body(value)).validateAndWrapResult()
+
+          result shouldBe Left(
+            ErrorWrapper(
+              correlationId,
+              ValueFormatError.forPathAndRange(expectedPath, "-99999999999.99", "99999999999.99")
+            )
+          )
+        }
+
+        "value is out of range" in doTest(JsNumber(99999999999.99 + 0.01))
+
+        "value is zero" in doTest(JsNumber(0))
+      }
+    }
+
+    "return RuleBothExpensesSuppliedError" when {
+      "passed consolidated and separate expenses" in {
+        val result = validator(validNino, validCalculationId, None, mtdRequestWithBothExpenses).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleBothExpensesError.withPath("/expenses"))
+        )
+      }
+    }
+
+    "return multiple errors" when {
+      "passed multiple invalid fields" in {
+        val result = validator("not-a-nino", "not-a-calculation-id", None, mtdRequestJson).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            BadRequestError,
+            Some(List(CalculationIdFormatError, NinoFormatError))
+          )
+        )
+      }
+    }
+
+    "return InvalidTaxYearParameterError" when {
+      "passed a tax year before TYS" in {
+        val result = validator(validNino, validCalculationId, Some("2022-23"), mtdRequestJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, InvalidTaxYearParameterError)
+        )
+      }
+    }
+  }
+
+  "return TaxYearFormatError" when {
+    "passed an incorrectly formatted tax year" in {
+      val result = validator(validNino, validCalculationId, Some("202324"), mtdRequestJson).validateAndWrapResult()
+      result shouldBe Left(
+        ErrorWrapper(correlationId, TaxYearFormatError)
+      )
+    }
+  }
+
+  "return RuleTaxYearRangeInvalidError error" when {
+    "passed a tax year range of more than one year" in {
+      val result = validator(validNino, validCalculationId, Some("2022-24"), mtdRequestJson).validateAndWrapResult()
+      result shouldBe Left(
+        ErrorWrapper(correlationId, RuleTaxYearRangeInvalidError)
+      )
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/connectors/MockSubmitUkPropertyBsasConnector.scala
+++ b/test/v5/submitUkPropertyBsas/connectors/MockSubmitUkPropertyBsasConnector.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.connectors
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.connectors.DownstreamOutcome
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasRequestData
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockSubmitUkPropertyBsasConnector extends MockFactory {
+
+  val mockConnector: SubmitUkPropertyBsasConnector = mock[SubmitUkPropertyBsasConnector]
+
+  object MockSubmitUKPropertyBsasConnector {
+
+    def submitUKPropertyBsas(requestData: SubmitUkPropertyBsasRequestData): CallHandler[Future[DownstreamOutcome[Unit]]] = {
+      (mockConnector
+        .submitPropertyBsas(_: SubmitUkPropertyBsasRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(requestData, *, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/connectors/SubmitUkPropertyBsasConnectorSpec.scala
+++ b/test/v5/submitUkPropertyBsas/connectors/SubmitUkPropertyBsasConnectorSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.connectors
+
+import shared.connectors.{ConnectorSpec, DownstreamOutcome}
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.outcomes.ResponseWrapper
+import v5.submitUkPropertyBsas.fixtures.def1.SubmitUKPropertyBsasRequestBodyFixtures._
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasRequestData
+import v5.submitUkPropertyBsas.models.def1.Def1_SubmitUkPropertyBsasRequestData
+
+import scala.concurrent.Future
+
+class SubmitUkPropertyBsasConnectorSpec extends ConnectorSpec {
+
+  private val nino          = Nino("AA123456A")
+  private val calculationId = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+  private val nonTysRequest = makeRequest(None)
+  private val tysRequest    = makeRequest(Some("2023-24"))
+
+  def makeRequest(taxYear: Option[String]): SubmitUkPropertyBsasRequestData = {
+    Def1_SubmitUkPropertyBsasRequestData(
+      nino = nino,
+      calculationId = calculationId,
+      taxYear = taxYear.map(TaxYear.fromMtd),
+      body = nonFHLBody
+    )
+  }
+
+  trait Test {
+    _: ConnectorTest =>
+
+    protected val connector: SubmitUkPropertyBsasConnector = new SubmitUkPropertyBsasConnector(
+      http = mockHttpClient,
+      appConfig = mockAppConfig
+    )
+
+  }
+
+  "SubmitUKPropertyBsasConnector" when {
+    "SubmitUKPropertyBsas" must {
+
+      "post a SubmitBsasRequest body and return the result for the non-TYS scenario" in new IfsTest with Test {
+        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val url     = s"$baseUrl/income-tax/adjustable-summary-calculation/$nino/$calculationId"
+        willPut(url = url, body = nonFHLBody) returns Future.successful(outcome)
+
+        val result: DownstreamOutcome[Unit] = await(connector.submitPropertyBsas(nonTysRequest))
+        result shouldBe outcome
+      }
+
+      "post a SubmitBsasRequest body and return the result for the TYS scenario" in new TysIfsTest with Test {
+        val outcome = Right(ResponseWrapper(correlationId, ()))
+        val url     = s"$baseUrl/income-tax/adjustable-summary-calculation/23-24/$nino/$calculationId"
+        willPut(url = url, body = nonFHLBody) returns Future.successful(outcome)
+
+        val result: DownstreamOutcome[Unit] = await(connector.submitPropertyBsas(tysRequest))
+        result shouldBe outcome
+      }
+
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/controllers/SubmitUkPropertyBsasControllerSpec.scala
+++ b/test/v5/submitUkPropertyBsas/controllers/SubmitUkPropertyBsasControllerSpec.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.controllers
+
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Result
+import shared.config.MockAppConfig
+import shared.controllers.{ControllerBaseSpec, ControllerTestRunner}
+import shared.hateoas.Method.GET
+import shared.hateoas.{HateoasWrapper, Link, MockHateoasFactory}
+import shared.models.audit.{AuditEvent, AuditResponse, GenericAuditDetail}
+import shared.models.domain.{CalculationId, TaxYear}
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.{MockAuditService, MockEnrolmentsAuthService, MockMtdIdLookupService}
+import shared.utils.MockIdGenerator
+import v5.models.errors._
+import v5.submitUkPropertyBsas.fixtures.def1.SubmitUKPropertyBsasRequestBodyFixtures._
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasHateoasData
+import v5.submitUkPropertyBsas.models.def1.Def1_SubmitUkPropertyBsasRequestData
+import v5.submitUkPropertyBsas.services.MockSubmitUkPropertyBsasService
+import v5.submitUkPropertyBsas.validators.MockSubmitUkPropertyBsasValidatorFactory
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class SubmitUkPropertyBsasControllerSpec
+    extends ControllerBaseSpec
+    with ControllerTestRunner
+    with MockEnrolmentsAuthService
+    with MockMtdIdLookupService
+    with MockSubmitUkPropertyBsasValidatorFactory
+    with MockSubmitUkPropertyBsasService
+    with MockHateoasFactory
+    with MockIdGenerator
+    with MockAuditService
+    with MockAppConfig {
+
+  private val calculationId = CalculationId("c75f40a6-a3df-4429-a697-471eeec46435")
+  private val rawTaxYear    = "2023-24"
+  private val taxYear       = TaxYear.fromMtd(rawTaxYear)
+
+  private val requestData = Def1_SubmitUkPropertyBsasRequestData(
+    nino = parsedNino,
+    calculationId = calculationId,
+    body = nonFHLBody,
+    taxYear = Some(taxYear)
+  )
+
+  val testHateoasLinks: Seq[Link] = Seq(
+    Link(
+      href = s"/individuals/self-assessment/adjustable-summary/$validNino/uk-property/$calculationId",
+      method = GET,
+      rel = "self"
+    )
+  )
+
+  private val mtdResponseJson = Json.parse(hateoasResponse(validNino, calculationId.calculationId))
+
+  "submitUkPropertyBsas" should {
+
+    "return OK" when {
+      "the request is valid" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockSubmitUkPropertyBsasService
+          .submitPropertyBsas(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
+
+        MockHateoasFactory
+          .wrap((), SubmitUkPropertyBsasHateoasData(validNino, calculationId.calculationId, Some(taxYear)))
+          .returns(HateoasWrapper((), testHateoasLinks))
+
+        runOkTestWithAudit(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(mtdResponseJson),
+          maybeAuditRequestBody = Some(validNonFHLInputJson),
+          maybeAuditResponseBody = Some(mtdResponseJson)
+        )
+      }
+    }
+
+    "return parser errors as per spec" when {
+
+      "the parser validation fails" in new Test {
+        willUseValidator(returning(NinoFormatError))
+        runErrorTestWithAudit(NinoFormatError, maybeAuditRequestBody = Some(validNonFHLInputJson))
+      }
+
+      "multiple parser errors occur" in new Test {
+        private val errors = List(CalculationIdFormatError, NinoFormatError)
+        willUseValidator(returningErrors(errors))
+        runMultipleErrorsTestWithAudit(errors, maybeAuditRequestBody = Some(validNonFHLInputJson))
+      }
+    }
+
+    "the service returns an error" in new Test {
+      willUseValidator(returningSuccess(requestData))
+
+      MockSubmitUkPropertyBsasService
+        .submitPropertyBsas(requestData)
+        .returns(Future.successful(Left(ErrorWrapper(correlationId, RuleOverConsolidatedExpensesThreshold))))
+
+      runErrorTestWithAudit(RuleOverConsolidatedExpensesThreshold, maybeAuditRequestBody = Some(validNonFHLInputJson))
+    }
+  }
+
+  trait Test extends ControllerTest with AuditEventChecking {
+
+    val controller = new SubmitUkPropertyBsasController(
+      authService = mockEnrolmentsAuthService,
+      lookupService = mockMtdIdLookupService,
+      validatorFactory = mockSubmitUkPropertyBsasValidatorFactory,
+      service = mockService,
+      hateoasFactory = mockHateoasFactory,
+      auditService = mockAuditService,
+      cc = cc,
+      idGenerator = mockIdGenerator
+    )
+
+    protected def callController(): Future[Result] =
+      controller.handleRequest(validNino, calculationId.calculationId, Some(rawTaxYear))(fakePostRequest(validNonFHLInputJson))
+
+    protected def event(auditResponse: AuditResponse, maybeRequestBody: Option[JsValue]): AuditEvent[GenericAuditDetail] =
+      AuditEvent(
+        auditType = "SubmitUKPropertyAccountingAdjustments",
+        transactionName = "submit-uk-property-accounting-adjustments",
+        detail = GenericAuditDetail(
+          versionNumber = apiVersion.name,
+          userType = "Individual",
+          agentReferenceNumber = None,
+          params = Map("nino" -> validNino, "calculationId" -> calculationId.calculationId),
+          requestBody = maybeRequestBody,
+          `X-CorrelationId` = correlationId,
+          auditResponse = auditResponse
+        )
+      )
+
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/fixtures/def1/SubmitUKPropertyBsasRequestBodyFixtures.scala
+++ b/test/v5/submitUkPropertyBsas/fixtures/def1/SubmitUKPropertyBsasRequestBodyFixtures.scala
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.fixtures.def1
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import v5.submitUkPropertyBsas.models.def1._
+
+object SubmitUKPropertyBsasRequestBodyFixtures {
+
+  val mtdRequestNonFhlFull: JsValue = Json.parse("""
+      |{
+      |  "nonFurnishedHolidayLet": {
+      |    "income": {
+      |      "totalRentsReceived": 1.45,
+      |      "premiumsOfLeaseGrant": 2.45,
+      |      "reversePremiums": 3.45,
+      |      "otherPropertyIncome": 4.45
+      |    },
+      |    "expenses": {
+      |      "consolidatedExpenses": 5.45,
+      |      "premisesRunningCosts": 6.45,
+      |      "repairsAndMaintenance": 7.45,
+      |      "financialCosts": 8.45,
+      |      "professionalFees": 9.45,
+      |      "costOfServices": 10.45,
+      |      "residentialFinancialCost": 11.45,
+      |      "other": 12.45,
+      |      "travelCosts": 13.45
+      |    }
+      |  }
+      |}
+      |""".stripMargin)
+
+  val validNonFHLInputJson: JsValue = Json.parse("""
+      |{
+      |  "nonFurnishedHolidayLet": {
+      |    "income": {
+      |      "totalRentsReceived": 1.45,
+      |      "premiumsOfLeaseGrant": 2.45,
+      |      "reversePremiums": 3.45,
+      |      "otherPropertyIncome": 4.45
+      |    },
+      |    "expenses": {
+      |      "premisesRunningCosts": 6.45,
+      |      "repairsAndMaintenance": 7.45,
+      |      "financialCosts": 8.45,
+      |      "professionalFees": 9.45,
+      |      "costOfServices": 10.45,
+      |      "residentialFinancialCost": 11.45,
+      |      "other": 12.45,
+      |      "travelCosts": 13.45
+      |    }
+      |  }
+      |}
+      |""".stripMargin)
+
+  val requestNonFhlFullModel: Def1_SubmitUkPropertyBsasRequestBody = Def1_SubmitUkPropertyBsasRequestBody(
+    nonFurnishedHolidayLet = Some(
+      NonFurnishedHolidayLet(
+        income = Some(
+          NonFHLIncome(
+            totalRentsReceived = Some(1.45),
+            premiumsOfLeaseGrant = Some(2.45),
+            reversePremiums = Some(3.45),
+            otherPropertyIncome = Some(4.45)
+          )),
+        expenses = Some(NonFHLExpenses(
+          consolidatedExpenses = Some(5.45),
+          premisesRunningCosts = Some(6.45),
+          repairsAndMaintenance = Some(7.45),
+          financialCosts = Some(8.45),
+          professionalFees = Some(9.45),
+          costOfServices = Some(10.45),
+          residentialFinancialCost = Some(11.45),
+          other = Some(12.45),
+          travelCosts = Some(13.45)
+        ))
+      )),
+    furnishedHolidayLet = None
+  )
+
+  val nonFHLBody: Def1_SubmitUkPropertyBsasRequestBody = requestNonFhlFullModel
+
+  val downstreamRequestNonFhlFull: JsValue = Json.parse("""
+      |{
+      |  "incomeSourceType": "02",
+      |  "adjustments": {
+      |    "income": {
+      |      "totalRentsReceived": 1.45,
+      |      "premiumsOfLeaseGrant": 2.45,
+      |      "reversePremiums": 3.45,
+      |      "otherPropertyIncome": 4.45
+      |    },
+      |    "expenses": {
+      |      "consolidatedExpenses": 5.45,
+      |      "premisesRunningCosts": 6.45,
+      |      "repairsAndMaintenance": 7.45,
+      |      "financialCosts": 8.45,
+      |      "professionalFees": 9.45,
+      |      "costOfServices": 10.45,
+      |      "residentialFinancialCost": 11.45,
+      |      "other": 12.45,
+      |      "travelCosts": 13.45
+      |    }
+      |  }
+      |}
+      |""".stripMargin)
+
+  val nonFHLExpensesAllFields: Option[JsObject] = Some(
+    Json.obj(
+      "premisesRunningCosts"     -> 6.45,
+      "repairsAndMaintenance"    -> 7.45,
+      "financialCosts"           -> 8.45,
+      "professionalFees"         -> 9.45,
+      "costOfServices"           -> 10.45,
+      "residentialFinancialCost" -> 11.45,
+      "other"                    -> 12.45,
+      "travelCosts"              -> 13.45
+    ))
+
+  val mtdRequestFhlFull: JsValue = Json.parse("""
+      |{
+      |  "furnishedHolidayLet": {
+      |    "income": {
+      |      "totalRentsReceived": 1.45
+      |    },
+      |    "expenses": {
+      |      "consolidatedExpenses": 2.45,
+      |      "premisesRunningCosts": 3.45,
+      |      "repairsAndMaintenance": 4.45,
+      |      "financialCosts": 5.45,
+      |      "professionalFees": 6.45,
+      |      "costOfServices": 7.45,
+      |      "other": 8.45,
+      |      "travelCosts": 9.45
+      |    }
+      |  }
+      |}
+      |""".stripMargin)
+
+  val validfhlInputJson: JsValue = Json.parse("""
+      |{
+      |  "furnishedHolidayLet": {
+      |    "income": {
+      |      "totalRentsReceived": 1.45
+      |    },
+      |    "expenses": {
+      |      "premisesRunningCosts": 3.45,
+      |      "repairsAndMaintenance": 4.45,
+      |      "financialCosts": 5.45,
+      |      "professionalFees": 6.45,
+      |      "costOfServices": 7.45,
+      |      "other": 8.45,
+      |      "travelCosts": 9.45
+      |    }
+      |  }
+      |}
+      |""".stripMargin)
+
+  val fhlIncomeAllFields: Option[JsObject] = Some(Json.obj("totalRentsReceived" -> 1.45))
+
+  val fhlExpensesAllFields: Option[JsObject] = Some(
+    Json.obj(
+      "premisesRunningCosts"  -> 3.45,
+      "repairsAndMaintenance" -> 4.45,
+      "financialCosts"        -> 5.45,
+      "professionalFees"      -> 6.45,
+      "costOfServices"        -> 7.45,
+      "other"                 -> 8.45,
+      "travelCosts"           -> 9.45
+    ))
+
+  val nonFHLIncomeAllFields: Option[JsObject] = Some(
+    Json.obj(
+      "totalRentsReceived"   -> 1.45,
+      "premiumsOfLeaseGrant" -> 2.45,
+      "reversePremiums"      -> 3.45,
+      "otherPropertyIncome"  -> 4.45
+    ))
+
+  val requestFhlFullModel: Def1_SubmitUkPropertyBsasRequestBody = Def1_SubmitUkPropertyBsasRequestBody(
+    nonFurnishedHolidayLet = None,
+    furnishedHolidayLet = Some(
+      FurnishedHolidayLet(
+        income = Some(
+          FHLIncome(
+            totalRentsReceived = Some(1.45)
+          )),
+        expenses = Some(FHLExpenses(
+          consolidatedExpenses = Some(2.45),
+          premisesRunningCosts = Some(3.45),
+          repairsAndMaintenance = Some(4.45),
+          financialCosts = Some(5.45),
+          professionalFees = Some(6.45),
+          costOfServices = Some(7.45),
+          other = Some(8.45),
+          travelCosts = Some(9.45)
+        ))
+      ))
+  )
+
+  val fhlBody: Def1_SubmitUkPropertyBsasRequestBody = requestFhlFullModel
+
+  val downstreamRequestFhlFull: JsValue = Json.parse("""
+      |{
+      |  "incomeSourceType": "04",
+      |  "adjustments": {
+      |    "income": {
+      |      "rentReceived": 1.45
+      |    },
+      |    "expenses": {
+      |      "consolidatedExpenses": 2.45,
+      |      "premisesRunningCosts": 3.45,
+      |      "repairsAndMaintenance": 4.45,
+      |      "financialCosts": 5.45,
+      |      "professionalFees": 6.45,
+      |      "costOfServices": 7.45,
+      |      "other": 8.45,
+      |      "travelCosts": 9.45
+      |    }
+      |  }
+      |}
+      |""".stripMargin)
+
+  def submitBsasRawDataBodyFHL(income: Option[JsObject] = None, expenses: Option[JsObject] = None): JsValue = {
+    Json.obj(
+      "furnishedHolidayLet" ->
+        (income.fold(Json.obj())(income => Json.obj("income" -> income)) ++
+          expenses.fold(Json.obj())(expenses => Json.obj("expenses" -> expenses))))
+  }
+
+  def submitBsasRawDataBodyNonFHL(income: Option[JsObject] = None, expenses: Option[JsObject] = None): JsValue = {
+    Json.obj(
+      "nonFurnishedHolidayLet" ->
+        (income.fold(Json.obj())(income => Json.obj("income" -> income)) ++
+          expenses.fold(Json.obj())(expenses => Json.obj("expenses" -> expenses))))
+  }
+
+  def hateoasResponse(nino: String, calcId: String, taxYear: Option[String] = None): String = {
+    val taxYearParam = taxYear.fold("")("?taxYear=" + _)
+
+    s"""
+       |{
+       |  "links":[
+       |    {
+       |      "href":"/individuals/self-assessment/adjustable-summary/$nino/uk-property/$calcId$taxYearParam",
+       |      "rel":"self",
+       |      "method":"GET"
+       |    }
+       |  ]
+       |}
+    """.stripMargin
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/models/SubmitUkPropertyBsasHateoasDataSpec.scala
+++ b/test/v5/submitUkPropertyBsas/models/SubmitUkPropertyBsasHateoasDataSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models
+
+import play.api.Configuration
+import shared.UnitSpec
+import shared.config.MockAppConfig
+import shared.hateoas.Method.GET
+import shared.hateoas.{HateoasFactory, HateoasWrapper, Link}
+import shared.models.domain.TaxYear
+
+class SubmitUkPropertyBsasHateoasDataSpec extends UnitSpec {
+
+  "HateoasFactory" must {
+    class Test extends MockAppConfig {
+      val hateoasFactory = new HateoasFactory(mockAppConfig)
+      val nino           = "someNino"
+      val calcId         = "anId"
+      val taxYear        = Some(TaxYear.fromMtd("2023-24"))
+      val context        = "individuals/self-assessment/adjustable-summary"
+
+      MockAppConfig.apiGatewayContext.returns(context).anyNumberOfTimes()
+    }
+
+    class TysDisabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> false)).anyNumberOfTimes()
+    }
+
+    class TysEnabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> true)).anyNumberOfTimes()
+    }
+
+    "return the correct links without tax year" in new TysDisabledTest {
+      private val result       = hateoasFactory.wrap((), SubmitUkPropertyBsasHateoasData(nino, calcId, None))
+      private val expectedLink = Link(s"/$context/$nino/uk-property/$calcId", GET, "self")
+
+      result shouldBe HateoasWrapper((), Seq(expectedLink))
+    }
+
+    "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+      private val result       = hateoasFactory.wrap((), SubmitUkPropertyBsasHateoasData(nino, calcId, taxYear))
+      private val expectedLink = Link(s"/$context/$nino/uk-property/$calcId?taxYear=2023-24", GET, "self")
+
+      result shouldBe HateoasWrapper((), Seq(expectedLink))
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/models/def1/Def1_SubmitUkPropertyBsasRequestBodySpec.scala
+++ b/test/v5/submitUkPropertyBsas/models/def1/Def1_SubmitUkPropertyBsasRequestBodySpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, Json}
+import shared.UnitSpec
+import v5.submitUkPropertyBsas.fixtures.def1.SubmitUKPropertyBsasRequestBodyFixtures._
+
+class Def1_SubmitUkPropertyBsasRequestBodySpec extends UnitSpec {
+
+  val emptyModel: Def1_SubmitUkPropertyBsasRequestBody = Def1_SubmitUkPropertyBsasRequestBody(None, None)
+
+  val nonFhlModel: Def1_SubmitUkPropertyBsasRequestBody = Def1_SubmitUkPropertyBsasRequestBody(Some(NonFurnishedHolidayLet(None, None)), None)
+
+  val fhlModel: Def1_SubmitUkPropertyBsasRequestBody = Def1_SubmitUkPropertyBsasRequestBody(None, Some(FurnishedHolidayLet(None, None)))
+
+  "reads" when {
+    "reading a simple non-fhl body" should {
+      "return the expected non-fhl model" in {
+        Json
+          .parse("""
+            |{
+            |  "nonFurnishedHolidayLet": {
+            |  }
+            |}
+            |""".stripMargin)
+          .as[Def1_SubmitUkPropertyBsasRequestBody] shouldBe nonFhlModel
+      }
+    }
+
+    "reading a simple fhl body" should {
+      "return the expected fhl model" in {
+        Json
+          .parse(
+            """
+              |{
+              |  "furnishedHolidayLet": {
+              |  }
+              |}
+              |""".stripMargin
+          )
+          .as[Def1_SubmitUkPropertyBsasRequestBody] shouldBe fhlModel
+      }
+    }
+
+    "reading a full non-fhl body" should {
+      "return the expected non-fhl model" in {
+        mtdRequestNonFhlFull.as[Def1_SubmitUkPropertyBsasRequestBody] shouldBe requestNonFhlFullModel
+      }
+    }
+
+    "reading a full fhl body" should {
+      "return the expected fhl model" in {
+        mtdRequestFhlFull.as[Def1_SubmitUkPropertyBsasRequestBody] shouldBe requestFhlFullModel
+      }
+    }
+
+    "reading an empty body" should {
+      "return an empty model" in {
+        JsObject.empty.as[Def1_SubmitUkPropertyBsasRequestBody] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "writing a simple non-fhl model" should {
+      "return the downstream JSON" in {
+        Json.toJson(nonFhlModel) shouldBe Json.parse("""
+            |{
+            |  "incomeSourceType": "02",
+            |  "adjustments": {
+            |  }
+            |}
+            |""".stripMargin)
+      }
+    }
+
+    "writing a simple fhl model" should {
+      "return the downstream JSON" in {
+        Json.toJson(fhlModel) shouldBe Json.parse(
+          """
+            |{
+            |  "incomeSourceType": "04",
+            |  "adjustments": {
+            |  }
+            |}
+            |""".stripMargin
+        )
+      }
+    }
+
+    "writing a full non-fhl model" should {
+      "return the downstream JSON" in {
+        Json.toJson(requestNonFhlFullModel) shouldBe downstreamRequestNonFhlFull
+      }
+    }
+
+    "writing a full fhl model" should {
+      "return the downstream JSON" in {
+        Json.toJson(requestFhlFullModel) shouldBe downstreamRequestFhlFull
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/models/def1/FHLExpensesSpec.scala
+++ b/test/v5/submitUkPropertyBsas/models/def1/FHLExpensesSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import shared.UnitSpec
+
+class FHLExpensesSpec extends UnitSpec {
+
+  val json: JsValue = Json.parse("""
+      |{
+      |  "premisesRunningCosts": 1.12,
+      |  "repairsAndMaintenance": 2.12,
+      |  "financialCosts": 3.12,
+      |  "professionalFees": 4.12,
+      |  "costOfServices": 6.12,
+      |  "travelCosts": 5.12,
+      |  "other": 7.12,
+      |  "consolidatedExpenses": 8.12
+      |}
+      |""".stripMargin)
+
+  val model: FHLExpenses = FHLExpenses(
+    premisesRunningCosts = Some(1.12),
+    repairsAndMaintenance = Some(2.12),
+    financialCosts = Some(3.12),
+    professionalFees = Some(4.12),
+    travelCosts = Some(5.12),
+    costOfServices = Some(6.12),
+    other = Some(7.12),
+    consolidatedExpenses = Some(8.12)
+  )
+
+  val emptyModel: FHLExpenses = FHLExpenses(None, None, None, None, None, None, None, None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        json.as[FHLExpenses] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        JsObject.empty.as[FHLExpenses] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe json
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/models/def1/FHLIncomeSpec.scala
+++ b/test/v5/submitUkPropertyBsas/models/def1/FHLIncomeSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, Json}
+import shared.UnitSpec
+
+class FHLIncomeSpec extends UnitSpec {
+
+  val model: FHLIncome = FHLIncome(Some(123.12))
+
+  val emptyModel: FHLIncome = FHLIncome(None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        Json
+          .parse("""
+              |{
+              |   "totalRentsReceived": 123.12
+              |}
+              |""".stripMargin)
+          .as[FHLIncome] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        JsObject.empty.as[FHLIncome] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe
+          Json.parse("""
+              |{
+              |   "rentReceived": 123.12
+              |}
+              |""".stripMargin)
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/models/def1/FurnishedHolidayLetSpec.scala
+++ b/test/v5/submitUkPropertyBsas/models/def1/FurnishedHolidayLetSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import shared.UnitSpec
+
+class FurnishedHolidayLetSpec extends UnitSpec {
+
+  // Use simple case as formats for contents of income/expenses are tested elsewhere...
+  val json: JsValue = Json.parse("""
+      |{
+      |  "income": {
+      |  },
+      |  "expenses": {
+      |  }
+      |}
+      |""".stripMargin)
+
+  val model: FurnishedHolidayLet = FurnishedHolidayLet(
+    Some(FHLIncome(None)),
+    Some(FHLExpenses(None, None, None, None, None, None, None, None))
+  )
+
+  val emptyModel: FurnishedHolidayLet = FurnishedHolidayLet(None, None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        json.as[FurnishedHolidayLet] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        JsObject.empty.as[FurnishedHolidayLet] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe json
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/models/def1/NonFHLExpensesSpec.scala
+++ b/test/v5/submitUkPropertyBsas/models/def1/NonFHLExpensesSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import shared.UnitSpec
+
+class NonFHLExpensesSpec extends UnitSpec {
+
+  val json: JsValue = Json.parse("""
+      |{
+      |  "premisesRunningCosts": 1.12,
+      |  "repairsAndMaintenance": 2.12,
+      |  "financialCosts": 3.12,
+      |  "professionalFees": 4.12,
+      |  "travelCosts": 5.12,
+      |  "costOfServices": 6.12,
+      |  "residentialFinancialCost": 7.12,
+      |  "other": 8.12,
+      |  "consolidatedExpenses": 9.12
+      |}
+      |""".stripMargin)
+
+  val model: NonFHLExpenses = NonFHLExpenses(
+    premisesRunningCosts = Some(1.12),
+    repairsAndMaintenance = Some(2.12),
+    financialCosts = Some(3.12),
+    professionalFees = Some(4.12),
+    travelCosts = Some(5.12),
+    costOfServices = Some(6.12),
+    residentialFinancialCost = Some(7.12),
+    other = Some(8.12),
+    consolidatedExpenses = Some(9.12)
+  )
+
+  val emptyModel: NonFHLExpenses = NonFHLExpenses(None, None, None, None, None, None, None, None, None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        json.as[NonFHLExpenses] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        JsObject.empty.as[NonFHLExpenses] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe json
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/models/def1/NonFHLIncomeSpec.scala
+++ b/test/v5/submitUkPropertyBsas/models/def1/NonFHLIncomeSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import shared.UnitSpec
+
+class NonFHLIncomeSpec extends UnitSpec {
+
+  val json: JsValue = Json
+    .parse("""
+        |{
+        |   "totalRentsReceived": 1.12,
+        |   "premiumsOfLeaseGrant": 2.12,
+        |   "reversePremiums": 3.12,
+        |   "otherPropertyIncome": 4.12
+        |}
+        |""".stripMargin)
+
+  val model: NonFHLIncome =
+    NonFHLIncome(
+      totalRentsReceived = Some(1.12),
+      premiumsOfLeaseGrant = Some(2.12),
+      reversePremiums = Some(3.12),
+      otherPropertyIncome = Some(4.12)
+    )
+
+  val emptyModel: NonFHLIncome = NonFHLIncome(None, None, None, None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        json
+          .as[NonFHLIncome] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        JsObject.empty.as[NonFHLIncome] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe json
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/models/def1/NonFurnishedHolidayLetSpec.scala
+++ b/test/v5/submitUkPropertyBsas/models/def1/NonFurnishedHolidayLetSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.models.def1
+
+import play.api.libs.json.{JsObject, JsValue, Json}
+import shared.UnitSpec
+
+class NonFurnishedHolidayLetSpec extends UnitSpec {
+
+  // Use simple case as formats for contents of income/expenses are tested elsewhere...
+  val json: JsValue = Json.parse("""
+      |{
+      |  "income": {
+      |  },
+      |  "expenses": {
+      |  }
+      |}
+      |""".stripMargin)
+
+  val model: NonFurnishedHolidayLet = NonFurnishedHolidayLet(
+    Some(NonFHLIncome(None, None, None, None)),
+    Some(NonFHLExpenses(None, None, None, None, None, None, None, None, None))
+  )
+
+  val emptyModel: NonFurnishedHolidayLet = NonFurnishedHolidayLet(None, None)
+
+  "reads" when {
+    "passed mtd json" should {
+      "return the corresponding model" in {
+        json.as[NonFurnishedHolidayLet] shouldBe model
+      }
+    }
+
+    "passed an empty JSON" should {
+      "return an empty model" in {
+        JsObject.empty.as[NonFurnishedHolidayLet] shouldBe emptyModel
+      }
+    }
+  }
+
+  "writes" when {
+    "passed a model" should {
+      "return the downstream JSON" in {
+        Json.toJson(model) shouldBe json
+      }
+    }
+
+    "passed an empty model" should {
+      "return an empty JSON" in {
+        Json.toJson(emptyModel) shouldBe JsObject.empty
+      }
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/schema/SubmitUkPropertyBsasSchemaSpec.scala
+++ b/test/v5/submitUkPropertyBsas/schema/SubmitUkPropertyBsasSchemaSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.schema
+
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import shared.UnitSpec
+import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+
+import scala.math.Ordered.orderingToOrdered
+
+class SubmitUkPropertyBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
+
+  "schema lookup" when {
+    "a tax year is present" must {
+      "use Def1 for tax years from 2023-24" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
+            SubmitUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitUkPropertyBsasSchema.Def1
+          }
+        }
+      }
+
+      "use Def1 for other tax years" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
+            SubmitUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitUkPropertyBsasSchema.Def1
+          }
+        }
+      }
+    }
+
+    "the tax year is present but not valid" must {
+      "use a default of Def1" in {
+        SubmitUkPropertyBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe SubmitUkPropertyBsasSchema.Def1
+      }
+    }
+
+    "no tax year is present" must {
+      "use a default of Def1" in {
+        SubmitUkPropertyBsasSchema.schemaFor(None) shouldBe SubmitUkPropertyBsasSchema.Def1
+      }
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/schema/SubmitUkPropertyBsasSchemaSpec.scala
+++ b/test/v5/submitUkPropertyBsas/schema/SubmitUkPropertyBsasSchemaSpec.scala
@@ -20,25 +20,19 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import shared.UnitSpec
 import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
 
-import scala.math.Ordered.orderingToOrdered
-
 class SubmitUkPropertyBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
 
   "schema lookup" when {
     "a tax year is present" must {
       "use Def1 for tax years from 2023-24" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
-            SubmitUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitUkPropertyBsasSchema.Def1
-          }
+        forTaxYearsFrom(TaxYear.fromMtd("2023-24")) { taxYear =>
+          SubmitUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitUkPropertyBsasSchema.Def1
         }
       }
 
-      "use Def1 for other tax years" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
-            SubmitUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitUkPropertyBsasSchema.Def1
-          }
+      "use Def1 for pre-TYS tax years" in {
+        forPreTysTaxYears { taxYear =>
+          SubmitUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitUkPropertyBsasSchema.Def1
         }
       }
     }

--- a/test/v5/submitUkPropertyBsas/services/MockSubmitUkPropertyBsasService.scala
+++ b/test/v5/submitUkPropertyBsas/services/MockSubmitUkPropertyBsasService.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.services
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.controllers.RequestContext
+import shared.services.ServiceOutcome
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasRequestData
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockSubmitUkPropertyBsasService extends MockFactory {
+
+  val mockService: SubmitUkPropertyBsasService = mock[SubmitUkPropertyBsasService]
+
+  object MockSubmitUkPropertyBsasService {
+
+    def submitPropertyBsas(requestData: SubmitUkPropertyBsasRequestData): CallHandler[Future[ServiceOutcome[Unit]]] = {
+      (mockService
+        .submitPropertyBsas(_: SubmitUkPropertyBsasRequestData)(_: RequestContext, _: ExecutionContext))
+        .expects(requestData, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/services/SubmitUKPropertyBsasServiceSpec.scala
+++ b/test/v5/submitUkPropertyBsas/services/SubmitUKPropertyBsasServiceSpec.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.services
+
+import shared.controllers.EndpointLogContext
+import shared.models.domain.{CalculationId, Nino}
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.ServiceSpec
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.models.errors._
+import v5.submitUkPropertyBsas.connectors.MockSubmitUkPropertyBsasConnector
+import v5.submitUkPropertyBsas.fixtures.def1.SubmitUKPropertyBsasRequestBodyFixtures._
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasRequestData
+import v5.submitUkPropertyBsas.models.def1.Def1_SubmitUkPropertyBsasRequestData
+
+import scala.concurrent.Future
+
+class SubmitUKPropertyBsasServiceSpec extends ServiceSpec {
+
+  private val nino          = Nino("AA123456A")
+  private val calculationId = CalculationId("f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c")
+
+  val requestData: SubmitUkPropertyBsasRequestData = Def1_SubmitUkPropertyBsasRequestData(
+    nino = nino,
+    calculationId = calculationId,
+    taxYear = None,
+    body = fhlBody
+  )
+
+  trait Test extends MockSubmitUkPropertyBsasConnector {
+
+    implicit val hc: HeaderCarrier              = HeaderCarrier()
+    implicit val logContext: EndpointLogContext = EndpointLogContext("controller", "submitUKPropertyBsas")
+
+    val service = new SubmitUkPropertyBsasService(connector = mockConnector)
+  }
+
+  "submitUKPropertyBsas" should {
+    "return a valid response" when {
+      "a valid request is supplied" in new Test {
+        MockSubmitUKPropertyBsasConnector
+          .submitUKPropertyBsas(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, ()))))
+
+        await(service.submitPropertyBsas(requestData)) shouldBe Right(ResponseWrapper(correlationId, ()))
+      }
+    }
+
+    "return error response" when {
+
+      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
+        s"a $downstreamErrorCode error is returned from the service" in new Test {
+
+          MockSubmitUKPropertyBsasConnector
+            .submitUKPropertyBsas(requestData)
+            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+
+          await(service.submitPropertyBsas(requestData)) shouldBe Left(ErrorWrapper(correlationId, error))
+        }
+
+      val errors = Seq(
+        "INVALID_TAXABLE_ENTITY_ID"     -> NinoFormatError,
+        "INVALID_CALCULATION_ID"        -> CalculationIdFormatError,
+        "INVALID_CORRELATIONID"         -> InternalError,
+        "INVALID_PAYLOAD"               -> InternalError,
+        "BVR_FAILURE_C55316"            -> InternalError,
+        "BVR_FAILURE_C15320"            -> InternalError,
+        "BVR_FAILURE_C55508"            -> RulePropertyIncomeAllowanceClaimed,
+        "BVR_FAILURE_C55509"            -> RulePropertyIncomeAllowanceClaimed,
+        "BVR_FAILURE_C55503"            -> RuleOverConsolidatedExpensesThreshold,
+        "BVR_FAILURE_C559107"           -> InternalError,
+        "BVR_FAILURE_C559103"           -> InternalError,
+        "BVR_FAILURE_C559099"           -> InternalError,
+        "NO_DATA_FOUND"                 -> NotFoundError,
+        "ASC_ALREADY_SUPERSEDED"        -> RuleSummaryStatusSuperseded,
+        "ASC_ALREADY_ADJUSTED"          -> RuleAlreadyAdjusted,
+        "UNALLOWABLE_VALUE"             -> RuleResultingValueNotPermitted,
+        "ASC_ID_INVALID"                -> RuleSummaryStatusInvalid,
+        "INCOMESOURCE_TYPE_NOT_MATCHED" -> RuleTypeOfBusinessIncorrectError,
+        "SERVER_ERROR"                  -> InternalError,
+        "SERVICE_UNAVAILABLE"           -> InternalError
+      )
+
+      val extraTysErrors = Seq(
+        "INVALID_TAX_YEAR"               -> TaxYearFormatError,
+        "NOT_FOUND"                      -> NotFoundError,
+        "TAX_YEAR_NOT_SUPPORTED"         -> RuleTaxYearNotSupportedError,
+        "INCOME_SOURCE_TYPE_NOT_MATCHED" -> RuleTypeOfBusinessIncorrectError
+      )
+
+      (errors ++ extraTysErrors).foreach(args => (serviceError _).tupled(args))
+    }
+  }
+
+}

--- a/test/v5/submitUkPropertyBsas/validators/MockSubmitUkPropertyBsasValidatorFactory.scala
+++ b/test/v5/submitUkPropertyBsas/validators/MockSubmitUkPropertyBsasValidatorFactory.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.validators
+
+import org.scalamock.handlers.CallHandler
+import play.api.libs.json.JsValue
+import shared.controllers.validators.{MockValidatorFactory, Validator}
+import v5.submitUkPropertyBsas.models.SubmitUkPropertyBsasRequestData
+import v5.submitUkPropertyBsas.schema.SubmitUkPropertyBsasSchema
+
+trait MockSubmitUkPropertyBsasValidatorFactory extends MockValidatorFactory[SubmitUkPropertyBsasRequestData] {
+
+  val mockSubmitUkPropertyBsasValidatorFactory: SubmitUkPropertyBsasValidatorFactory = mock[SubmitUkPropertyBsasValidatorFactory]
+
+  def validator(): CallHandler[Validator[SubmitUkPropertyBsasRequestData]] =
+    (mockSubmitUkPropertyBsasValidatorFactory
+      .validator(_: String, _: String, _: Option[String], _: JsValue, _: SubmitUkPropertyBsasSchema))
+      .expects(*, *, *, *, *)
+
+}

--- a/test/v5/submitUkPropertyBsas/validators/def1/Def1_SubmitUkPropertyBsasValidatorSpec.scala
+++ b/test/v5/submitUkPropertyBsas/validators/def1/Def1_SubmitUkPropertyBsasValidatorSpec.scala
@@ -249,6 +249,7 @@ class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
       }
 
       "passed both fhl and non-fhl even if they are empty" in {
+        // Note: no other errors should be returned
         val body = Json.parse(
           s"""
                |{
@@ -260,15 +261,7 @@ class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
         val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
 
         result shouldBe Left(
-          ErrorWrapper(
-            correlationId,
-            BadRequestError,
-            Some(
-              List(
-                RuleBothPropertiesSuppliedError,
-                RuleIncorrectOrEmptyBodyError.withPaths(List("/nonFurnishedHolidayLet", "/furnishedHolidayLet"))
-              ))
-          )
+          ErrorWrapper(correlationId, RuleBothPropertiesSuppliedError)
         )
       }
     }

--- a/test/v5/submitUkPropertyBsas/validators/def1/Def1_SubmitUkPropertyBsasValidatorSpec.scala
+++ b/test/v5/submitUkPropertyBsas/validators/def1/Def1_SubmitUkPropertyBsasValidatorSpec.scala
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.submitUkPropertyBsas.validators.def1
+
+import org.scalatest.Assertion
+import play.api.libs.json.{JsNumber, JsObject, JsValue, Json}
+import shared.UnitSpec
+import shared.models.domain.{CalculationId, Nino, TaxYear}
+import shared.models.errors._
+import shared.models.utils.JsonErrorValidators
+import v5.models.errors.{RuleBothExpensesError, RuleBothPropertiesSuppliedError}
+import v5.submitUkPropertyBsas.models.def1.{Def1_SubmitUkPropertyBsasRequestBody, Def1_SubmitUkPropertyBsasRequestData}
+
+class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorValidators {
+
+  private implicit val correlationId: String = "1234"
+
+  private val validNino          = "AA123456A"
+  private val validCalculationId = "a54ba782-5ef4-47f4-ab72-495406665ca9"
+  private val validTaxYear       = "2023-24"
+
+  private val parsedNino          = Nino(validNino)
+  private val parsedCalculationId = CalculationId(validCalculationId)
+  private val parsedTaxYear       = TaxYear.fromMtd(validTaxYear)
+
+  private val nonFhlBodyJson =
+    Json
+      .parse(
+        s"""
+       |{
+       |   "nonFurnishedHolidayLet": {
+       |      "income": {
+       |         "totalRentsReceived": 1000.45,
+       |         "premiumsOfLeaseGrant": 1000.45,
+       |         "reversePremiums": 1000.45,
+       |         "otherPropertyIncome": 1000.45
+       |      },
+       |      "expenses": {
+       |         "premisesRunningCosts": 1000.45,
+       |         "repairsAndMaintenance": 1000.45,
+       |         "financialCosts": 1000.45,
+       |         "professionalFees": 1000.45,
+       |         "costOfServices": 1000.45,
+       |         "residentialFinancialCost": 1000.45,
+       |         "other": 1000.45,
+       |         "travelCosts": 1000.45
+       |      }
+       |   }
+       |}
+       |""".stripMargin
+      )
+      .as[JsObject]
+
+  private val parsedNonFhlBody = nonFhlBodyJson.as[Def1_SubmitUkPropertyBsasRequestBody]
+
+  private val nonFhlConsolidatedBodyJson =
+    Json.parse(
+      """
+      |{
+      |   "nonFurnishedHolidayLet": {
+      |      "income": {
+      |         "totalRentsReceived": 1000.45,
+      |         "premiumsOfLeaseGrant": 1000.45,
+      |         "reversePremiums": 1000.45,
+      |         "otherPropertyIncome": 1000.45
+      |      },
+      |      "expenses": {
+      |         "consolidatedExpenses": 1000.45
+      |      }
+      |   }
+      |}""".stripMargin
+    )
+
+  private val parsedNonFhlConsolidatedBody = nonFhlConsolidatedBodyJson.as[Def1_SubmitUkPropertyBsasRequestBody]
+
+  private val fhlBodyJson =
+    Json
+      .parse(
+        s"""
+       |{
+       |   "furnishedHolidayLet": {
+       |      "income": {
+       |         "totalRentsReceived": 1000.45
+       |      },
+       |      "expenses": {
+       |         "premisesRunningCosts": 1000.45,
+       |         "repairsAndMaintenance": 1000.45,
+       |         "financialCosts": 1000.45,
+       |         "professionalFees": 1000.45,
+       |         "costOfServices": 1000.45,
+       |         "other": 1000.45,
+       |         "travelCosts": 1000.45
+       |      }
+       |   }
+       |}
+       |""".stripMargin
+      )
+      .as[JsObject]
+
+  private val parsedFhlBody = fhlBodyJson.as[Def1_SubmitUkPropertyBsasRequestBody]
+
+  private val fhlConsolidatedBodyJson =
+    Json.parse(
+      s"""
+       |{
+       |   "furnishedHolidayLet": {
+       |      "income": {
+       |         "totalRentsReceived": 1000.45
+       |      },
+       |      "expenses": {
+       |         "consolidatedExpenses": 1000.45
+       |      }
+       |   }
+       |}
+       |""".stripMargin
+    )
+
+  private val parsedFhlConsolidatedBody = fhlConsolidatedBodyJson.as[Def1_SubmitUkPropertyBsasRequestBody]
+
+  private def validator(nino: String, calculationId: String, taxYear: Option[String], body: JsValue) =
+    new Def1_SubmitUkPropertyBsasValidator(nino, calculationId, taxYear, body)
+
+  "running a validation" should {
+    "return the parsed domain object" when {
+
+      "given a valid fhl request" in {
+        val result = validator(validNino, validCalculationId, None, fhlBodyJson).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitUkPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedFhlBody)
+        )
+      }
+
+      "a valid TYS request is supplied" in {
+        val result = validator(validNino, validCalculationId, Some(validTaxYear), fhlBodyJson).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitUkPropertyBsasRequestData(parsedNino, parsedCalculationId, Some(parsedTaxYear), parsedFhlBody)
+        )
+      }
+
+      "a valid non-fhl request is supplied" in {
+        val result = validator(validNino, validCalculationId, None, nonFhlBodyJson).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitUkPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedNonFhlBody)
+        )
+      }
+
+      "a valid fhl consolidated expenses request is supplied" in {
+        val result = validator(validNino, validCalculationId, None, fhlConsolidatedBodyJson).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitUkPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedFhlConsolidatedBody)
+        )
+      }
+
+      "a valid non-fhl consolidated expenses request is supplied" in {
+        val result = validator(validNino, validCalculationId, None, nonFhlConsolidatedBodyJson).validateAndWrapResult()
+
+        result shouldBe Right(
+          Def1_SubmitUkPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedNonFhlConsolidatedBody)
+        )
+      }
+
+      "a minimal fhl request is supplied" in {
+        val minimalJson =
+          Json.parse(
+            """
+            |{
+            |   "furnishedHolidayLet": {
+            |      "income": {
+            |         "totalRentsReceived": 1000.45
+            |      }
+            |   }
+            |}
+            |""".stripMargin
+          )
+        val parsedMinimal = minimalJson.as[Def1_SubmitUkPropertyBsasRequestBody]
+
+        val result = validator(validNino, validCalculationId, None, minimalJson).validateAndWrapResult()
+        result shouldBe Right(
+          Def1_SubmitUkPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedMinimal)
+        )
+      }
+
+      "a minimal non-fhl request is supplied" in {
+        val minimalJson =
+          Json.parse(
+            """
+              |{
+              |   "nonFurnishedHolidayLet": {
+              |      "income": {
+              |         "totalRentsReceived": 1000.45
+              |      }
+              |   }
+              |}
+              |""".stripMargin
+          )
+        val parsedMinimal = minimalJson.as[Def1_SubmitUkPropertyBsasRequestBody]
+
+        val result = validator(validNino, validCalculationId, None, minimalJson).validateAndWrapResult()
+        result shouldBe Right(
+          Def1_SubmitUkPropertyBsasRequestData(parsedNino, parsedCalculationId, None, parsedMinimal)
+        )
+      }
+    }
+
+    "return NinoFormatError" when {
+      "given an invalid nino" in {
+        val result = validator("A12344A", validCalculationId, None, fhlBodyJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, NinoFormatError)
+        )
+      }
+    }
+
+    "return CalculationIdFormatError" when {
+      "given an invalid calculationId" in {
+        val result = validator(validNino, "12345", None, fhlBodyJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, CalculationIdFormatError)
+        )
+      }
+    }
+
+    "return RuleBothPropertiesSuppliedError" when {
+      "passed both fhl and non-fhl" in {
+        val body   = fhlBodyJson ++ nonFhlBodyJson
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleBothPropertiesSuppliedError)
+        )
+      }
+
+      "passed both fhl and non-fhl even if they are empty" in {
+        val body = Json.parse(
+          s"""
+               |{
+               |  "furnishedHolidayLet": {},
+               |  "nonFurnishedHolidayLet": []
+               |}
+               |""".stripMargin
+        )
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            BadRequestError,
+            Some(
+              List(
+                RuleBothPropertiesSuppliedError,
+                RuleIncorrectOrEmptyBodyError.withPaths(List("/nonFurnishedHolidayLet", "/furnishedHolidayLet"))
+              ))
+          )
+        )
+      }
+    }
+
+    "return RuleIncorrectOrEmptyBodyError" when {
+      "given an empty body" in {
+        val body   = Json.parse("{}")
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError)
+        )
+      }
+
+      "an object/array is empty or mandatory field is missing" when {
+
+        List(
+          "/furnishedHolidayLet",
+          "/furnishedHolidayLet/income",
+          "/furnishedHolidayLet/expenses"
+        ).foreach(path => testWith(fhlBodyJson.replaceWithEmptyObject(path), path))
+
+        List(
+          "/nonFurnishedHolidayLet",
+          "/nonFurnishedHolidayLet/income",
+          "/nonFurnishedHolidayLet/expenses"
+        ).foreach(path => testWith(nonFhlBodyJson.replaceWithEmptyObject(path), path))
+
+        def testWith(body: JsValue, expectedPath: String): Unit =
+          s"for $expectedPath" in {
+            val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+            result shouldBe Left(
+              ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError.withPath(expectedPath))
+            )
+          }
+      }
+
+      "an object is empty except for a additional (non-schema) property" in {
+        val body = Json.parse("""{
+                                |    "nonFurnishedHolidayLet": {
+                                |       "unknownField": 999.99
+                                |    }
+                                |}""".stripMargin)
+
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError.withPath("/nonFurnishedHolidayLet"))
+        )
+      }
+    }
+
+    "return ValueFormatError" when {
+      "income or (non-consolidated) expenses is invalid" when {
+        List(
+          "/furnishedHolidayLet/income/totalRentsReceived",
+          "/furnishedHolidayLet/expenses/premisesRunningCosts",
+          "/furnishedHolidayLet/expenses/repairsAndMaintenance",
+          "/furnishedHolidayLet/expenses/financialCosts",
+          "/furnishedHolidayLet/expenses/professionalFees",
+          "/furnishedHolidayLet/expenses/costOfServices",
+          "/furnishedHolidayLet/expenses/other",
+          "/furnishedHolidayLet/expenses/travelCosts"
+        ).foreach(path => testWith(fhlBodyJson.update(path, _), path))
+
+        List(
+          "/nonFurnishedHolidayLet/income/totalRentsReceived",
+          "/nonFurnishedHolidayLet/income/premiumsOfLeaseGrant",
+          "/nonFurnishedHolidayLet/income/reversePremiums",
+          "/nonFurnishedHolidayLet/income/otherPropertyIncome",
+          "/nonFurnishedHolidayLet/expenses/premisesRunningCosts",
+          "/nonFurnishedHolidayLet/expenses/repairsAndMaintenance",
+          "/nonFurnishedHolidayLet/expenses/financialCosts",
+          "/nonFurnishedHolidayLet/expenses/professionalFees",
+          "/nonFurnishedHolidayLet/expenses/costOfServices",
+          "/nonFurnishedHolidayLet/expenses/residentialFinancialCost",
+          "/nonFurnishedHolidayLet/expenses/other",
+          "/nonFurnishedHolidayLet/expenses/travelCosts"
+        ).foreach(path => testWith(nonFhlBodyJson.update(path, _), path))
+      }
+
+      "consolidated expenses is invalid" when {
+        List(
+          "/furnishedHolidayLet/expenses/consolidatedExpenses"
+        ).foreach(path => testWith(fhlConsolidatedBodyJson.update(path, _), path))
+
+        List(
+          "/nonFurnishedHolidayLet/expenses/consolidatedExpenses"
+        ).foreach(path => testWith(nonFhlConsolidatedBodyJson.update(path, _), path))
+      }
+
+      "multiple fields are invalid" in {
+        val path1 = "/nonFurnishedHolidayLet/income/totalRentsReceived"
+        val path2 = "/nonFurnishedHolidayLet/expenses/premisesRunningCosts"
+
+        val body = nonFhlBodyJson
+          .update(path1, JsNumber(0))
+          .update(path2, JsNumber(123.123))
+
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            ValueFormatError.copy(paths = Some(List(path1, path2)), message = "The value must be between -99999999999.99 and 99999999999.99")
+          )
+        )
+      }
+
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit = s"for $expectedPath" when {
+        def doTest(value: JsNumber): Assertion = {
+          val result = validator(validNino, validCalculationId, None, body(value)).validateAndWrapResult()
+
+          result shouldBe Left(
+            ErrorWrapper(
+              correlationId,
+              ValueFormatError.forPathAndRange(expectedPath, "-99999999999.99", "99999999999.99")
+            )
+          )
+        }
+
+        "value is out of range" in doTest(JsNumber(99999999999.99 + 0.01))
+
+        "value is zero" in doTest(JsNumber(0))
+      }
+    }
+
+    "return RuleBothExpensesSuppliedError" when {
+      "passed consolidated and separate expenses" in {
+        val body   = fhlBodyJson.update("furnishedHolidayLet/expenses/consolidatedExpenses", JsNumber(123.45))
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleBothExpensesError.withPath("/furnishedHolidayLet/expenses"))
+        )
+      }
+
+      "passed consolidated and separate non-fhl expenses" in {
+        val body   = nonFhlBodyJson.update("nonFurnishedHolidayLet/expenses/consolidatedExpenses", JsNumber(123.45))
+        val result = validator(validNino, validCalculationId, None, body).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            RuleBothExpensesError.withPath("/nonFurnishedHolidayLet/expenses")
+          )
+        )
+      }
+    }
+
+    "return TaxYearFormatError" when {
+      "given a badly formatted tax year" in {
+        val result = validator(validNino, validCalculationId, Some("202324"), fhlBodyJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, TaxYearFormatError)
+        )
+      }
+    }
+
+    "return RuleTaxYearRangeInvalidError error" when {
+      "given a tax year range of more than one year" in {
+        val result = validator(validNino, validCalculationId, Some("2022-24"), fhlBodyJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleTaxYearRangeInvalidError)
+        )
+      }
+    }
+
+    "return InvalidTaxYearParameterError" when {
+      "given a tax year before TYS" in {
+        val result = validator(validNino, validCalculationId, Some("2022-23"), fhlBodyJson).validateAndWrapResult()
+        result shouldBe Left(
+          ErrorWrapper(correlationId, InvalidTaxYearParameterError)
+        )
+      }
+    }
+
+    "return multiple errors" when {
+      "the request has multiple errors" in {
+        val result = validator("not-a-nino", "not-a-calculation-id", None, fhlBodyJson).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            BadRequestError,
+            Some(List(CalculationIdFormatError, NinoFormatError))
+          )
+        )
+      }
+    }
+  }
+
+}

--- a/test/v5/triggerBsas/connectors/MockTriggerBsasConnector.scala
+++ b/test/v5/triggerBsas/connectors/MockTriggerBsasConnector.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.connectors
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.connectors.DownstreamOutcome
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.triggerBsas.models.{TriggerBsasRequestData, TriggerBsasResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockTriggerBsasConnector extends MockFactory {
+
+  val mockConnector: TriggerBsasConnector = mock[TriggerBsasConnector]
+
+  object MockTriggerBsasConnector {
+
+    def triggerBsas(requestData: TriggerBsasRequestData): CallHandler[Future[DownstreamOutcome[TriggerBsasResponse]]] = {
+      (mockConnector
+        .triggerBsas(_: TriggerBsasRequestData)(_: HeaderCarrier, _: ExecutionContext, _: String))
+        .expects(requestData, *, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/triggerBsas/connectors/TriggerBsasConnectorSpec.scala
+++ b/test/v5/triggerBsas/connectors/TriggerBsasConnectorSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.connectors
+
+import org.scalamock.handlers.CallHandler
+import shared.connectors.{ConnectorSpec, DownstreamOutcome}
+import shared.models.domain.{Nino, TaxYear}
+import shared.models.errors.{DownstreamErrorCode, DownstreamErrors}
+import shared.models.outcomes.ResponseWrapper
+import v5.triggerBsas.fixtures.def1.TriggerBsasRequestBodyFixtures._
+import v5.triggerBsas.models.TriggerBsasRequestData
+import v5.triggerBsas.models.def1.{Def1_TriggerBsasRequestData, Def1_TriggerBsasResponse}
+
+import scala.concurrent.Future
+
+class TriggerBsasConnectorSpec extends ConnectorSpec {
+
+  val nino: Nino    = Nino("AA123456A")
+  val calculationId = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c"
+
+  private val preTysTaxYear = TaxYear.fromIso("2019-05-05")
+  private val tysTaxYear    = TaxYear.fromIso("2023-05-02")
+
+  "triggerBsas" must {
+
+    "post a TriggerBsasRequest body and return the result" in new IfsTest with Test {
+      protected def taxYear: TaxYear = preTysTaxYear
+
+      val outcome = Right(ResponseWrapper(correlationId, Def1_TriggerBsasResponse(calculationId)))
+      stubHttpResponse(outcome)
+
+      await(connector.triggerBsas(request)) shouldBe outcome
+    }
+
+    "post a TriggerBsasRequest body and return the result given a TYS tax year" in new TysIfsTest with Test {
+      override protected val request: TriggerBsasRequestData = Def1_TriggerBsasRequestData(nino, tysModel)
+      protected def taxYear: TaxYear                         = tysTaxYear
+
+      val outcome = Right(ResponseWrapper(correlationId, Def1_TriggerBsasResponse(calculationId)))
+      stubTysHttpResponse(outcome)
+
+      await(connector.triggerBsas(request)) shouldBe outcome
+    }
+
+  }
+
+  "response is an error" must {
+    val downstreamErrorResponse = DownstreamErrors.single(DownstreamErrorCode("SOME_ERROR"))
+    val outcome                 = Left(ResponseWrapper(correlationId, downstreamErrorResponse))
+
+    "return the error" in new IfsTest with Test {
+      protected def taxYear: TaxYear = preTysTaxYear
+
+      stubHttpResponse(outcome)
+
+      await(connector.triggerBsas(request)) shouldBe outcome
+    }
+
+    "return the error given a TYS tax year request" in new TysIfsTest with Test {
+      override protected val request: TriggerBsasRequestData = Def1_TriggerBsasRequestData(nino, tysModel)
+      protected def taxYear: TaxYear                         = tysTaxYear
+
+      stubTysHttpResponse(outcome)
+
+      await(connector.triggerBsas(request)) shouldBe outcome
+    }
+  }
+
+  private trait Test {
+    _: ConnectorTest =>
+
+    protected def taxYear: TaxYear
+    protected val request: TriggerBsasRequestData = Def1_TriggerBsasRequestData(nino, model)
+    protected val connector: TriggerBsasConnector = new TriggerBsasConnector(http = mockHttpClient, appConfig = mockAppConfig)
+
+    protected def stubHttpResponse(
+        outcome: DownstreamOutcome[Def1_TriggerBsasResponse]): CallHandler[Future[DownstreamOutcome[Def1_TriggerBsasResponse]]]#Derived = {
+      willPost(
+        url = s"$baseUrl/income-tax/adjustable-summary-calculation/$nino",
+        body = model
+      ).returns(Future.successful(outcome))
+    }
+
+    protected def stubTysHttpResponse(
+        outcome: DownstreamOutcome[Def1_TriggerBsasResponse]): CallHandler[Future[DownstreamOutcome[Def1_TriggerBsasResponse]]]#Derived = {
+      willPost(
+        url = s"$baseUrl/income-tax/adjustable-summary-calculation/${taxYear.asTysDownstream}/$nino",
+        body = tysModel
+      ).returns(Future.successful(outcome))
+    }
+
+  }
+
+}

--- a/test/v5/triggerBsas/controllers/TriggerBsasControllerSpec.scala
+++ b/test/v5/triggerBsas/controllers/TriggerBsasControllerSpec.scala
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.controllers
+
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Result
+import shared.config.MockAppConfig
+import shared.controllers.{ControllerBaseSpec, ControllerTestRunner}
+import shared.hateoas.Method.GET
+import shared.hateoas.{HateoasWrapper, Link, MockHateoasFactory}
+import shared.models.audit.{AuditEvent, AuditResponse, GenericAuditDetail}
+import shared.models.domain.TaxYear
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.{MockAuditService, MockEnrolmentsAuthService, MockMtdIdLookupService}
+import shared.utils.MockIdGenerator
+import v5.models.domain.TypeOfBusiness
+import v5.models.errors._
+import v5.triggerBsas.fixtures.def1.TriggerBsasRequestBodyFixtures._
+import v5.triggerBsas.models.TriggerBsasHateoasData
+import v5.triggerBsas.models.def1.Def1_TriggerBsasRequestData
+import v5.triggerBsas.services.MockTriggerBsasService
+import v5.triggerBsas.validators.MockTriggerBsasValidatorFactory
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class TriggerBsasControllerSpec
+    extends ControllerBaseSpec
+    with ControllerTestRunner
+    with MockEnrolmentsAuthService
+    with MockMtdIdLookupService
+    with MockTriggerBsasValidatorFactory
+    with MockTriggerBsasService
+    with MockHateoasFactory
+    with MockIdGenerator
+    with MockAuditService
+    with MockAppConfig {
+
+  private val requestData = Def1_TriggerBsasRequestData(
+    parsedNino,
+    triggerBsasRequestDataBody()
+  )
+
+  private val requestForProperty = Def1_TriggerBsasRequestData(
+    parsedNino,
+    triggerBsasRequestDataBody(typeOfBusiness = TypeOfBusiness.`uk-property-fhl`)
+  )
+
+  val testHateoasLinkSE: Link = Link(
+    href = s"/individuals/self-assessment/adjustable-summary/$validNino/self-employment/c75f40a6-a3df-4429-a697-471eeec46435",
+    method = GET,
+    rel = "self"
+  )
+
+  val testHateoasLinkProperty: Link = Link(
+    href = s"/individuals/self-assessment/adjustable-summary/$validNino/uk-property/c75f40a6-a3df-4429-a697-471eeec46435",
+    method = GET,
+    rel = "self"
+  )
+
+  "triggerBsas" should {
+    "return OK" when {
+      "a valid request is supplied for business type self-employment" in new Test {
+        private val mtdResponseJson = Json.parse(hateoasResponseForSE(validNino))
+
+        willUseValidator(returningSuccess(requestData))
+
+        MockTriggerBsasService
+          .triggerBsas(requestData)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, responseObj))))
+
+        MockHateoasFactory
+          .wrap(
+            responseObj,
+            TriggerBsasHateoasData(validNino, TypeOfBusiness.`self-employment`, responseObj.calculationId, Some(TaxYear.fromMtd("2020-21"))))
+          .returns(HateoasWrapper(responseObj, Seq(testHateoasLinkSE)))
+
+        runOkTestWithAudit(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(mtdResponseJson),
+          maybeAuditRequestBody = Some(requestBody),
+          maybeAuditResponseBody = Some(mtdResponseJson)
+        )
+      }
+
+      "a valid request is supplied for business type uk-property" in new Test {
+        override protected val requestBodyForController: JsValue = requestBodyForProperty
+
+        private val mtdResponseJson = Json.parse(hateoasResponseForProperty(validNino))
+
+        willUseValidator(returningSuccess(requestForProperty))
+
+        MockTriggerBsasService
+          .triggerBsas(requestForProperty)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, responseObj))))
+
+        MockHateoasFactory
+          .wrap(
+            responseObj,
+            TriggerBsasHateoasData(validNino, TypeOfBusiness.`uk-property-fhl`, responseObj.calculationId, Some(TaxYear.fromMtd("2020-21"))))
+          .returns(HateoasWrapper(responseObj, Seq(testHateoasLinkProperty)))
+
+        runOkTestWithAudit(
+          expectedStatus = OK,
+          maybeExpectedResponseBody = Some(mtdResponseJson),
+          maybeAuditRequestBody = Some(requestBodyForProperty),
+          maybeAuditResponseBody = Some(mtdResponseJson)
+        )
+      }
+    }
+
+    "return the error as per spec" when {
+
+      "the parser validation fails" in new Test {
+        willUseValidator(returning(NinoFormatError))
+        runErrorTestWithAudit(NinoFormatError, maybeAuditRequestBody = Some(requestBody))
+      }
+
+      "the service returns an error" in new Test {
+        willUseValidator(returningSuccess(requestData))
+
+        MockTriggerBsasService
+          .triggerBsas(requestData)
+          .returns(Future.successful(Left(ErrorWrapper(correlationId, RulePeriodicDataIncompleteError))))
+
+        runErrorTestWithAudit(RulePeriodicDataIncompleteError, maybeAuditRequestBody = Some(requestBody))
+      }
+    }
+  }
+
+  trait Test extends ControllerTest with AuditEventChecking {
+
+    val controller = new TriggerBsasController(
+      authService = mockEnrolmentsAuthService,
+      lookupService = mockMtdIdLookupService,
+      validatorFactory = mockTriggerBsasValidatorFactory,
+      service = mockService,
+      hateoasFactory = mockHateoasFactory,
+      auditService = mockAuditService,
+      cc = cc,
+      idGenerator = mockIdGenerator
+    )
+
+    protected val requestBodyForController: JsValue = requestBody
+
+    protected def callController(): Future[Result] =
+      controller.triggerBsas(validNino)(fakePostRequest(requestBodyForController))
+
+    protected def event(auditResponse: AuditResponse, maybeRequestBody: Option[JsValue]): AuditEvent[GenericAuditDetail] =
+      AuditEvent(
+        auditType = "TriggerBusinessSourceAdjustableSummary",
+        transactionName = "trigger-business-source-adjustable-summary",
+        detail = GenericAuditDetail(
+          versionNumber = apiVersion.name,
+          userType = "Individual",
+          agentReferenceNumber = None,
+          params = Map("nino" -> validNino),
+          requestBody = maybeRequestBody,
+          `X-CorrelationId` = correlationId,
+          auditResponse = auditResponse
+        )
+      )
+
+  }
+
+}

--- a/test/v5/triggerBsas/fixtures/def1/TriggerBsasRequestBodyFixtures.scala
+++ b/test/v5/triggerBsas/fixtures/def1/TriggerBsasRequestBodyFixtures.scala
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.fixtures.def1
+
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.AnyContentAsJson
+import v5.models.domain.TypeOfBusiness
+import v5.triggerBsas.models.def1.{AccountingPeriod, Def1_TriggerBsasRequestBody, Def1_TriggerBsasResponse}
+
+object TriggerBsasRequestBodyFixtures {
+
+  val mtdJson: JsValue = Json.parse("""
+                                      |{
+                                      |  "accountingPeriod" : {
+                                      |     "startDate" : "2018-11-25",
+                                      |     "endDate" : "2018-11-26"
+                                      |  },
+                                      |  "typeOfBusiness" : "self-employment",
+                                      |  "businessId" : "anId"
+                                      |}
+                                      |""".stripMargin)
+
+  val downstreamJson: JsValue = Json.parse("""
+                                             |{
+                                             |   "incomeSourceType" : "01",
+                                             |   "incomeSourceId" : "anId",
+                                             |   "accountingPeriodStartDate" : "2018-11-25",
+                                             |   "accountingPeriodEndDate" : "2018-11-26"
+                                             |}
+  """.stripMargin)
+
+  val model: Def1_TriggerBsasRequestBody = Def1_TriggerBsasRequestBody(
+    AccountingPeriod("2018-11-25", "2018-11-26"),
+    TypeOfBusiness.`self-employment`.toString,
+    "anId"
+  )
+
+  val tysModel: Def1_TriggerBsasRequestBody = Def1_TriggerBsasRequestBody(
+    AccountingPeriod("2023-05-01", "2023-05-02"),
+    TypeOfBusiness.`self-employment`.toString,
+    "anId"
+  )
+
+  val responseObj: Def1_TriggerBsasResponse = Def1_TriggerBsasResponse("c75f40a6-a3df-4429-a697-471eeec46435")
+
+  val response: JsValue = Json.parse("""{
+                                       |"calculationId" : "c75f40a6-a3df-4429-a697-471eeec46435"
+                                       |}""".stripMargin)
+
+  val hateoasResponseForSE: String => String = (nino: String) => s"""
+                                                                    |{
+                                                                    |  "calculationId": "c75f40a6-a3df-4429-a697-471eeec46435",
+                                                                    |  "links":[
+                                                                    |    {
+                                                                    |      "href":"/individuals/self-assessment/adjustable-summary/$nino/self-employment/c75f40a6-a3df-4429-a697-471eeec46435",
+                                                                    |      "rel":"self",
+                                                                    |      "method":"GET"
+                                                                    |    }
+                                                                    |  ]
+                                                                    |}
+    """.stripMargin
+
+  val hateoasResponseForProperty: String => String = (nino: String) => s"""
+                                                                          |{
+                                                                          |  "calculationId": "c75f40a6-a3df-4429-a697-471eeec46435",
+                                                                          |  "links":[
+                                                                          |    {
+                                                                          |      "href":"/individuals/self-assessment/adjustable-summary/$nino/uk-property/c75f40a6-a3df-4429-a697-471eeec46435",
+                                                                          |      "rel":"self",
+                                                                          |      "method":"GET"
+                                                                          |    }
+                                                                          |  ]
+                                                                          |}
+    """.stripMargin
+
+  val requestBody: JsValue = Json.parse("""
+                                          |{
+                                          |  "accountingPeriod": {
+                                          |    "startDate": "2019-05-05",
+                                          |    "endDate": "2020-05-06"
+                                          |  },
+                                          |  "typeOfBusiness": "self-employment",
+                                          |  "businessId": "XAIS12345678901"
+                                          |}
+                                          |""".stripMargin)
+
+  val requestBodyForProperty: JsValue = Json.parse("""
+                                                     |{
+                                                     |  "accountingPeriod": {
+                                                     |    "startDate": "2019-05-05",
+                                                     |    "endDate": "2020-05-06"
+                                                     |  },
+                                                     |  "typeOfBusiness": "uk-property-fhl",
+                                                     |  "businessId": "XAIS12345678901"
+                                                     |}
+                                                     |""".stripMargin)
+
+  val downstreamResponse: String =
+    """
+      |{
+      | "metadata": {
+      |  "calculationId": "c75f40a6-a3df-4429-a697-471eeec46435",
+      |  "requestedDateTime": "0000-01-01",
+      |  "taxableEntityId": "0",
+      |  "taxYear": 2020,
+      |  "status": "valid"
+      | },
+      | "inputs": {
+      |  "incomeSourceId": "111111111111111",
+      |  "incomeSourceType": "01",
+      |  "accountingPeriodStartDate": "0000-01-01",
+      |  "accountingPeriodEndDate": "0000-01-01",
+      |  "source": "MTD-SA",
+      |  "submissionPeriods": [
+      |   {
+      |    "periodId": "2222222222222222",
+      |    "startDate": "0000-01-01",
+      |    "endDate": "0000-01-01",
+      |    "receivedDateTime": "0000-01-01"
+      |   }
+      |  ]
+      | },
+      | "adjustableSummaryCalculation": {
+      |  "totalIncome": 0.02,
+      |  "income": {
+      |   "turnover": 0.02,
+      |   "other": 0.02
+      |  },
+      |  "totalExpenses": 0.02,
+      |  "expenses": {
+      |   "consolidatedExpenses": 0.02,
+      |   "costOfGoodsAllowable": 0.02,
+      |   "paymentsToSubcontractorsAllowable": 0.02,
+      |   "wagesAndStaffCostsAllowable": 0.02,
+      |   "carVanTravelExpensesAllowable": 0.02,
+      |   "premisesRunningCostsAllowable": 0.02,
+      |   "maintenanceCostsAllowable": 0.02,
+      |   "adminCostsAllowable": 0.02,
+      |   "interestOnBankOtherLoansAllowable": 0.02,
+      |   "financeChargesAllowable": 0.02,
+      |   "irrecoverableDebtsAllowable": 0.02,
+      |   "professionalFeesAllowable": 0.02,
+      |   "depreciationAllowable": 0.02,
+      |   "otherExpensesAllowable": 0.02,
+      |   "advertisingCostsAllowable": 0.02,
+      |   "businessEntertainmentCostsAllowable": 0.02
+      |  },
+      |  "netProfit": 0.02,
+      |  "netLoss": 0.02,
+      |  "additions": {
+      |   "costOfGoodsDisallowable": 0.02,
+      |   "paymentsToSubcontractorsDisallowable": 0.02,
+      |   "wagesAndStaffCostsDisallowable": 0.02,
+      |   "carVanTravelExpensesDisallowable": 0.02,
+      |   "premisesRunningCostsDisallowable": 0.02,
+      |   "maintenanceCostsDisallowable": 0.02,
+      |   "adminCostsDisallowable": 0.02,
+      |   "interestOnBankOtherLoansDisallowable": 0.02,
+      |   "financeChargesDisallowable": 0.02,
+      |   "irrecoverableDebtsDisallowable": 0.02,
+      |   "professionalFeesDisallowable": 0.02,
+      |   "depreciationDisallowable": 0.02,
+      |   "otherExpensesDisallowable": 0.02,
+      |   "advertisingCostsDisallowable": 0.02,
+      |   "businessEntertainmentCostsDisallowable": 0.02,
+      |   "outstandingBusinessIncome": 0.02,
+      |   "balancingChargeOther": 0.02,
+      |   "balancingChargeBpra": 0.02,
+      |   "goodAndServicesOwnUse": 0.02
+      |  },
+      |  "deductions": {
+      |   "tradingAllowance": 0.02,
+      |   "annualInvestmentAllowance": 0.02,
+      |   "capitalAllowanceMainPool": 0.02,
+      |   "capitalAllowanceSpecialRatePool": 0.02,
+      |   "zeroEmissionGoods": 0.02,
+      |   "businessPremisesRenovationAllowance": 0.02,
+      |   "enhancedCapitalAllowance": 0.02,
+      |   "allowanceOnSales": 0.02,
+      |   "capitalAllowanceSingleAssetPool": 0.02,
+      |   "includedNonTaxableProfits": 0.02
+      |  },
+      |  "accountingAdjustments": 0.02,
+      |  "selfEmploymentAccountingAdjustments": {
+      |   "basisAdjustment": 0.02,
+      |   "overlapReliefUsed": 0.02,
+      |   "accountingAdjustment": 0.02,
+      |   "averagingAdjustment": 0.02
+      |  },
+      |  "taxableProfit": 0.02,
+      |  "adjustedIncomeTaxLoss": 0.02
+      | }
+      |}
+      |
+    """.stripMargin
+
+  def triggerBsasRawDataBody(startDate: String = "2019-05-05",
+                             endDate: String = "2020-05-06",
+                             typeOfBusiness: String = TypeOfBusiness.`self-employment`.toString,
+                             businessId: String = "XAIS12345678901"): AnyContentAsJson = {
+
+    AnyContentAsJson(
+      Json.obj(
+        "accountingPeriod" -> Json.obj("startDate" -> startDate, "endDate" -> endDate),
+        "typeOfBusiness"   -> typeOfBusiness,
+        "businessId"       -> businessId)
+    )
+  }
+
+  def triggerBsasRequestDataBody(startDate: String = "2019-05-05",
+                                 endDate: String = "2020-05-06",
+                                 typeOfBusiness: TypeOfBusiness = TypeOfBusiness.`self-employment`,
+                                 businessId: String = "XAIS12345678901"): Def1_TriggerBsasRequestBody = {
+    Def1_TriggerBsasRequestBody(
+      AccountingPeriod(startDate, endDate),
+      typeOfBusiness = typeOfBusiness.toString,
+      businessId = businessId
+    )
+  }
+
+}

--- a/test/v5/triggerBsas/models/TriggerBsasResponseHateoasFactorySpec.scala
+++ b/test/v5/triggerBsas/models/TriggerBsasResponseHateoasFactorySpec.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models
+
+import play.api.Configuration
+import shared.UnitSpec
+import shared.config.MockAppConfig
+import shared.hateoas.Method.GET
+import shared.hateoas.{HateoasFactory, HateoasWrapper, Link}
+import shared.models.domain.TaxYear
+import v5.models.domain.TypeOfBusiness._
+import v5.triggerBsas.models.def1.Def1_TriggerBsasResponse
+
+class TriggerBsasResponseHateoasFactorySpec extends UnitSpec {
+
+  val triggerBsasResponse: TriggerBsasResponse = Def1_TriggerBsasResponse("anId")
+
+
+  "HateoasFactory" when {
+    class Test extends MockAppConfig {
+      val hateoasFactory = new HateoasFactory(mockAppConfig)
+      val nino = "someNino"
+      val bsasId = "anId"
+      val taxYear = Some(TaxYear.fromMtd("2023-24"))
+      val context = "individuals/self-assessment/adjustable-summary"
+
+      MockAppConfig.apiGatewayContext.returns(context).anyNumberOfTimes()
+    }
+
+    class TysDisabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> false)).anyNumberOfTimes()
+    }
+
+    class TysEnabledTest extends Test {
+      MockAppConfig.featureSwitchConfig.returns(Configuration("tys-api.enabled" -> true)).anyNumberOfTimes()
+    }
+
+    "triggering a self employment BSAS" should {
+      "return the correct links without tax year" in new TysDisabledTest {
+        private val result = hateoasFactory.wrap(triggerBsasResponse, TriggerBsasHateoasData(nino, `self-employment`, bsasId, None))
+        private val expectedLink = Link(s"/$context/$nino/self-employment/$bsasId", GET, "self")
+
+        result shouldBe HateoasWrapper(triggerBsasResponse, Seq(expectedLink))
+      }
+
+      "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+        private val result = hateoasFactory.wrap(triggerBsasResponse, TriggerBsasHateoasData(nino, `self-employment`, bsasId, taxYear))
+        private val expectedLink = Link(s"/$context/$nino/self-employment/$bsasId?taxYear=2023-24", GET, "self")
+
+        result shouldBe HateoasWrapper(triggerBsasResponse, Seq(expectedLink))
+      }
+    }
+
+    "triggering an FHL property BSAS" should {
+      "return the correct links without tax year" in new TysDisabledTest {
+        private val result = hateoasFactory.wrap(triggerBsasResponse, TriggerBsasHateoasData(nino, `uk-property-fhl`, bsasId, None))
+        private val expectedLink = Link(s"/$context/$nino/uk-property/$bsasId", GET, "self")
+
+        result shouldBe HateoasWrapper(triggerBsasResponse, Seq(expectedLink))
+      }
+
+      "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+        private val result = hateoasFactory.wrap(triggerBsasResponse, TriggerBsasHateoasData(nino, `uk-property-fhl`, bsasId, taxYear))
+        private val expectedLink = Link(s"/$context/$nino/uk-property/$bsasId?taxYear=2023-24", GET, "self")
+
+        result shouldBe HateoasWrapper(triggerBsasResponse, Seq(expectedLink))
+      }
+    }
+
+    "triggering a non-FHL property BSAS" should {
+      "return the correct links without tax year" in new TysDisabledTest {
+        private val result = hateoasFactory.wrap(triggerBsasResponse, TriggerBsasHateoasData(nino, `uk-property-non-fhl`, bsasId, None))
+        private val expectedLink = Link(s"/$context/$nino/uk-property/$bsasId", GET, "self")
+
+        result shouldBe HateoasWrapper(triggerBsasResponse, Seq(expectedLink))
+      }
+
+      "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+        private val result = hateoasFactory.wrap(triggerBsasResponse, TriggerBsasHateoasData(nino, `uk-property-non-fhl`, bsasId, taxYear))
+        private val expectedLink = Link(s"/$context/$nino/uk-property/$bsasId?taxYear=2023-24", GET, "self")
+
+        result shouldBe HateoasWrapper(triggerBsasResponse, Seq(expectedLink))
+      }
+    }
+
+    "triggering a foreign property BSAS" should {
+      "return the correct links without tax year" in new TysDisabledTest {
+        private val result = hateoasFactory.wrap(triggerBsasResponse, TriggerBsasHateoasData(nino, `foreign-property`, bsasId, None))
+        private val expectedLink = Link(s"/$context/$nino/foreign-property/$bsasId", GET, "self")
+
+        result shouldBe HateoasWrapper(triggerBsasResponse, Seq(expectedLink))
+      }
+
+      "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+        private val result = hateoasFactory.wrap(triggerBsasResponse, TriggerBsasHateoasData(nino, `foreign-property`, bsasId, taxYear))
+        private val expectedLink = Link(s"/$context/$nino/foreign-property/$bsasId?taxYear=2023-24", GET, "self")
+
+        result shouldBe HateoasWrapper(triggerBsasResponse, Seq(expectedLink))
+      }
+    }
+
+    "triggering a foreign property fhl eea BSAS" should {
+      "return the correct links without tax year" in new TysDisabledTest {
+        private val result = hateoasFactory.wrap(triggerBsasResponse, TriggerBsasHateoasData(nino, `foreign-property-fhl-eea`, bsasId, None))
+        private val expectedLink = Link(s"/$context/$nino/foreign-property/$bsasId", GET, "self")
+
+        result shouldBe HateoasWrapper(triggerBsasResponse, Seq(expectedLink))
+      }
+
+      "return the correct links with TYS enabled and the tax year is TYS" in new TysEnabledTest {
+        private val result = hateoasFactory.wrap(triggerBsasResponse, TriggerBsasHateoasData(nino, `foreign-property-fhl-eea`, bsasId, taxYear))
+        private val expectedLink = Link(s"/$context/$nino/foreign-property/$bsasId?taxYear=2023-24", GET, "self")
+
+        result shouldBe HateoasWrapper(triggerBsasResponse, Seq(expectedLink))
+      }
+    }
+  }
+
+}

--- a/test/v5/triggerBsas/models/TriggerBsasResponseSpec.scala
+++ b/test/v5/triggerBsas/models/TriggerBsasResponseSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models
+
+import play.api.libs.json.{JsError, Json}
+import shared.UnitSpec
+import v5.triggerBsas.models.def1.Def1_TriggerBsasResponse
+
+class TriggerBsasResponseSpec extends UnitSpec {
+
+  val triggerBsasResponse: Def1_TriggerBsasResponse = Def1_TriggerBsasResponse("anId")
+
+  "TriggerBsasResponse" when {
+    "read from valid JSON" should {
+      "return the expected TriggerBsasResponse object" in {
+        Json
+          .parse("""
+            |{
+            |   "metadata" : {
+            |       "calculationId" : "anId"
+            |   }
+            |}
+            |""".stripMargin)
+          .as[Def1_TriggerBsasResponse] shouldBe triggerBsasResponse
+      }
+    }
+
+    "read from invalid JSON" should {
+      "return a JsError" in {
+        Json
+          .parse("""
+            |{
+            |   "calculationId" : 3
+            |}
+            |""".stripMargin)
+          .validate[Def1_TriggerBsasResponse] shouldBe a[JsError]
+      }
+    }
+
+    "written to JSON" should {
+      "return the expected JsValue" in {
+        Json.toJson(triggerBsasResponse) shouldBe Json.parse("""
+            |{
+            |   "calculationId" : "anId"
+            |}
+            |""".stripMargin)
+      }
+    }
+  }
+
+}

--- a/test/v5/triggerBsas/models/def1/AccountingPeriodSpec.scala
+++ b/test/v5/triggerBsas/models/def1/AccountingPeriodSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models.def1
+
+import play.api.libs.json.{JsError, JsSuccess, Json}
+import shared.UnitSpec
+
+class AccountingPeriodSpec extends UnitSpec {
+
+  private val requestJson = Json.parse("""
+                                         |{
+                                         |  "startDate" : "2018-11-25",
+                                         |  "endDate" : "2018-11-26"
+                                         |}
+  """.stripMargin)
+
+  private val invalidJson = Json.parse("""
+                                         |{
+                                         |  "startDate" : 4,
+                                         |  "endDate" : true
+                                         |}
+  """.stripMargin)
+
+  private val model = AccountingPeriod("2018-11-25", "2018-11-26")
+
+  "AccountingPeriod" when {
+    "read from valid JSON" should {
+      "return the expected AccountingPeriod object" in {
+        requestJson.validate[AccountingPeriod] shouldBe JsSuccess(model)
+      }
+    }
+
+    "read from invalid JSON" should {
+      "return a JsError" in {
+        invalidJson.validate[AccountingPeriod] shouldBe a[JsError]
+      }
+    }
+
+    "written to JSON" should {
+      "return the expected JsValue" in {
+        Json.toJson(model) shouldBe requestJson
+      }
+    }
+  }
+
+}

--- a/test/v5/triggerBsas/models/def1/Def1_TriggerBsasRequestBodySpec.scala
+++ b/test/v5/triggerBsas/models/def1/Def1_TriggerBsasRequestBodySpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models.def1
+
+import play.api.libs.json.Json
+import shared.UnitSpec
+import v5.triggerBsas.fixtures.def1.TriggerBsasRequestBodyFixtures._
+
+class Def1_TriggerBsasRequestBodySpec extends UnitSpec {
+
+  "TriggerBsasRequestBody" when {
+    "reads" should {
+      "return the expected TriggerBsasRequestBody object" in {
+        mtdJson.as[Def1_TriggerBsasRequestBody] shouldBe model
+      }
+    }
+
+    "writes" should {
+      "return the expected JSON" in {
+        Json.toJson(model) shouldBe downstreamJson
+      }
+    }
+  }
+
+}

--- a/test/v5/triggerBsas/models/def1/Def1_TriggerBsasResponseSpec.scala
+++ b/test/v5/triggerBsas/models/def1/Def1_TriggerBsasResponseSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.models.def1
+
+import play.api.libs.json.{JsError, Json}
+import shared.UnitSpec
+import v5.triggerBsas.models.TriggerBsasResponse
+
+class Def1_TriggerBsasResponseSpec extends UnitSpec {
+
+  val triggerBsasResponse: TriggerBsasResponse = Def1_TriggerBsasResponse("anId")
+
+  "Def1_TriggerBsasResponse" when {
+    "read from valid JSON" should {
+      "return the expected Def1_TriggerBsasResponse object" in {
+        Json
+          .parse("""
+            |{
+            |   "metadata" : {
+            |       "calculationId" : "anId"
+            |   }
+            |}
+  """.stripMargin)
+          .as[Def1_TriggerBsasResponse] shouldBe triggerBsasResponse
+      }
+    }
+
+    "read from invalid JSON" should {
+      "return a JsError" in {
+        Json
+          .parse("""
+            |{
+            |   "calculationId" : 3
+            |}
+  """.stripMargin)
+          .validate[Def1_TriggerBsasResponse] shouldBe a[JsError]
+      }
+    }
+
+    "written to JSON" should {
+      "return the expected JsValue" in {
+        Json.toJson(triggerBsasResponse) shouldBe Json.parse("""
+            |{
+            |   "calculationId" : "anId"
+            |}
+  """.stripMargin)
+      }
+    }
+  }
+
+}

--- a/test/v5/triggerBsas/schema/TriggerSchemaSpec.scala
+++ b/test/v5/triggerBsas/schema/TriggerSchemaSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.schema
+
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json.{JsObject, Json}
+import shared.UnitSpec
+import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+
+import java.time.LocalDate
+import scala.math.Ordered.orderingToOrdered
+
+class TriggerSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
+
+  "Getting a schema" when {
+    "endDate is in body" must {
+      def body(endDate: LocalDate) = Json.parse(s"""
+          |{
+          |  "accountingPeriod": {
+          |    "endDate": "$endDate"
+          |  }
+          |}
+          """.stripMargin)
+
+      "use Def1 for tax years from 2023-24" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
+            TriggerSchema.schemaFor(body(taxYear.endDate)) shouldBe TriggerSchema.Def1
+          }
+        }
+      }
+
+      "use Def1 for other tax years" in {
+        forAll { taxYear: TaxYear =>
+          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
+            TriggerSchema.schemaFor(body(taxYear.endDate)) shouldBe TriggerSchema.Def1
+          }
+        }
+      }
+    }
+
+    "An endDate is not in the body" must {
+      "use a default of Def1" in {
+        TriggerSchema.schemaFor(JsObject.empty) shouldBe TriggerSchema.Def1
+      }
+    }
+
+    "An invalid endDate is in the body" must {
+      "use a default of Def1" in {
+        val body = Json.parse(s"""
+                                                     |{
+                                                     |  "accountingPeriod": {
+                                                     |    "endDate": "NotADate"
+                                                     |  }
+                                                     |}
+          """.stripMargin)
+
+        TriggerSchema.schemaFor(body) shouldBe TriggerSchema.Def1
+      }
+    }
+
+  }
+
+}

--- a/test/v5/triggerBsas/schema/TriggerSchemaSpec.scala
+++ b/test/v5/triggerBsas/schema/TriggerSchemaSpec.scala
@@ -22,7 +22,6 @@ import shared.UnitSpec
 import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
 
 import java.time.LocalDate
-import scala.math.Ordered.orderingToOrdered
 
 class TriggerSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
 
@@ -37,18 +36,14 @@ class TriggerSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks wit
           """.stripMargin)
 
       "use Def1 for tax years from 2023-24" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear >= TaxYear.fromMtd("2023-24")) {
-            TriggerSchema.schemaFor(body(taxYear.endDate)) shouldBe TriggerSchema.Def1
-          }
+        forTaxYearsFrom(TaxYear.fromMtd("2023-24")) { taxYear =>
+          TriggerSchema.schemaFor(body(taxYear.endDate)) shouldBe TriggerSchema.Def1
         }
       }
 
-      "use Def1 for other tax years" in {
-        forAll { taxYear: TaxYear =>
-          whenever(taxYear < TaxYear.fromMtd("2023-24")) {
-            TriggerSchema.schemaFor(body(taxYear.endDate)) shouldBe TriggerSchema.Def1
-          }
+      "use Def1 for pre-TYS tax years" in {
+        forPreTysTaxYears { taxYear =>
+          TriggerSchema.schemaFor(body(taxYear.endDate)) shouldBe TriggerSchema.Def1
         }
       }
     }

--- a/test/v5/triggerBsas/services/MockTriggerBsasService.scala
+++ b/test/v5/triggerBsas/services/MockTriggerBsasService.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.services
+
+import org.scalamock.handlers.CallHandler
+import org.scalamock.scalatest.MockFactory
+import shared.controllers.RequestContext
+import shared.services.ServiceOutcome
+import v5.triggerBsas.models.{TriggerBsasRequestData, TriggerBsasResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockTriggerBsasService extends MockFactory {
+
+  val mockService: TriggerBsasService = mock[TriggerBsasService]
+
+  object MockTriggerBsasService {
+
+    def triggerBsas(requestData: TriggerBsasRequestData): CallHandler[Future[ServiceOutcome[TriggerBsasResponse]]] = {
+      (mockService
+        .triggerBsas(_: TriggerBsasRequestData)(_: RequestContext, _: ExecutionContext))
+        .expects(requestData, *, *)
+    }
+
+  }
+
+}

--- a/test/v5/triggerBsas/services/TriggerBsasServiceSpec.scala
+++ b/test/v5/triggerBsas/services/TriggerBsasServiceSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.services
+
+import shared.controllers.EndpointLogContext
+import shared.models.domain.Nino
+import shared.models.errors._
+import shared.models.outcomes.ResponseWrapper
+import shared.services.ServiceSpec
+import uk.gov.hmrc.http.HeaderCarrier
+import v5.models.errors._
+import v5.triggerBsas.connectors.MockTriggerBsasConnector
+import v5.triggerBsas.fixtures.def1.TriggerBsasRequestBodyFixtures._
+import v5.triggerBsas.models.TriggerBsasRequestData
+import v5.triggerBsas.models.def1.{Def1_TriggerBsasRequestData, Def1_TriggerBsasResponse}
+
+import scala.concurrent.Future
+
+class TriggerBsasServiceSpec extends ServiceSpec {
+
+  private val nino = Nino("AA123456A")
+
+  val calculationId                   = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c"
+  val request: TriggerBsasRequestData = Def1_TriggerBsasRequestData(nino, model)
+  val response: Def1_TriggerBsasResponse   = Def1_TriggerBsasResponse(calculationId)
+
+  trait Test extends MockTriggerBsasConnector {
+    implicit val hc: HeaderCarrier              = HeaderCarrier()
+    implicit val logContext: EndpointLogContext = EndpointLogContext("controller", "triggerBsas")
+
+    val service = new TriggerBsasService(mockConnector)
+  }
+
+  "triggerBsas" should {
+    "return a valid response" when {
+      "a valid request is supplied" in new Test {
+        MockTriggerBsasConnector
+          .triggerBsas(request)
+          .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
+
+        await(service.triggerBsas(request)) shouldBe Right(ResponseWrapper(correlationId, response))
+      }
+    }
+
+    "return error response" when {
+
+      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
+        s"a $downstreamErrorCode error is returned from the service" in new Test {
+
+          MockTriggerBsasConnector
+            .triggerBsas(request)
+            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+
+          await(service.triggerBsas(request)) shouldBe Left(ErrorWrapper(correlationId, error))
+        }
+
+      val errors = Seq(
+        ("INVALID_TAXABLE_ENTITY_ID", NinoFormatError),
+        ("ACCOUNTING_PERIOD_NOT_ENDED", RuleAccountingPeriodNotEndedError),
+        ("OBLIGATIONS_NOT_MET", RulePeriodicDataIncompleteError),
+        ("NO_ACCOUNTING_PERIOD", RuleNoAccountingPeriodError),
+        ("NO_DATA_FOUND", TriggerNotFoundError),
+        ("INVALID_PAYLOAD", InternalError),
+        ("SERVER_ERROR", InternalError),
+        ("SERVICE_UNAVAILABLE", InternalError),
+        ("INVALID_CORRELATIONID", InternalError)
+      )
+
+      val extraTysErrors = Seq(
+        "INVALID_CORRELATION_ID" -> InternalError,
+        "INVALID_TAX_YEAR"       -> InternalError,
+        "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError
+      )
+
+      (errors ++ extraTysErrors).foreach(args => (serviceError _).tupled(args))
+    }
+  }
+
+}

--- a/test/v5/triggerBsas/validators/MockTriggerBsasValidatorFactory.scala
+++ b/test/v5/triggerBsas/validators/MockTriggerBsasValidatorFactory.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.validators
+
+import org.scalamock.handlers.CallHandler
+import play.api.libs.json.JsValue
+import shared.controllers.validators.{MockValidatorFactory, Validator}
+import v5.triggerBsas.models.TriggerBsasRequestData
+import v5.triggerBsas.schema.TriggerSchema
+
+trait MockTriggerBsasValidatorFactory extends MockValidatorFactory[TriggerBsasRequestData] {
+
+  val mockTriggerBsasValidatorFactory: TriggerBsasValidatorFactory = mock[TriggerBsasValidatorFactory]
+
+  def validator(): CallHandler[Validator[TriggerBsasRequestData]] =
+    (mockTriggerBsasValidatorFactory.validator(_: String, _: JsValue, _: TriggerSchema)).expects(*, *, *)
+
+}

--- a/test/v5/triggerBsas/validators/def1/Def1_TriggerBsasValidatorSpec.scala
+++ b/test/v5/triggerBsas/validators/def1/Def1_TriggerBsasValidatorSpec.scala
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v5.triggerBsas.validators.def1
+
+import cats.data.Validated
+import cats.data.Validated.Valid
+import config.MockBsasConfig
+import play.api.libs.json.{JsObject, JsValue, Json}
+import shared.UnitSpec
+import shared.models.domain.Nino
+import shared.models.errors._
+import v5.models.domain.TypeOfBusiness
+import v5.models.errors.{RuleAccountingPeriodNotSupportedError, TypeOfBusinessFormatError}
+import v5.triggerBsas.models.TriggerBsasRequestData
+import v5.triggerBsas.models.def1.{Def1_TriggerBsasRequestBody, Def1_TriggerBsasRequestData}
+
+class Def1_TriggerBsasValidatorSpec extends UnitSpec with MockBsasConfig {
+
+  private implicit val correlationId: String = "1234"
+
+  private val validNino  = "AA123456A"
+  private val parsedNino = Nino(validNino)
+
+  private val rulesValidator = new Def1_TriggerBsasRulesValidator(mockBsasConfig)
+
+  private def validator(nino: String, body: JsValue) = new Def1_TriggerBsasValidator(rulesValidator)(nino, body)
+
+  private def triggerBsasRequestJson(startDate: String = "2021-05-05",
+                                     endDate: String = "2022-05-06",
+                                     typeOfBusiness: String = "self-employment",
+                                     businessId: String = "XAIS12345678901"): JsObject = {
+    Json.obj(
+      "accountingPeriod" -> Json.obj("startDate" -> startDate, "endDate" -> endDate),
+      "typeOfBusiness"   -> typeOfBusiness,
+      "businessId"       -> businessId
+    )
+
+  }
+
+  class SetUp {
+    MockedBsasConfig.v3TriggerForeignBsasMinimumTaxYear.returns("2021-22").anyNumberOfTimes()
+    MockedBsasConfig.v3TriggerNonForeignBsasMinimumTaxYear.returns("2019-20").anyNumberOfTimes()
+  }
+
+  "running validation" should {
+    "return the parsed domain object" when {
+      List(
+        "self-employment",
+        "uk-property-fhl",
+        "uk-property-non-fhl",
+        "foreign-property-fhl-eea",
+        "foreign-property"
+      ).foreach { typeOfBusiness =>
+        s"$typeOfBusiness is supplied" in new SetUp {
+          val body: JsObject                       = triggerBsasRequestJson(typeOfBusiness = typeOfBusiness)
+          val expectedBody: Def1_TriggerBsasRequestBody = body.as[Def1_TriggerBsasRequestBody]
+
+          val result: Validated[Seq[MtdError], TriggerBsasRequestData] = validator(validNino, body).validate
+          result shouldBe Valid(Def1_TriggerBsasRequestData(parsedNino, expectedBody))
+        }
+      }
+    }
+
+    "return NinoFormatError" when {
+      "the nino is invalid" in new SetUp {
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] = validator("not-a-nino", triggerBsasRequestJson()).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, NinoFormatError)
+        )
+      }
+    }
+
+    "return a StartDateFormatError" when {
+      "the start date format is incorrect" in new SetUp {
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] =
+          validator(validNino, triggerBsasRequestJson(startDate = "06-05-2019")).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, StartDateFormatError)
+        )
+      }
+
+      "the start date is before the min start date" in new SetUp {
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] =
+          validator(validNino, triggerBsasRequestJson(startDate = "1890-05-23")).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, StartDateFormatError)
+        )
+      }
+    }
+
+    "return an EndDateFormatError" when {
+      "the end date format is incorrect" in new SetUp {
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] =
+          validator(validNino, triggerBsasRequestJson(endDate = "06-05-2020")).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, EndDateFormatError)
+        )
+      }
+
+      "the end date is after the max end date" in new SetUp {
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] =
+          validator(validNino, triggerBsasRequestJson(endDate = "2101-05-20")).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, EndDateFormatError)
+        )
+      }
+    }
+
+    "return a TypeOfBusinessFormatError" when {
+      "an incorrect business type is given" in new SetUp {
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] =
+          validator(validNino, triggerBsasRequestJson(typeOfBusiness = "not-a-type-of-business")).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, TypeOfBusinessFormatError)
+        )
+      }
+    }
+
+    "return a BusinessIdFormatError" when {
+      "a business id is provided with wrong formatting" in new SetUp {
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] =
+          validator(validNino, triggerBsasRequestJson(businessId = "not-a-business-id")).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, BusinessIdFormatError)
+        )
+      }
+    }
+
+    "return a RuleIncorrectOrEmptyBodyError" when {
+      "an empty body is submitted" in new SetUp {
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] = validator(validNino, JsObject.empty).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError)
+        )
+      }
+
+      "mandatory fields are missing" in new SetUp {
+        val requestJs: JsObject                                  = Json.obj("accountingPeriod" -> Json.obj("endDate" -> "2020-05-06"))
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] = validator(validNino, requestJs).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleIncorrectOrEmptyBodyError.withPaths(List("/accountingPeriod/startDate", "/businessId", "/typeOfBusiness")))
+        )
+      }
+    }
+
+    "return a RuleEndBeforeStartDateError" when {
+      "the end date is before the start date" in new SetUp {
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] =
+          validator(validNino, triggerBsasRequestJson(startDate = "2022-05-07")).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleEndBeforeStartDateError)
+        )
+      }
+    }
+
+    "return a RuleEndBeforeStartDateError" when {
+      "the end date is equal to start date" in new SetUp {
+        val body: JsObject                       = triggerBsasRequestJson(startDate = "2022-05-07", endDate = "2022-05-07")
+        val expectedBody: Def1_TriggerBsasRequestBody = body.as[Def1_TriggerBsasRequestBody]
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] =
+          validator(validNino, body).validateAndWrapResult()
+
+        result shouldBe Right(Def1_TriggerBsasRequestData(parsedNino, expectedBody))
+      }
+    }
+
+    "return a RuleAccountingPeriodNotSupportedError" when {
+      "the accounting period is before the minimum tax year" in new SetUp {
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] =
+          validator(validNino, triggerBsasRequestJson(startDate = "2015-05-05", endDate = "2016-05-06")).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(correlationId, RuleAccountingPeriodNotSupportedError)
+        )
+      }
+    }
+
+    "return multiple errors" when {
+      "the request body has muliple issues" in new SetUp {
+        val result: Either[ErrorWrapper, TriggerBsasRequestData] =
+          validator(validNino, triggerBsasRequestJson(typeOfBusiness = "", businessId = "")).validateAndWrapResult()
+
+        result shouldBe Left(
+          ErrorWrapper(
+            correlationId,
+            BadRequestError,
+            Some(List(BusinessIdFormatError, TypeOfBusinessFormatError))
+          )
+        )
+      }
+    }
+  }
+
+  "the Accounting Period validation" should {
+    "return no errors" when {
+      "passed the correct Accounting Period dates for each Type of Business" when {
+        List(
+          (TypeOfBusiness.`self-employment`, "2019-04-06"),
+          (TypeOfBusiness.`uk-property-fhl`, "2019-04-06"),
+          (TypeOfBusiness.`uk-property-non-fhl`, "2019-04-06"),
+          (TypeOfBusiness.`foreign-property-fhl-eea`, "2021-04-06"),
+          (TypeOfBusiness.`foreign-property`, "2021-04-06")
+        ).foreach { case (typeOfBusiness, endDate) =>
+          s"typeOfBusiness is $typeOfBusiness and the endDate is after the allowed end date" in {
+            val body         = triggerBsasRequestJson(typeOfBusiness = typeOfBusiness.toString, startDate = "2019-01-01", endDate = endDate)
+            val expectedBody = body.as[Def1_TriggerBsasRequestBody]
+
+            val result: Validated[Seq[MtdError], TriggerBsasRequestData] = validator(validNino, body).validate
+            result shouldBe Valid(Def1_TriggerBsasRequestData(parsedNino, expectedBody))
+          }
+        }
+      }
+
+      "return RuleAccountingPeriodNotSupported" when {
+        "passed incorrect Accounting Period dates for each Type of Business" when {
+          List(
+            (TypeOfBusiness.`self-employment`, "2019-04-05"),
+            (TypeOfBusiness.`uk-property-fhl`, "2019-04-05"),
+            (TypeOfBusiness.`uk-property-non-fhl`, "2019-04-05"),
+            (TypeOfBusiness.`foreign-property-fhl-eea`, "2021-04-05"),
+            (TypeOfBusiness.`foreign-property`, "2021-04-05")
+          ).foreach { case (typeOfBusiness, endDate) =>
+            s"typeOfBusiness is $typeOfBusiness and endDate is before the earliest allowed end date" in {
+              val body = triggerBsasRequestJson(typeOfBusiness = typeOfBusiness.toString, startDate = "2019-01-01", endDate = endDate)
+
+              val result: Either[ErrorWrapper, TriggerBsasRequestData] = validator(validNino, body).validateAndWrapResult()
+
+              result shouldBe Left(
+                ErrorWrapper(correlationId, RuleAccountingPeriodNotSupportedError)
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
### Notes:
* Created full v5 classes (from v3 and v4 where reqd) 

* Used _endpoint name-first_ package structure with child packages `controllers`, `services`, `models` etc. This may need changing if we go with something different, but it is much easier to find things than the old structure.

* Have gone with the class naming convention as discussed (namely only prefix Def1_ for the top-level request data, request body and response classes). However, for list (hateoas wrapping) some classes deeper in the data structures also required schema-independent traits with Def1-prefixed implementations. 

* One child package is new: `schema`. This contains an enumeration (via sealed trait) of schema value Def1, Def2 etc for the endpoint that represent the different schema definitions. The purpose of this is two-fold:
    * To allow the schema value to be passed along as part of the request data to be used. Currently this is only used in the connectors (but is not reqd for empty/ignored downstream responses) to determine the type of JSON `Reads` the connector needs to use. Connectors simply use `import schema._` after the `import request._` to bring it into scope and change the type parameters on the `DownstreamUri` to `DownstreamResp`.
    * The other purpose is that it can then be used explicitly in the validator factory to select the appropriate validator.

* For each endpoint the schema trait companion object has `schemaFor` method(s) to get the schema value based on the tax year. The signature of this method depends on where the tax year comes from: typically a query or path param, but BSAS trigger has it in the request body. Because this is done prior to validation, a default Def1 schema is used if there is any problem with getting the tax year. This _seems_ reasonable but we might want to give this further thought. There is certainly some scope for cleaner ways to map tax year ranges to schema values.