### PR TITLE
NOJIRA-multi-schema-fixes

### DIFF
--- a/app/shared/schema/DownstreamReadable.scala
+++ b/app/shared/schema/DownstreamReadable.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v5.schema
+package shared.schema
 
 import play.api.libs.json.Reads
 

--- a/app/v5/listBsas/controllers/ListBsasController.scala
+++ b/app/v5/listBsas/controllers/ListBsasController.scala
@@ -22,7 +22,7 @@ import shared.controllers._
 import shared.hateoas.HateoasFactory
 import shared.services.{EnrolmentsAuthService, MtdIdLookupService}
 import shared.utils._
-import v5.listBsas.models.{BsasSummary, ListBsasHateoasData, ListBsasRequestData, ListBsasResponse}
+import v5.listBsas.models.ListBsasHateoasData
 import v5.listBsas.schema.ListBsasSchema
 import v5.listBsas.services.ListBsasService
 import v5.listBsas.validators.ListBsasValidatorFactory
@@ -55,7 +55,7 @@ class ListBsasController @Inject() (val authService: EnrolmentsAuthService,
           .withValidator(validator)
           .withService(service.listBsas)
           .withResultCreator(
-            ResultCreator.hateoasListWrapping(hateoasFactory)((parsedRequest: ListBsasRequestData, response: ListBsasResponse[BsasSummary]) =>
+            ResultCreator.hateoasListWrapping(hateoasFactory)((parsedRequest, response) =>
               ListBsasHateoasData(nino, response, Some(parsedRequest.taxYear))))
 
       requestHandler.handleRequest()

--- a/app/v5/listBsas/models/def1/Def1_ListBsasResponse.scala
+++ b/app/v5/listBsas/models/def1/Def1_ListBsasResponse.scala
@@ -17,7 +17,6 @@
 package v5.listBsas.models.def1
 
 import play.api.libs.json.{Json, OWrites, Reads, Writes}
-import v5.hateoas.HateoasLinks
 import v5.listBsas.models.ListBsasResponse
 import v5.models.domain.TypeOfBusiness
 
@@ -31,9 +30,10 @@ case class Def1_ListBsasResponse[I](businessSources: Seq[BusinessSource[I]]) ext
       businessSource.copy(summaries = businessSource.summaries.map(f))
     })
   }
+
 }
 
-object Def1_ListBsasResponse extends HateoasLinks {
+object Def1_ListBsasResponse {
 
   implicit def reads[I: Reads]: Reads[Def1_ListBsasResponse[I]] =
     implicitly[Reads[Seq[BusinessSource[I]]]].map(Def1_ListBsasResponse(_))

--- a/app/v5/listBsas/schema/ListBsasSchema.scala
+++ b/app/v5/listBsas/schema/ListBsasSchema.scala
@@ -19,9 +19,9 @@ package v5.listBsas.schema
 import play.api.libs.json.Reads
 import shared.controllers.validators.resolvers.ResolveTaxYear
 import shared.models.domain.TaxYear
+import shared.schema.DownstreamReadable
 import v5.listBsas.models.{BsasSummary, ListBsasResponse}
 import v5.listBsas.models.def1.{Def1_BsasSummary, Def1_ListBsasResponse}
-import v5.schema.DownstreamReadable
 
 import scala.math.Ordered.orderingToOrdered
 
@@ -40,7 +40,7 @@ object ListBsasSchema {
     maybeTaxYear
       .map(ResolveTaxYear.resolver)
       .flatMap(_.toOption.map(schemaFor))
-      .getOrElse(defaultSchema)
+      .getOrElse(schemaFor(TaxYear.currentTaxYear))
   }
 
   def schemaFor(taxYear: TaxYear): ListBsasSchema = {

--- a/app/v5/retrieveForeignPropertyBsas/schema/RetrieveForeignPropertyBsasSchema.scala
+++ b/app/v5/retrieveForeignPropertyBsas/schema/RetrieveForeignPropertyBsasSchema.scala
@@ -19,9 +19,9 @@ package v5.retrieveForeignPropertyBsas.schema
 import play.api.libs.json.Reads
 import shared.controllers.validators.resolvers.ResolveTaxYear
 import shared.models.domain.TaxYear
+import shared.schema.DownstreamReadable
 import v5.retrieveForeignPropertyBsas.models.RetrieveForeignPropertyBsasResponse
 import v5.retrieveForeignPropertyBsas.models.def1.Def1_RetrieveForeignPropertyBsasResponse
-import v5.schema.DownstreamReadable
 
 import scala.math.Ordered.orderingToOrdered
 

--- a/app/v5/retrieveSelfEmploymentBsas/schema/RetrieveSelfEmploymentBsasSchema.scala
+++ b/app/v5/retrieveSelfEmploymentBsas/schema/RetrieveSelfEmploymentBsasSchema.scala
@@ -19,9 +19,9 @@ package v5.retrieveSelfEmploymentBsas.schema
 import play.api.libs.json.Reads
 import shared.controllers.validators.resolvers.ResolveTaxYear
 import shared.models.domain.TaxYear
+import shared.schema.DownstreamReadable
 import v5.retrieveSelfEmploymentBsas.models.RetrieveSelfEmploymentBsasResponse
 import v5.retrieveSelfEmploymentBsas.models.def1.Def1_RetrieveSelfEmploymentBsasResponse
-import v5.schema.DownstreamReadable
 
 import scala.math.Ordered.orderingToOrdered
 

--- a/app/v5/retrieveUkPropertyBsas/schema/RetrieveUkPropertyBsasSchema.scala
+++ b/app/v5/retrieveUkPropertyBsas/schema/RetrieveUkPropertyBsasSchema.scala
@@ -19,9 +19,9 @@ package v5.retrieveUkPropertyBsas.schema
 import play.api.libs.json.Reads
 import shared.controllers.validators.resolvers.ResolveTaxYear
 import shared.models.domain.TaxYear
+import shared.schema.DownstreamReadable
 import v5.retrieveUkPropertyBsas.models.RetrieveUkPropertyBsasResponse
 import v5.retrieveUkPropertyBsas.models.def1.Def1_RetrieveUkPropertyBsasResponse
-import v5.schema.DownstreamReadable
 
 import scala.math.Ordered.orderingToOrdered
 

--- a/app/v5/triggerBsas/schema/TriggerSchema.scala
+++ b/app/v5/triggerBsas/schema/TriggerSchema.scala
@@ -18,7 +18,7 @@ package v5.triggerBsas.schema
 
 import play.api.libs.json.{JsValue, Reads}
 import shared.models.domain.TaxYear
-import v5.schema.DownstreamReadable
+import shared.schema.DownstreamReadable
 import v5.triggerBsas.models.TriggerBsasResponse
 import v5.triggerBsas.models.def1.Def1_TriggerBsasResponse
 

--- a/test/shared/models/domain/TaxYearPropertyCheckSupport.scala
+++ b/test/shared/models/domain/TaxYearPropertyCheckSupport.scala
@@ -16,14 +16,17 @@
 
 package shared.models.domain
 
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{Arbitrary, Gen, ShrinkLowPriority}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-trait TaxYearPropertyCheckSupport {
+
+// Use ShrinkLowPriority otherwise failures will shrink to produce TaxYears
+// outside the Gen.choose(...) range resulting in misleading failures
+trait TaxYearPropertyCheckSupport extends ShrinkLowPriority {
   self: ScalaCheckDrivenPropertyChecks =>
 
   // Based on the limitations of the various tax year formats:
-  private val minAllowed: TaxYear = TaxYear.starting(2000)
+  private val minAllowed: TaxYear = TaxYear.starting(2011)
   private val maxAllowed: TaxYear = TaxYear.starting(2098)
 
   private def arbTaxYear(minStartYear: Int, maxStartYear: Int): Arbitrary[TaxYear] =


### PR DESCRIPTION
- move DownstreamReadable under shared package
- fixes to TaxYearPropertyCheckSupport
- fix list so that schema is based on current tax year when no tax year param supplied (as per spec)