### PR TITLE
MTDSA-21946 - Fix: API returns 400 when mtd-identifier-lookup returns 403

### DIFF
--- a/app/shared/connectors/MtdIdLookupConnector.scala
+++ b/app/shared/connectors/MtdIdLookupConnector.scala
@@ -22,13 +22,20 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
+object MtdIdLookupConnector {
+  case class Error(statusCode: Int) extends AnyVal
+
+  type Outcome = Either[MtdIdLookupConnector.Error, String]
+
+}
+
 @Singleton
 class MtdIdLookupConnector @Inject() (http: HttpClient, appConfig: AppConfig) {
 
-  def getMtdId(nino: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[MtdIdLookupOutcome] = {
+  def getMtdId(nino: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[MtdIdLookupConnector.Outcome] = {
     import shared.connectors.httpparsers.MtdIdLookupHttpParser.mtdIdLookupHttpReads
 
-    http.GET[MtdIdLookupOutcome](s"${appConfig.mtdIdBaseUrl}/mtd-identifier-lookup/nino/$nino")
+    http.GET[MtdIdLookupConnector.Outcome](s"${appConfig.mtdIdBaseUrl}/mtd-identifier-lookup/nino/$nino")
   }
 
 }

--- a/app/shared/connectors/httpparsers/MtdIdLookupHttpParser.scala
+++ b/app/shared/connectors/httpparsers/MtdIdLookupHttpParser.scala
@@ -16,26 +16,20 @@
 
 package shared.connectors.httpparsers
 
-import shared.connectors.MtdIdLookupOutcome
-import shared.models.errors.{InternalError, InvalidBearerTokenError, NinoFormatError}
-import play.api.http.Status.{FORBIDDEN, OK, UNAUTHORIZED}
+import play.api.http.Status.OK
 import play.api.libs.json._
+import shared.connectors
+import shared.connectors.MtdIdLookupConnector
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
 
 object MtdIdLookupHttpParser extends HttpParser {
 
   private val mtdIdJsonReads: Reads[String] = (__ \ "mtdbsa").read[String]
 
-  implicit val mtdIdLookupHttpReads: HttpReads[MtdIdLookupOutcome] = (_: String, _: String, response: HttpResponse) => {
+  implicit val mtdIdLookupHttpReads: HttpReads[connectors.MtdIdLookupConnector.Outcome] = (_: String, _: String, response: HttpResponse) => {
     response.status match {
-      case OK =>
-        response.validateJson[String](mtdIdJsonReads) match {
-          case Some(mtdId) => Right(mtdId)
-          case None        => Left(InternalError)
-        }
-      case FORBIDDEN    => Left(NinoFormatError)
-      case UNAUTHORIZED => Left(InvalidBearerTokenError)
-      case _            => Left(InternalError)
+      case OK     => Right(response.json.as[String](mtdIdJsonReads))
+      case status => Left(MtdIdLookupConnector.Error(status))
     }
   }
 

--- a/app/shared/connectors/package.scala
+++ b/app/shared/connectors/package.scala
@@ -16,12 +16,9 @@
 
 package shared
 
-import shared.models.errors.{DownstreamError, MtdError}
+import shared.models.errors.DownstreamError
 import shared.models.outcomes.ResponseWrapper
 
 package object connectors {
-
-  type MtdIdLookupOutcome = Either[MtdError, String]
-
   type DownstreamOutcome[A] = Either[ResponseWrapper[DownstreamError], ResponseWrapper[A]]
 }

--- a/app/shared/controllers/AuthorisedController.scala
+++ b/app/shared/controllers/AuthorisedController.scala
@@ -48,8 +48,8 @@ abstract class AuthorisedController(cc: ControllerComponents)(implicit ec: Execu
     def invokeBlockWithAuthCheck[A](mtdId: String, request: Request[A], block: UserRequest[A] => Future[Result])(implicit
         headerCarrier: HeaderCarrier): Future[Result] = {
       authService.authorised(predicate(mtdId)).flatMap[Result] {
-        case Right(userDetails)                => block(UserRequest(userDetails.copy(mtdId = mtdId), request))
-        case Left(mtdError)                    => errorResponse(mtdError)
+        case Right(userDetails) => block(UserRequest(userDetails.copy(mtdId = mtdId), request))
+        case Left(mtdError)     => errorResponse(mtdError)
       }
     }
 

--- a/app/shared/models/errors/CommonMtdErrors.scala
+++ b/app/shared/models/errors/CommonMtdErrors.scala
@@ -72,11 +72,11 @@ object InvalidTaxYearParameterError
 
 //Authentication/Authorisation errors
 
-object ClientNotAuthenticatedError extends MtdError("CLIENT_OR_AGENT_NOT_AUTHORISED", "The client or agent is not authorised", UNAUTHORIZED)
-
 /** Authentication OK but not allowed access to the requested resource
   */
-object ClientNotAuthorisedError extends MtdError("CLIENT_OR_AGENT_NOT_AUTHORISED", "The client or agent is not authorised", FORBIDDEN)
+object ClientOrAgentNotAuthorisedError extends MtdError("CLIENT_OR_AGENT_NOT_AUTHORISED", "The client or agent is not authorised", FORBIDDEN){
+  def withStatus401: MtdError = copy(httpStatus = UNAUTHORIZED)
+}
 
 object InvalidBearerTokenError extends MtdError("UNAUTHORIZED", "Bearer token is missing or not authorized", UNAUTHORIZED)
 

--- a/app/shared/services/EnrolmentsAuthService.scala
+++ b/app/shared/services/EnrolmentsAuthService.scala
@@ -60,11 +60,11 @@ class EnrolmentsAuthService @Inject() (val connector: AuthConnector, val appConf
           }
         case _ =>
           logger.warn(s"[EnrolmentsAuthService][authorised] Invalid AffinityGroup.")
-          Future.successful(Left(ClientNotAuthorisedError))
+          Future.successful(Left(ClientOrAgentNotAuthorisedError))
       }
       .recoverWith {
-        case _: MissingBearerToken     => Future.successful(Left(ClientNotAuthorisedError))
-        case _: AuthorisationException => Future.successful(Left(ClientNotAuthorisedError))
+        case _: MissingBearerToken     => Future.successful(Left(ClientOrAgentNotAuthorisedError))
+        case _: AuthorisationException => Future.successful(Left(ClientOrAgentNotAuthorisedError))
         case error =>
           logger.warn(s"[EnrolmentsAuthService][authorised] An unexpected error occurred: $error")
           Future.successful(Left(InternalError))

--- a/app/shared/services/MtdIdLookupService.scala
+++ b/app/shared/services/MtdIdLookupService.scala
@@ -16,22 +16,35 @@
 
 package shared.services
 
-import shared.connectors.{MtdIdLookupConnector, MtdIdLookupOutcome}
+import play.api.http.Status._
+import shared.connectors.MtdIdLookupConnector
 import shared.controllers.validators.resolvers.ResolveNino
-import shared.models.errors.NinoFormatError
+import shared.models.errors.{InvalidBearerTokenError, NinoFormatError, _}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
+object MtdIdLookupService {
+  type Outcome = Either[MtdError, String]
+}
+
 @Singleton
 class MtdIdLookupService @Inject() (val connector: MtdIdLookupConnector) {
 
-  def lookup(nino: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[MtdIdLookupOutcome] = {
-    if (ResolveNino.isValid(nino)) {
-      connector.getMtdId(nino)
-    } else {
+  def lookup(nino: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[MtdIdLookupService.Outcome] = {
+    if (!ResolveNino.isValid(nino)) {
       Future.successful(Left(NinoFormatError))
+    } else {
+      connector.getMtdId(nino) map {
+        case Right(mtdId) => Right(mtdId)
+        case Left(MtdIdLookupConnector.Error(statusCode)) =>
+          statusCode match {
+            case FORBIDDEN    => Left(ClientOrAgentNotAuthorisedError)
+            case UNAUTHORIZED => Left(InvalidBearerTokenError)
+            case _            => Left(InternalError)
+          }
+      }
     }
   }
 

--- a/app/shared/utils/ErrorHandler.scala
+++ b/app/shared/utils/ErrorHandler.scala
@@ -66,7 +66,7 @@ class ErrorHandler @Inject() (
 
       case _ =>
         val errorCode = statusCode match {
-          case UNAUTHORIZED           => ClientNotAuthenticatedError
+          case UNAUTHORIZED           => ClientOrAgentNotAuthorisedError.withStatus401
           case METHOD_NOT_ALLOWED     => InvalidHttpMethodError
           case UNSUPPORTED_MEDIA_TYPE => InvalidBodyTypeError
           case _                      => MtdError("INVALID_REQUEST", message, BAD_REQUEST)
@@ -99,7 +99,7 @@ class ErrorHandler @Inject() (
 
     val (errorCode, eventType) = ex match {
       case _: NotFoundException      => (NotFoundError, "ResourceNotFound")
-      case _: AuthorisationException => (ClientNotAuthenticatedError, "ClientError")
+      case _: AuthorisationException => (ClientOrAgentNotAuthorisedError.withStatus401, "ClientError")
       case _: JsValidationException  => (BadRequestError, "ServerValidationError")
       case e: HttpException          => (BadRequestError, "ServerValidationError")
       case e: UpstreamErrorResponse if UpstreamErrorResponse.Upstream4xxResponse.unapply(e).isDefined =>

--- a/it/shared/stubs/AuthStub.scala
+++ b/it/shared/stubs/AuthStub.scala
@@ -29,6 +29,7 @@ object AuthStub extends WireMockMethods {
   }
 
   def unauthorisedNotLoggedIn(): StubMapping = {
+    // Note that MissingBearerToken extends NoActiveSession
     when(method = POST, uri = authoriseUri)
       .thenReturn(status = UNAUTHORIZED, headers = Map("WWW-Authenticate" -> """MDTP detail="MissingBearerToken""""))
   }

--- a/it/shared/stubs/MtdIdLookupStub.scala
+++ b/it/shared/stubs/MtdIdLookupStub.scala
@@ -1,32 +1,20 @@
 package shared.stubs
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import play.api.http.Status.{BAD_REQUEST, FORBIDDEN, INTERNAL_SERVER_ERROR, OK}
+import play.api.http.Status.OK
 import play.api.libs.json.Json
 import support.WireMockMethods
 
 object MtdIdLookupStub extends WireMockMethods {
 
-  def ninoFound(nino: String): StubMapping = {
-    when(method = GET, uri = lookupUrl(nino))
-      .thenReturn(status = OK, body = Json.obj("mtdbsa" -> "12345678"))
-  }
-
-  def unauthorised(nino: String): StubMapping = {
-    when(method = GET, uri = lookupUrl(nino))
-      .thenReturn(status = FORBIDDEN, body = Json.obj())
-  }
-
-  def badRequest(nino: String): StubMapping = {
-    when(method = GET, uri = lookupUrl(nino))
-      .thenReturn(status = BAD_REQUEST, body = Json.obj())
-  }
-
   private def lookupUrl(nino: String): String = s"/mtd-identifier-lookup/nino/$nino"
 
-  def internalServerError(nino: String): StubMapping = {
+  def ninoFound(nino: String): StubMapping =
     when(method = GET, uri = lookupUrl(nino))
-      .thenReturn(status = INTERNAL_SERVER_ERROR, body = Json.obj())
-  }
+      .thenReturn(status = OK, body = Json.obj("mtdbsa" -> "12345678"))
+
+  def error(nino: String, status: Int): StubMapping =
+    when(method = GET, uri = lookupUrl(nino))
+      .thenReturn(status, body = Json.obj())
 
 }

--- a/it/v3/endpoints/AuthISpec.scala
+++ b/it/v3/endpoints/AuthISpec.scala
@@ -72,7 +72,7 @@ class AuthISpec extends IntegrationBaseSpec {
       }
     }
 
-    "an MTD ID lookup fails with a 403" should {
+    "MTD ID lookup fails with a 403" should {
 
       "return 403" in new Test {
         override val nino: String = "AA123456A"
@@ -88,7 +88,7 @@ class AuthISpec extends IntegrationBaseSpec {
     }
   }
 
-    "an MTD ID is successfully retrieve from the NINO and the user is authorised" should {
+    "MTD ID lookup succeeds and the user is authorised" should {
 
       "return 200" in new Test {
         override def setupStubs(): StubMapping = {
@@ -104,7 +104,7 @@ class AuthISpec extends IntegrationBaseSpec {
       }
     }
 
-    "an MTD ID is successfully retrieve from the NINO and the user is NOT logged in" should {
+    "MTD ID lookup succeeds but the user is NOT logged in" should {
 
       "return 403" in new Test {
         override val nino: String = "AA123456A"
@@ -120,7 +120,7 @@ class AuthISpec extends IntegrationBaseSpec {
       }
     }
 
-    "an MTD ID is successfully retrieve from the NINO and the user is NOT authorised" should {
+    "MTD ID lookup succeeds but the user is NOT authorised" should {
 
       "return 403" in new Test {
         override val nino: String = "AA123456A"

--- a/it/v3/endpoints/AuthISpec.scala
+++ b/it/v3/endpoints/AuthISpec.scala
@@ -57,20 +57,36 @@ class AuthISpec extends IntegrationBaseSpec {
 
   "Calling the sample endpoint" when {
 
-    "the NINO cannot be converted to a MTD ID" should {
+    "MTD ID lookup fails with a 500" should {
 
       "return 500" in new Test {
         override val nino: String = "AA123456A"
 
         override def setupStubs(): StubMapping = {
           AuditStub.audit()
-          MtdIdLookupStub.internalServerError(nino)
+          MtdIdLookupStub.error(nino, Status.INTERNAL_SERVER_ERROR)
         }
 
         val response: WSResponse = await(request().post(requestJson))
         response.status shouldBe Status.INTERNAL_SERVER_ERROR
       }
     }
+
+    "an MTD ID lookup fails with a 403" should {
+
+      "return 403" in new Test {
+        override val nino: String = "AA123456A"
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          MtdIdLookupStub.error(nino, Status.FORBIDDEN)
+        }
+
+        val response: WSResponse = await(request().post(requestJson))
+        response.status shouldBe Status.FORBIDDEN
+      }
+    }
+  }
 
     "an MTD ID is successfully retrieve from the NINO and the user is authorised" should {
 
@@ -119,6 +135,5 @@ class AuthISpec extends IntegrationBaseSpec {
         response.status shouldBe Status.FORBIDDEN
       }
     }
-  }
 
 }

--- a/it/v5/endpoints/AuthISpec.scala
+++ b/it/v5/endpoints/AuthISpec.scala
@@ -57,14 +57,14 @@ class AuthISpec extends IntegrationBaseSpec {
 
   "Calling the sample endpoint" when {
 
-    "the NINO cannot be converted to a MTD ID" should {
+    "MTD ID lookup fails with a 500" should {
 
       "return 500" in new Test {
         override val nino: String = "AA123456A"
 
         override def setupStubs(): StubMapping = {
           AuditStub.audit()
-          MtdIdLookupStub.internalServerError(nino)
+          MtdIdLookupStub.error(nino, Status.INTERNAL_SERVER_ERROR)
         }
 
         val response: WSResponse = await(request().post(requestJson))
@@ -72,7 +72,23 @@ class AuthISpec extends IntegrationBaseSpec {
       }
     }
 
-    "an MTD ID is successfully retrieve from the NINO and the user is authorised" should {
+    "MTD ID lookup fails with a 403" should {
+
+      "return 403" in new Test {
+        override val nino: String = "AA123456A"
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          MtdIdLookupStub.error(nino, Status.FORBIDDEN)
+        }
+
+        val response: WSResponse = await(request().post(requestJson))
+        response.status shouldBe Status.FORBIDDEN
+      }
+    }
+  }
+
+    "MTD ID lookup succeeds but the user is authorised" should {
 
       "return 200" in new Test {
         override def setupStubs(): StubMapping = {
@@ -88,7 +104,7 @@ class AuthISpec extends IntegrationBaseSpec {
       }
     }
 
-    "an MTD ID is successfully retrieve from the NINO and the user is NOT logged in" should {
+    "MTD ID lookup succeeds but the user is NOT logged in" should {
 
       "return 403" in new Test {
         override val nino: String = "AA123456A"
@@ -104,7 +120,7 @@ class AuthISpec extends IntegrationBaseSpec {
       }
     }
 
-    "an MTD ID is successfully retrieve from the NINO and the user is NOT authorised" should {
+    "MTD ID lookup succeeds but the user is NOT authorised" should {
 
       "return 403" in new Test {
         override val nino: String = "AA123456A"
@@ -119,6 +135,5 @@ class AuthISpec extends IntegrationBaseSpec {
         response.status shouldBe Status.FORBIDDEN
       }
     }
-  }
 
 }

--- a/it/v5/endpoints/AuthISpec.scala
+++ b/it/v5/endpoints/AuthISpec.scala
@@ -88,7 +88,7 @@ class AuthISpec extends IntegrationBaseSpec {
     }
   }
 
-    "MTD ID lookup succeeds but the user is authorised" should {
+    "MTD ID lookup succeeds and the user is authorised" should {
 
       "return 200" in new Test {
         override def setupStubs(): StubMapping = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.20.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.21.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.0")
 addSbtPlugin("org.scalastyle"    % "scalastyle-sbt-plugin" % "1.0.0" exclude ("org.scala-lang.modules", "scala-xml_2.12"))

--- a/test/shared/connectors/MockMtdIdLookupConnector.scala
+++ b/test/shared/connectors/MockMtdIdLookupConnector.scala
@@ -28,7 +28,7 @@ trait MockMtdIdLookupConnector extends MockFactory {
 
   object MockedMtdIdLookupConnector {
 
-    def lookup(nino: String): CallHandler[Future[MtdIdLookupOutcome]] = {
+    def lookup(nino: String): CallHandler[Future[MtdIdLookupConnector.Outcome]] = {
       (mockMtdIdLookupConnector
         .getMtdId(_: String)(_: HeaderCarrier, _: ExecutionContext))
         .expects(nino, *, *)

--- a/test/shared/connectors/MtdIdLookupConnectorSpec.scala
+++ b/test/shared/connectors/MtdIdLookupConnectorSpec.scala
@@ -18,7 +18,6 @@ package shared.connectors
 
 import shared.config.MockAppConfig
 import shared.mocks.MockHttpClient
-import shared.models.errors.InternalError
 
 import scala.concurrent.Future
 
@@ -41,25 +40,25 @@ class MtdIdLookupConnectorSpec extends ConnectorSpec {
     "return an MtdId" when {
       "the http client returns a mtd id" in new Test {
         MockedHttpClient
-          .get[MtdIdLookupOutcome](s"$baseUrl/mtd-identifier-lookup/nino/$nino", dummyHeaderCarrierConfig)
+          .get[MtdIdLookupConnector.Outcome](s"$baseUrl/mtd-identifier-lookup/nino/$nino", dummyHeaderCarrierConfig)
           .returns(Future.successful(Right(mtdId)))
 
-        val result: MtdIdLookupOutcome = await(connector.getMtdId(nino))
-        result shouldBe Right(mtdId)
+        await(connector.getMtdId(nino)) shouldBe Right(mtdId)
       }
     }
 
-    "return a DownstreamError" when {
-      "the http client returns a DownstreamError" in new Test {
+    "return an error" when {
+      "the http client returns that error" in new Test {
+        val statusCode: Int = IM_A_TEAPOT
+
         MockedHttpClient
-          .get[MtdIdLookupOutcome](
+          .get[MtdIdLookupConnector.Outcome](
             url = s"$baseUrl/mtd-identifier-lookup/nino/$nino",
             config = dummyHeaderCarrierConfig
           )
-          .returns(Future.successful(Left(InternalError)))
+          .returns(Future.successful(Left(MtdIdLookupConnector.Error(statusCode))))
 
-        val result: MtdIdLookupOutcome = await(connector.getMtdId(nino))
-        result shouldBe Left(InternalError)
+        await(connector.getMtdId(nino)) shouldBe Left(MtdIdLookupConnector.Error(statusCode))
       }
     }
   }

--- a/test/shared/connectors/httpparsers/MtdIdLookupHttpParserSpec.scala
+++ b/test/shared/connectors/httpparsers/MtdIdLookupHttpParserSpec.scala
@@ -16,81 +16,46 @@
 
 package shared.connectors.httpparsers
 
-import shared.connectors.MtdIdLookupOutcome
-import shared.connectors.httpparsers.MtdIdLookupHttpParser.mtdIdLookupHttpReads
-import shared.models.errors._
-import play.api.libs.json.Json
+import play.api.http.Status.IM_A_TEAPOT
+import play.api.libs.json.{JsResultException, Json}
 import play.api.libs.json.Writes.StringWrites
-import play.api.test.Helpers.{FORBIDDEN, INTERNAL_SERVER_ERROR, OK, UNAUTHORIZED}
+import play.api.test.Helpers.OK
 import shared.UnitSpec
+import shared.connectors.MtdIdLookupConnector
+import shared.connectors.httpparsers.MtdIdLookupHttpParser.mtdIdLookupHttpReads
 import uk.gov.hmrc.http.HttpResponse
 
 class MtdIdLookupHttpParserSpec extends UnitSpec {
 
   private val method = "GET"
   private val url    = "test-url"
-  private val mtdId  = "test-mtd-id"
 
-  private val mtdIdJson   = Json.obj("mtdbsa" -> mtdId)
-  private val invalidJson = Json.obj("hello" -> "world")
+  "read" when {
+    "the response contains a 200 status" when {
+      "the response body contains an MtdId" must {
+        "return the MtdId" in {
+          val mtdId    = "test-mtd-id"
+          val response = HttpResponse(OK, Json.obj("mtdbsa" -> mtdId), Map.empty[String, Seq[String]])
 
-  "read" should {
-    "return an MtdId" when {
-      "the HttpResponse contains a 200 status and a correct response body" in {
-        val response                   = HttpResponse(OK, mtdIdJson, Map.empty[String, Seq[String]])
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
+          mtdIdLookupHttpReads.read(method, url, response) shouldBe Right(mtdId)
+        }
+      }
 
-        result shouldBe Right(mtdId)
+      "the response body is not valid" must {
+        "throw an JsResultException" in {
+          val response = HttpResponse(OK, Json.obj("hello" -> "world"), Map.empty[String, Seq[String]])
+
+          intercept[JsResultException](mtdIdLookupHttpReads.read(method, url, response))
+        }
       }
     }
 
-    "returns an downstream error" when {
-      "backend doesn't have a valid data" in {
-        val response                   = HttpResponse(OK, invalidJson, Map.empty[String, Seq[String]])
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
+    "the response contains a non-200 status" must {
+      "return the status code as an error" in {
+        val status   = IM_A_TEAPOT
+        val response = HttpResponse(status, "ignored")
 
-        result shouldBe Left(InternalError)
-      }
-
-      "backend doesn't return any data" in {
-        val response                   = HttpResponse(OK, "")
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
-
-        result shouldBe Left(InternalError)
-      }
-
-      "the json cannot be read" in {
-        val response                   = HttpResponse(OK, None.orNull)
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
-
-        result shouldBe Left(InternalError)
-      }
-    }
-
-    "return an InvalidNino error" when {
-      "the HttpResponse contains a 403 status" in {
-        val response                   = HttpResponse(FORBIDDEN, "")
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
-
-        result shouldBe Left(NinoFormatError)
-      }
-    }
-
-    "return an Unauthorised error" when {
-      "the HttpResponse contains a 403 status" in {
-        val response                   = HttpResponse(UNAUTHORIZED, "")
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
-
-        result shouldBe Left(InvalidBearerTokenError)
-      }
-    }
-
-    "return a DownstreamError" when {
-      "the HttpResponse contains any other status" in {
-        val response                   = HttpResponse(INTERNAL_SERVER_ERROR, "")
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
-
-        result shouldBe Left(InternalError)
+        mtdIdLookupHttpReads.read(method, url, response) shouldBe Left(MtdIdLookupConnector.Error(status))
       }
     }
   }

--- a/test/shared/controllers/AuthorisedControllerSpec.scala
+++ b/test/shared/controllers/AuthorisedControllerSpec.scala
@@ -29,8 +29,10 @@ import scala.concurrent.Future
 
 class AuthorisedControllerSpec extends ControllerBaseSpec {
 
-  private val nino  = "AA123456A"
-  private val mtdId = "X123567890"
+  private val nino = "AA123456A"
+
+  private val mtdId     = "X123567890"
+  private val someError = MtdError("SOME_CODE", "A message", IM_A_TEAPOT)
 
   private val predicate: Predicate = Enrolment("HMRC-MTD-IT")
     .withIdentifier("MTDITID", mtdId)
@@ -40,10 +42,7 @@ class AuthorisedControllerSpec extends ControllerBaseSpec {
 
     "the user is authorised" should {
       "return a 200" in new Test {
-
-        MockedMtdIdLookupService
-          .lookup(nino)
-          .returns(Future.successful(Right(mtdId)))
+        MockedMtdIdLookupService.lookup(nino) returns Future.successful(Right(mtdId))
 
         MockedEnrolmentsAuthService.authoriseUser()
 
@@ -52,101 +51,26 @@ class AuthorisedControllerSpec extends ControllerBaseSpec {
       }
     }
 
-    "auth returns an unexpected error" should {
-      "return a 500" in new Test {
+    "the EnrolmentsAuthService returns an error" should {
+      "return that error (with its status code)" in new Test {
+        MockedMtdIdLookupService.lookup(nino) returns Future.successful(Right(mtdId))
 
-        MockedMtdIdLookupService
-          .lookup(nino)
-          .returns(Future.successful(Right(mtdId)))
-
-        MockedEnrolmentsAuthService
-          .authorised(predicate)
-          .returns(Future.successful(Left(InternalError)))
+        MockedEnrolmentsAuthService.authorised(predicate) returns Future.successful(Left(someError))
 
         val result: Future[Result] = target.action(nino)(fakeGetRequest)
-        status(result) shouldBe INTERNAL_SERVER_ERROR
+        status(result) shouldBe someError.httpStatus
+        contentAsJson(result) shouldBe Json.toJson(someError)
       }
     }
 
-    "the nino is invalid" should {
-      "return a 400" in new Test {
-
-        MockedMtdIdLookupService
-          .lookup(nino)
-          .returns(Future.successful(Left(NinoFormatError)))
+    "the MtdIdLookupService returns an error" should {
+      "return that error (with its status code)" in new Test {
+        MockedMtdIdLookupService.lookup(nino) returns Future.successful(Left(someError))
 
         val result: Future[Result] = target.action(nino)(fakeGetRequest)
-        status(result) shouldBe BAD_REQUEST
+        status(result) shouldBe someError.httpStatus
+        contentAsJson(result) shouldBe Json.toJson(someError)
       }
-    }
-
-    "the nino is valid but invalid bearer token" should {
-      "return a 401" in new Test {
-
-        MockedMtdIdLookupService
-          .lookup(nino)
-          .returns(Future.successful(Left(InvalidBearerTokenError)))
-
-        val result: Future[Result] = target.action(nino)(fakeGetRequest)
-        status(result) shouldBe UNAUTHORIZED
-      }
-    }
-
-  }
-
-  "authorisation checks fail when retrieving the MDT ID" should {
-    "return a 403" in new Test {
-
-      MockedMtdIdLookupService
-        .lookup(nino)
-        .returns(Future.successful(Left(ClientNotAuthorisedError)))
-
-      val result: Future[Result] = target.action(nino)(fakeGetRequest)
-      status(result) shouldBe FORBIDDEN
-    }
-  }
-
-  "the an error occurs retrieving the MDT ID" should {
-    "return a 500" in new Test {
-
-      MockedMtdIdLookupService
-        .lookup(nino)
-        .returns(Future.successful(Left(InternalError)))
-
-      val result: Future[Result] = target.action(nino)(fakeGetRequest)
-      status(result) shouldBe INTERNAL_SERVER_ERROR
-    }
-  }
-
-  "the MTD user is not authenticated" should {
-    "return a 401" in new Test {
-
-      MockedMtdIdLookupService
-        .lookup(nino)
-        .returns(Future.successful(Right(mtdId)))
-
-      MockedEnrolmentsAuthService
-        .authorised(predicate)
-        .returns(Future.successful(Left(ClientNotAuthorisedError)))
-
-      val result: Future[Result] = target.action(nino)(fakeGetRequest)
-      status(result) shouldBe FORBIDDEN
-    }
-  }
-
-  "the MTD user is not authorised" should {
-    "return a 403" in new Test {
-
-      MockedMtdIdLookupService
-        .lookup(nino)
-        .returns(Future.successful(Right(mtdId)))
-
-      MockedEnrolmentsAuthService
-        .authorised(predicate)
-        .returns(Future.successful(Left(ClientNotAuthorisedError)))
-
-      val result: Future[Result] = target.action(nino)(fakeGetRequest)
-      status(result) shouldBe FORBIDDEN
     }
   }
 

--- a/test/shared/services/EnrolmentsAuthServiceSpec.scala
+++ b/test/shared/services/EnrolmentsAuthServiceSpec.scala
@@ -19,7 +19,7 @@ package shared.services
 import org.scalamock.handlers.CallHandler
 import shared.config.{ConfidenceLevelConfig, MockAppConfig}
 import shared.models.auth.UserDetails
-import shared.models.errors.{ClientNotAuthorisedError, InternalError}
+import shared.models.errors.{ClientOrAgentNotAuthorisedError, InternalError}
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.{EmptyPredicate, Predicate}
 import uk.gov.hmrc.auth.core.retrieve.Retrieval
@@ -139,7 +139,7 @@ class EnrolmentsAuthServiceSpec extends ServiceSpec with MockAppConfig {
           .authorised(expectedPredicate, affinityGroup)
           .returns(Future.failed(MissingBearerToken()))
 
-        await(target.authorised(inputPredicate)) shouldBe Left(ClientNotAuthorisedError)
+        await(target.authorised(inputPredicate)) shouldBe Left(ClientOrAgentNotAuthorisedError)
       }
 
     def disallowUsersWithoutEnrolments(inputPredicate: Predicate, authValidationEnabled: Boolean, expectedPredicate: Predicate): Unit =
@@ -150,7 +150,7 @@ class EnrolmentsAuthServiceSpec extends ServiceSpec with MockAppConfig {
           .authorised(expectedPredicate, affinityGroup)
           .returns(Future.failed(InsufficientEnrolments()))
 
-        await(target.authorised(inputPredicate)) shouldBe Left(ClientNotAuthorisedError)
+        await(target.authorised(inputPredicate)) shouldBe Left(ClientOrAgentNotAuthorisedError)
       }
   }
 

--- a/test/shared/services/MockMtdIdLookupService.scala
+++ b/test/shared/services/MockMtdIdLookupService.scala
@@ -16,12 +16,16 @@
 
 package shared.services
 
-import shared.connectors.MtdIdLookupOutcome
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
+import shared.models.errors.MtdError
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
+
+object MockMtdIdLookupService{
+  type MtdIdServiceOutcome = Either[MtdError, String]
+}
 
 trait MockMtdIdLookupService extends MockFactory {
 
@@ -29,7 +33,7 @@ trait MockMtdIdLookupService extends MockFactory {
 
   object MockedMtdIdLookupService {
 
-    def lookup(nino: String): CallHandler[Future[MtdIdLookupOutcome]] = {
+    def lookup(nino: String): CallHandler[Future[MtdIdLookupService.Outcome]] = {
       (mockMtdIdLookupService
         .lookup(_: String)(_: HeaderCarrier, _: ExecutionContext))
         .expects(nino, *, *)

--- a/test/shared/services/MtdIdLookupServiceSpec.scala
+++ b/test/shared/services/MtdIdLookupServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package shared.services
 
-import shared.connectors.{MockMtdIdLookupConnector, MtdIdLookupOutcome}
+import shared.connectors.{MockMtdIdLookupConnector, MtdIdLookupConnector}
 import shared.models.errors._
 
 import scala.concurrent.Future
@@ -24,7 +24,6 @@ import scala.concurrent.Future
 class MtdIdLookupServiceSpec extends ServiceSpec {
 
   val nino        = "AA123456A"
-  val invalidNino = "INVALID_NINO"
 
   trait Test extends MockMtdIdLookupConnector {
     lazy val target = new MtdIdLookupService(mockMtdIdLookupConnector)
@@ -32,44 +31,45 @@ class MtdIdLookupServiceSpec extends ServiceSpec {
 
   "calling .getMtdId" when {
 
+    "an mtdId is found for the NINO" should {
+      "return the mtdId" in new Test {
+        val mtdId = "someMtdId"
+
+        MockedMtdIdLookupConnector.lookup(nino) returns Future.successful(Right(mtdId))
+
+        await(target.lookup(nino)) shouldBe Right(mtdId)
+      }
+    }
+
     "an invalid NINO is passed in" should {
-      "return a valid mtdId" in new Test {
+      "return NinoFormatError" in new Test {
+        val invalidNino = "INVALID_NINO"
 
-        val expected = Left(NinoFormatError)
-
-        // should not call the connector
-        MockedMtdIdLookupConnector
-          .lookup(invalidNino)
-          .never()
-
-        val result: MtdIdLookupOutcome = await(target.lookup(invalidNino))
-        result shouldBe expected
+        await(target.lookup(invalidNino)) shouldBe Left(NinoFormatError)
       }
     }
 
-    "a not authorised error occurs the service" should {
-      "proxy the error to the caller" in new Test {
-        val connectorResponse = Left(ClientNotAuthorisedError)
+    "the downstream service returns a 403 status error" should {
+      "return ClientOrAgentNotAuthorisedError" in new Test {
+        MockedMtdIdLookupConnector.lookup(nino) returns Future.successful(Left(MtdIdLookupConnector.Error(FORBIDDEN)))
 
-        MockedMtdIdLookupConnector
-          .lookup(nino)
-          .returns(Future.successful(connectorResponse))
-
-        val result: MtdIdLookupOutcome = await(target.lookup(nino))
-        result shouldBe connectorResponse
+        await(target.lookup(nino)) shouldBe Left(ClientOrAgentNotAuthorisedError)
       }
     }
 
-    "a downstream error occurs the service" should {
-      "proxy the error to the caller" in new Test {
-        val connectorResponse = Left(InternalError)
+    "the downstream service returns a 401 status error" should {
+      "return InvalidBearerTokenError" in new Test {
+        MockedMtdIdLookupConnector.lookup(nino) returns Future.successful(Left(MtdIdLookupConnector.Error(UNAUTHORIZED)))
 
-        MockedMtdIdLookupConnector
-          .lookup(nino)
-          .returns(Future.successful(connectorResponse))
+        await(target.lookup(nino)) shouldBe Left(InvalidBearerTokenError)
+      }
+    }
 
-        val result: MtdIdLookupOutcome = await(target.lookup(nino))
-        result shouldBe connectorResponse
+    "the downstream service returns another status code" should {
+      "return InternalError" in new Test {
+        MockedMtdIdLookupConnector.lookup(nino) returns Future.successful(Left(MtdIdLookupConnector.Error(IM_A_TEAPOT)))
+
+        await(target.lookup(nino)) shouldBe Left(InternalError)
       }
     }
 

--- a/test/shared/utils/ErrorHandlerSpec.scala
+++ b/test/shared/utils/ErrorHandlerSpec.scala
@@ -105,7 +105,7 @@ class ErrorHandlerSpec extends UnitSpec with GuiceOneAppPerSuite {
         val result: Future[Result] = handler.onClientError(requestHeader, UNAUTHORIZED, "test")
         status(result) shouldBe UNAUTHORIZED
 
-        contentAsJson(result) shouldBe ClientNotAuthorisedError.asJson
+        contentAsJson(result) shouldBe ClientOrAgentNotAuthorisedError.asJson
       }
     }
 
@@ -145,7 +145,7 @@ class ErrorHandlerSpec extends UnitSpec with GuiceOneAppPerSuite {
         // TODO This really should be FORBIDDEN (403), but would need to be changed across all the APIs at once (if at all).
         status(result) shouldBe UNAUTHORIZED
 
-        contentAsJson(result) shouldBe ClientNotAuthorisedError.asJson
+        contentAsJson(result) shouldBe ClientOrAgentNotAuthorisedError.asJson
       }
     }
 


### PR DESCRIPTION
- add failing integration test
- move lookup error transformation from connector to service layer and fix central issue
- simplify AuthorisedControllerSpec so that it only tests its own responsibilities
- rationalise the ClientNotAuthorisedError vs ClientNotAuthenticatedError situation