### PR TITLE
NOJIRA - allow easier testing of feature switches

### DIFF
--- a/test/config/BsasFeatureSwitchesSpec.scala
+++ b/test/config/BsasFeatureSwitchesSpec.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ */
+
+package config
+
+import play.api.Configuration
+import shared.UnitSpec
+import shared.config.FeatureSwitchesBehaviour
+
+class BsasFeatureSwitchesSpec extends UnitSpec with FeatureSwitchesBehaviour[BsasFeatureSwitches] {
+  override def featureSwitches(configuration: Configuration): BsasFeatureSwitches = BsasFeatureSwitches(configuration)
+
+  "isIfsEnabled" should {
+    behave like aFeatureSwitchWithKey("ifs.enabled", _.isIfsEnabled)
+  }
+
+  "isIfsInProduction" should {
+    behave like aFeatureSwitchWithKey("ifs.released-in-production", _.isIfsInProduction)
+  }
+
+}

--- a/test/shared/config/FeatureSwitchesBehaviour.scala
+++ b/test/shared/config/FeatureSwitchesBehaviour.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ */
+
+package shared.config
+
+import play.api.Configuration
+import shared.UnitSpec
+
+trait FeatureSwitchesBehaviour[FS <: FeatureSwitches] {
+  _: UnitSpec =>
+
+  def featureSwitches(configuration: Configuration): FS
+
+  def aFeatureSwitchWithKey(key: String, evaluateSwitch: FS => Boolean): Unit =
+    s"a feature switch with key $key" should {
+      def config(value: Boolean) = Configuration(key -> value)
+
+      "be true" when {
+        "absent from the config" in {
+          val fs = featureSwitches(Configuration.empty)
+          evaluateSwitch(fs) shouldBe true
+        }
+
+        "enabled" in {
+          val fs = featureSwitches(config(true))
+          evaluateSwitch(fs) shouldBe true
+        }
+      }
+
+      "be false" when {
+        "disabled" in {
+          val fs = featureSwitches(config(false))
+          evaluateSwitch(fs) shouldBe false
+        }
+      }
+    }
+
+}

--- a/test/shared/config/FeatureSwitchesSpec.scala
+++ b/test/shared/config/FeatureSwitchesSpec.scala
@@ -19,35 +19,18 @@ package shared.config
 import play.api.Configuration
 import shared.UnitSpec
 
-class FeatureSwitchesSpec extends UnitSpec {
+class FeatureSwitchesSpec extends UnitSpec with FeatureSwitchesBehaviour[FeatureSwitches] {
 
-  private case class TestFeatureSwitches(protected val featureSwitchConfig: Configuration) extends FeatureSwitches
+  override def featureSwitches(configuration: Configuration): FeatureSwitches = new FeatureSwitches {
+    override protected val featureSwitchConfig: Configuration = configuration
+  }
 
-  "FeatureSwitches" should {
-    "be true" when {
-      "absent from the config" in {
-        val configuration   = Configuration.empty
-        val featureSwitches = TestFeatureSwitches(configuration)
+  "isEnabled" should {
+    behave like aFeatureSwitchWithKey("some-feature.enabled", _.isEnabled("some-feature"))
+  }
 
-        featureSwitches.isEnabled("some-feature") shouldBe true
-      }
-
-      "enabled" in {
-        val configuration   = Configuration("some-feature.enabled" -> true)
-        val featureSwitches = TestFeatureSwitches(configuration)
-
-        featureSwitches.isEnabled("some-feature") shouldBe true
-      }
-    }
-
-    "be false" when {
-      "disabled" in {
-        val configuration   = Configuration("some-feature.enabled" -> false)
-        val featureSwitches = TestFeatureSwitches(configuration)
-
-        featureSwitches.isEnabled("some-feature") shouldBe false
-      }
-    }
+  "isReleasedInProduction" should {
+    behave like aFeatureSwitchWithKey("some-feature.released-in-production", _.isReleasedInProduction("some-feature"))
   }
 
 }


### PR DESCRIPTION
All feature switches should behave the same. In order to be able to test the correct behaviour in APIs where there are multiple feature switches and reduce unnecessary boilerplate, this PR proposes a  `FeatureSwitchesBehaviour` trait that has test cases to check this in a general case (for 'enabled', 'released-in-production' and other flavours).

The FeatureSwitchesSpec uses this (to test the general purpose `isEnabled`/`isEnabledInProduction`) methods; and the API-specific BsasFeatureSwitchesSpec does the same for those methods particular to BSAS.