### PR TITLE
MTDSA-24815 - add support for validating unexpected request body fields

### DIFF
--- a/app/shared/controllers/validators/resolvers/ResolveJsonObject.scala
+++ b/app/shared/controllers/validators/resolvers/ResolveJsonObject.scala
@@ -17,67 +17,25 @@
 package shared.controllers.validators.resolvers
 
 import cats.data.Validated
-import cats.data.Validated.{Invalid, Valid}
 import play.api.libs.json._
-import shared.models.errors.{MtdError, RuleIncorrectOrEmptyBodyError}
+import shared.controllers.validators.resolvers.UnexpectedJsonFieldsValidator.SchemaStructureSource
+import shared.models.errors.MtdError
 import shared.utils.Logging
 
 class ResolveJsonObject[T](implicit val reads: Reads[T]) extends ResolverSupport with Logging {
 
-  val resolver: Resolver[JsValue, T] = {
-    case jsObj: JsObject if jsObj.fields.isEmpty =>
-      Invalid(List(RuleIncorrectOrEmptyBodyError))
-
-    case jsObj: JsObject =>
-      jsObj.validate[T] match {
-        case JsSuccess(parsed, _) => Valid(parsed)
-        case JsError(errors) =>
-          val immutableErrors = errors.map { case (path, errors) => (path, errors.toList) }.toList
-          Invalid(handleErrors(immutableErrors))
-      }
-
-    case _ =>
-      Invalid(List(RuleIncorrectOrEmptyBodyError))
-  }
+  val resolver: Resolver[JsValue, T] = ResolveJsonObject.resolver
 
   def apply(data: JsValue): Validated[Seq[MtdError], T] = resolver(data)
+}
 
-  private def handleErrors(errors: Seq[(JsPath, Seq[JsonValidationError])]): Seq[MtdError] = {
-    val failures = errors.map {
+object ResolveJsonObject extends ResolverSupport {
 
-      case (path: JsPath, List(JsonValidationError(List("error.path.missing")))) =>
-        MissingMandatoryField(path)
+  def resolver[A: Reads]: Resolver[JsValue, A] = ResolveJsonObjectInternal.resolver.map(_._2)
 
-      case (path: JsPath, List(JsonValidationError(List(error: String)))) if error.contains("error.expected") =>
-        WrongFieldType(path)
+  /** Gets a resolver that also validates for unexpected JSON fields
+    */
+  def strictResolver[A: Reads: SchemaStructureSource]: Resolver[JsValue, A] =
+    (ResolveJsonObjectInternal.resolver thenValidate UnexpectedJsonFieldsValidator.validator).map(_._2)
 
-      case (path: JsPath, _) =>
-        OtherFailure(path)
-    }
-
-    val logString = failures
-      .groupBy(_.getClass)
-      .values
-      .map(failure => s"${failure.head.failureReason}: " + s"${failure.map(_.fromJsPath)}")
-      .toString()
-      .dropRight(1)
-      .drop(5)
-
-    logger.warn(s"Request body failed validation with errors - $logString")
-    List(RuleIncorrectOrEmptyBodyError.withPaths(failures.map(_.fromJsPath).sorted))
-  }
-
-  private class JsonFormatValidationFailure(path: JsPath, failure: String) {
-    val failureReason: String = failure
-
-    def fromJsPath: String =
-      path.toString
-        .replace("(", "/")
-        .replace(")", "")
-
-  }
-
-  private case class MissingMandatoryField(path: JsPath) extends JsonFormatValidationFailure(path, "Missing mandatory field")
-  private case class WrongFieldType(path: JsPath)        extends JsonFormatValidationFailure(path, "Wrong field type")
-  private case class OtherFailure(path: JsPath)          extends JsonFormatValidationFailure(path, "Other failure")
 }

--- a/app/shared/controllers/validators/resolvers/ResolveJsonObjectInternal.scala
+++ b/app/shared/controllers/validators/resolvers/ResolveJsonObjectInternal.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shared.controllers.validators.resolvers
+
+import cats.data.Validated.{Invalid, Valid}
+import play.api.libs.json._
+import shared.models.errors.{MtdError, RuleIncorrectOrEmptyBodyError}
+import shared.utils.Logging
+
+class ResolveJsonObjectInternal[A](implicit val reads: Reads[A]) extends ResolverSupport with Logging {
+
+  val resolver: Resolver[JsValue, (JsObject, A)] = {
+    case jsObj: JsObject =>
+      if (jsObj.fields.isEmpty) {
+        Invalid(List(RuleIncorrectOrEmptyBodyError))
+      } else {
+        jsObj.validate[A] match {
+          case JsSuccess(parsed, _) => Valid((jsObj, parsed))
+          case JsError(errors) =>
+            val immutableErrors = errors.map { case (path, errors) => (path, errors.toList) }.toList
+            Invalid(toMtdError(immutableErrors))
+        }
+      }
+
+    case _ =>
+      Invalid(List(RuleIncorrectOrEmptyBodyError))
+  }
+
+  private def toMtdError(errors: Seq[(JsPath, Seq[JsonValidationError])]): Seq[MtdError] = {
+    val failures = errors.map {
+      case (path, List(JsonValidationError(List("error.path.missing"))))                      => MissingMandatoryField(path)
+      case (path, List(JsonValidationError(List(error)))) if error.contains("error.expected") => WrongFieldType(path)
+      case (path, _)                                                                          => OtherFailure(path)
+    }
+
+    log(failures)
+    List(RuleIncorrectOrEmptyBodyError.withPaths(failures.map(_.errorPath).sorted))
+  }
+
+  private def log(failures: Seq[JsonFormatValidationFailure]): Unit = {
+    val logString = failures
+      .groupBy(_.getClass)
+      .values
+      .map(failures => s"${failures.head.failureReason}: " + s"${failures.map(_.errorPath)}")
+      .mkString(", ")
+
+    logger.warn(s"Request body failed validation with errors - $logString")
+  }
+
+  private class JsonFormatValidationFailure(jsPath: JsPath, val failureReason: String) {
+
+    def errorPath: String =
+      jsPath.path.map {
+        case IdxPathNode(idx) => s"/$idx"
+        case node: PathNode   => node.toString
+      }.mkString
+
+  }
+
+  private case class MissingMandatoryField(path: JsPath) extends JsonFormatValidationFailure(path, "Missing mandatory field")
+  private case class WrongFieldType(path: JsPath)        extends JsonFormatValidationFailure(path, "Wrong field type")
+  private case class OtherFailure(path: JsPath)          extends JsonFormatValidationFailure(path, "Other failure")
+}
+
+object ResolveJsonObjectInternal extends ResolverSupport {
+
+  def resolver[T: Reads]: Resolver[JsValue, (JsObject, T)] = new ResolveJsonObjectInternal[T].resolver
+
+}

--- a/app/shared/controllers/validators/resolvers/ResolveNonEmptyJsonObject.scala
+++ b/app/shared/controllers/validators/resolvers/ResolveNonEmptyJsonObject.scala
@@ -17,32 +17,37 @@
 package shared.controllers.validators.resolvers
 
 import cats.data.Validated
-import play.api.libs.json.{JsValue, OFormat, Reads}
+import play.api.libs.json.{JsValue, Reads}
+import shared.controllers.validators.resolvers.UnexpectedJsonFieldsValidator.SchemaStructureSource
 import shared.models.errors.{MtdError, RuleIncorrectOrEmptyBodyError}
-import shared.utils.EmptinessChecker
 import shared.utils.EmptyPathsResult._
+import shared.utils.{EmptinessChecker, Logging}
 
-class ResolveNonEmptyJsonObject[T: OFormat: EmptinessChecker]()(implicit val reads: Reads[T]) extends ResolverSupport {
+class ResolveNonEmptyJsonObject[A: Reads: EmptinessChecker] extends ResolverSupport {
 
-  private val jsonResolver = new ResolveJsonObject[T].resolver
+  val resolver: Resolver[JsValue, A] = ResolveNonEmptyJsonObject.resolver
 
-  private val checkNonEmpty: Validator[T] = { data =>
-    EmptinessChecker.findEmptyPaths(data) match {
-      case CompletelyEmpty   => Some(List(RuleIncorrectOrEmptyBodyError))
-      case EmptyPaths(paths) => Some(List(RuleIncorrectOrEmptyBodyError.withPaths(paths)))
-      case NoEmptyPaths      => None
-    }
-  }
-
-  val resolver: Resolver[JsValue, T] = jsonResolver thenValidate checkNonEmpty
-
-  def apply(data: JsValue): Validated[Seq[MtdError], T] = resolver(data)
+  def apply(data: JsValue): Validated[Seq[MtdError], A] = resolver(data)
 
 }
 
-object ResolveNonEmptyJsonObject extends ResolverSupport {
+object ResolveNonEmptyJsonObject extends ResolverSupport with Logging {
 
-  def resolver[T: OFormat: EmptinessChecker]: Resolver[JsValue, T] =
-    new ResolveNonEmptyJsonObject().resolver
+  private def nonEmptyValidator[A: EmptinessChecker]: Validator[A] = { data =>
+    EmptinessChecker.findEmptyPaths(data) match {
+      case CompletelyEmpty => Some(List(RuleIncorrectOrEmptyBodyError))
+      case EmptyPaths(paths) =>
+        logger.warn(s"Request body failed validation with errors - Empty object or array: $paths")
+        Some(List(RuleIncorrectOrEmptyBodyError.withPaths(paths)))
+      case NoEmptyPaths => None
+    }
+  }
+
+  def resolver[A: Reads: EmptinessChecker]: Resolver[JsValue, A] = ResolveJsonObject.resolver thenValidate nonEmptyValidator
+
+  /** Gets a resolver that also validates for unexpected JSON fields
+    */
+  def strictResolver[A: Reads: EmptinessChecker: SchemaStructureSource]: Resolver[JsValue, A] =
+    ResolveJsonObject.strictResolver thenValidate nonEmptyValidator
 
 }

--- a/app/shared/controllers/validators/resolvers/UnexpectedJsonFieldsValidator.scala
+++ b/app/shared/controllers/validators/resolvers/UnexpectedJsonFieldsValidator.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shared.controllers.validators.resolvers
+
+import play.api.libs.json.{JsArray, JsObject, JsValue}
+import shapeless.labelled.FieldType
+import shapeless.{::, HList, HNil, LabelledGeneric, Lazy, Witness}
+import shared.models.errors.RuleIncorrectOrEmptyBodyError
+import shared.utils.Logging
+import UnexpectedJsonFieldsValidator.SchemaStructureSource
+import shared.models.domain.TaxYear
+
+class UnexpectedJsonFieldsValidator[A](implicit extraPathChecker: SchemaStructureSource[A]) extends ResolverSupport with Logging {
+  import UnexpectedJsonFieldsValidator.SchemaStructure
+
+  def validator: Validator[(JsObject, A)] = { case (inputJson, data) =>
+    val expectedJson = extraPathChecker.schemaStructureOf(data)
+
+    findExtraPaths(acc = Nil, path = "", in = inputJson, expected = expectedJson) match {
+      case Nil => None
+      case paths =>
+        logger.warn(s"Request body failed validation with errors - Unexpected fields: $paths")
+        Some(Seq(RuleIncorrectOrEmptyBodyError.withPaths(paths)))
+    }
+  }
+
+  private def findExtraPaths(acc: List[String], path: String, in: JsValue, expected: SchemaStructure): List[String] =
+    (in, expected) match {
+      case (in: JsObject, expected: SchemaStructure.Obj) => handleObjects(acc, path, in, expected)
+      case (in: JsArray, expected: SchemaStructure.Arr)  => handleArrays(acc, path, in, expected)
+      case _                                             => acc
+    }
+
+  private def handleObjects(acc: List[String], path: String, in: JsObject, expected: SchemaStructure.Obj) = {
+    val extraPathsInThisObject = {
+      val extraFields = in.value.toMap -- expected.keys
+      extraFields.map { case (name, _) => s"$path/$name" }.toList
+    }
+
+    expected.fields.foldLeft(acc ++ extraPathsInThisObject) { case (acc, (fieldName, expectedField)) =>
+      in.value.get(fieldName) match {
+        case Some(inField) => findExtraPaths(acc, s"$path/$fieldName", inField, expectedField)
+        case None          => acc
+      }
+    }
+  }
+
+  private def handleArrays(acc: List[String], path: String, in: JsArray, expected: SchemaStructure.Arr) = {
+    val zippedArrayItems = (in.value.zipWithIndex zip expected.items).toList
+
+    zippedArrayItems.foldLeft(acc) { case (acc, ((inItem, index), expectedItem)) =>
+      findExtraPaths(acc, s"$path/$index", inItem, expectedItem)
+    }
+  }
+
+}
+
+object UnexpectedJsonFieldsValidator extends ResolverSupport {
+  def validator[A](implicit extraPathChecker: SchemaStructureSource[A]): Validator[(JsObject, A)] = new UnexpectedJsonFieldsValidator[A].validator
+
+  sealed trait SchemaStructure
+
+  private[UnexpectedJsonFieldsValidator] object SchemaStructure {
+
+    case class Obj(fields: List[(String, SchemaStructure)]) extends SchemaStructure {
+      def keys: Set[String] = fields.map(_._1).toSet
+    }
+
+    case class Arr(items: Seq[SchemaStructure]) extends SchemaStructure
+    case object Leaf                            extends SchemaStructure
+  }
+
+  trait SchemaStructureSource[A] {
+    def schemaStructureOf(value: A): SchemaStructure
+  }
+
+  // Internal specialization of SchemaStructureSource for object instances so we can directly access its fields
+  private[UnexpectedJsonFieldsValidator] trait ObjSchemaStructureSource[A] extends SchemaStructureSource[A] {
+    def schemaStructureOf(value: A): SchemaStructure.Obj
+  }
+
+  object SchemaStructureSource {
+
+    def apply[A](implicit aInstance: SchemaStructureSource[A]): SchemaStructureSource[A] = aInstance
+
+    def instance[A](func: A => SchemaStructure): SchemaStructureSource[A] = (value: A) => func(value)
+
+    private def instanceObj[A](func: A => SchemaStructure.Obj): ObjSchemaStructureSource[A] = (value: A) => func(value)
+
+    def leaf[A]: SchemaStructureSource[A] = SchemaStructureSource.instance(_ => SchemaStructure.Leaf)
+
+    implicit val stringInstance: SchemaStructureSource[String]   = instance(_ => SchemaStructure.Leaf)
+    implicit val intInstance: SchemaStructureSource[Int]         = instance(_ => SchemaStructure.Leaf)
+    implicit val doubleInstance: SchemaStructureSource[Double]   = instance(_ => SchemaStructure.Leaf)
+    implicit val booleanInstance: SchemaStructureSource[Boolean] = instance(_ => SchemaStructure.Leaf)
+
+    implicit val bigIntInstance: SchemaStructureSource[BigInt]         = instance(_ => SchemaStructure.Leaf)
+    implicit val bigDecimalInstance: SchemaStructureSource[BigDecimal] = instance(_ => SchemaStructure.Leaf)
+    implicit val taxYearInstance: SchemaStructureSource[TaxYear]       = instance(_ => SchemaStructure.Leaf)
+
+    implicit def optionInstance[A](implicit aInstance: SchemaStructureSource[A]): SchemaStructureSource[Option[A]] =
+      instance(opt => opt.map(aInstance.schemaStructureOf).getOrElse(SchemaStructure.Leaf))
+
+    implicit def seqInstance[A, I](implicit aInstance: SchemaStructureSource[A]): SchemaStructureSource[Seq[A]] =
+      instance(list => SchemaStructure.Arr(list.map(aInstance.schemaStructureOf)))
+
+    implicit def listInstance[A](implicit aInstance: SchemaStructureSource[A]): SchemaStructureSource[List[A]] =
+      instance(list => SchemaStructure.Arr(list.map(aInstance.schemaStructureOf)))
+
+    implicit val hnilInstance: ObjSchemaStructureSource[HNil] = instanceObj(_ => SchemaStructure.Obj(Nil))
+
+    implicit def hlistInstance[K <: Symbol, H, T <: HList](implicit
+        witness: Witness.Aux[K],
+        hInstance: Lazy[SchemaStructureSource[H]],
+        tInstance: ObjSchemaStructureSource[T]
+    ): ObjSchemaStructureSource[FieldType[K, H] :: T] =
+      instanceObj { case h :: t =>
+        val hField  = witness.value.name -> hInstance.value.schemaStructureOf(h)
+        val tFields = tInstance.schemaStructureOf(t).fields
+        SchemaStructure.Obj(hField :: tFields)
+      }
+
+    implicit def genericInstance[A, R](implicit
+        gen: LabelledGeneric.Aux[A, R],
+        enc: Lazy[SchemaStructureSource[R]]
+    ): SchemaStructureSource[A] =
+      instance(a => enc.value.schemaStructureOf(gen.to(a)))
+
+  }
+
+}

--- a/test/shared/controllers/validators/resolvers/ResolveJsonObjectInternalSpec.scala
+++ b/test/shared/controllers/validators/resolvers/ResolveJsonObjectInternalSpec.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shared.controllers.validators.resolvers
+
+import cats.data.Validated.{Invalid, Valid}
+import play.api.libs.json._
+import shared.models.errors.RuleIncorrectOrEmptyBodyError
+import shared.models.utils.JsonErrorValidators
+import shared.utils.UnitSpec
+
+class ResolveJsonObjectInternalSpec extends UnitSpec with JsonErrorValidators {
+
+  case class Bar(field1: String, field2: String)
+
+  case class Foo(bar: Bar, bars: Seq[Bar])
+
+  implicit val barReads: Reads[Bar] = Json.reads
+  implicit val fooReads: Reads[Foo] = Json.reads
+
+  private val resolver = ResolveJsonObjectInternal.resolver[Foo]
+
+  "ResolveJsonObjectInternal" when {
+    "the JSON is valid" must {
+      "return the JSON and output object" in {
+        val json = Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two" }, "bars": []}""")
+
+        resolver(json) shouldBe Valid((json, Foo(bar = Bar("field one", "field two"), Nil)))
+      }
+    }
+
+    "an empty object is passed" must {
+      "return an RuleIncorrectOrEmptyBodyError" in {
+        resolver(JsObject.empty) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError))
+      }
+    }
+
+    "a string is passed" must {
+      "return an RuleIncorrectOrEmptyBodyError" in {
+        resolver(JsString("someString")) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError))
+      }
+    }
+
+    "a boolean is passed" must {
+      "return an RuleIncorrectOrEmptyBodyError" in {
+        resolver(JsBoolean(true)) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError))
+      }
+    }
+
+    "an array is passed" must {
+      "return an RuleIncorrectOrEmptyBodyError" in {
+        resolver(JsArray(Seq.empty)) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError))
+      }
+    }
+
+    "an Null is passed" must {
+      "return an RuleIncorrectOrEmptyBodyError" in {
+        resolver(JsNull) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError))
+      }
+    }
+
+    "required fields are missing" when {
+      "the field is at the top level" must {
+        "return an error with path to the missing field" in {
+          val json = Json.parse("""{ "bars": []}""")
+
+          resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/bar")))
+        }
+      }
+
+      "the field is nested in an object" must {
+        "return an error with path to the missing field" in {
+          val json = Json.parse("""{ "bar": {"field1" : "field one" }, "bars": []}""")
+
+          resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/bar/field2")))
+        }
+      }
+
+      "the field is nested in an object in an array" must {
+        "return an error with path to the missing field" in {
+          val json = Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two" }, "bars": [{"field1" : "field one" }]}""")
+
+          resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/bars/0/field2")))
+        }
+      }
+
+      "multiple fields are missing" must {
+        "return an error with paths to the missing fields" in {
+          val json = Json.parse("""{ "bar": {}, "bars": []}""")
+
+          resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPaths(Seq("/bar/field1", "/bar/field2"))))
+        }
+      }
+    }
+
+    "fields are the wrong type" must {
+      "the field is at the top level" must {
+        "return an error with path to the bad field" in {
+          val json = Json.parse("""{ "bar": true, "bars": []}""")
+
+          resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/bar")))
+        }
+      }
+
+      "the field is nested in an object" must {
+        "return an error with path to the bad field" in {
+          val json = Json.parse("""{ "bar": {"field1" : "field one", "field2": 2 }, "bars": []}""")
+
+          resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/bar/field2")))
+        }
+      }
+
+      "the field is nested in an object in an array" must {
+        "return an error with path to the bad field" in {
+          val json =
+            Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two" }, "bars": [{"field1" : "field one", "field2": 2 }]}""")
+
+          resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/bars/0/field2")))
+        }
+      }
+
+      "multiple fields are the wrong type" must {
+        "return an error with paths to the bad fields" in {
+          val json = Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two" }, "bars": [{"field1" : 2, "field2": 2 }]}""")
+
+          resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPaths(Seq("/bars/0/field1", "/bars/0/field2"))))
+        }
+      }
+    }
+
+    "multiple types of errors are present" must {
+      "the field is at the top level" must {
+        "return an error with paths to all problematic fields" in {
+          val json = Json.parse("""{  "bars": [{"field1" : "field one", "field2": 2 }]}""")
+
+          resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPaths(Seq("/bar", "/bars/0/field2"))))
+        }
+      }
+    }
+
+  }
+
+}

--- a/test/shared/controllers/validators/resolvers/ResolveJsonObjectSpec.scala
+++ b/test/shared/controllers/validators/resolvers/ResolveJsonObjectSpec.scala
@@ -17,36 +17,58 @@
 package shared.controllers.validators.resolvers
 
 import cats.data.Validated.{Invalid, Valid}
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{JsValue, Json, Reads}
 import shared.models.errors.RuleIncorrectOrEmptyBodyError
 import shared.models.utils.JsonErrorValidators
 import shared.utils.UnitSpec
 
-class ResolveJsonObjectSpec extends UnitSpec with JsonErrorValidators {
+class ResolveJsonObjectSpec extends UnitSpec with ResolverSupport with JsonErrorValidators {
 
-  case class TestDataObject(fieldOne: String, fieldTwo: String)
+  case class Foo(field1: String, field2: String)
 
-  implicit val testDataObjectReads: Reads[TestDataObject] = Json.reads[TestDataObject]
+  implicit val fooReads: Reads[Foo]    = Json.reads
 
-  private val resolve = new ResolveJsonObject[TestDataObject]
-
-  "ResolveJsonObject" should {
+  private def jsonObjectResolver(resolver: Resolver[JsValue, Foo]): Unit = {
     "return the parsed object" when {
       "given a valid JSON object" in {
-        val json = Json.parse("""{ "fieldOne" : "field one", "fieldTwo" : "field two" }""")
+        val json = Json.parse("""{ "field1" : "field one", "field2" : "field two" }""")
 
-        val result = resolve(json)
-        result shouldBe Valid(TestDataObject("field one", "field two"))
+        resolver(json) shouldBe Valid(Foo("field one", "field two"))
       }
     }
 
     "return the expected error " when {
       "a required field is missing" in {
-        val json = Json.parse("""{ "fieldOne" : "field one" }""")
+        val json = Json.parse("""{ "field1" : "field one" }""")
 
-        val result = resolve(json)
-        result shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/fieldTwo")))
+        resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/field2")))
       }
+    }
+  }
+
+  "ResolveJsonObject" when {
+    "the default resolver is used" must {
+      val resolver = ResolveJsonObject.resolver[Foo]
+
+      behave like jsonObjectResolver(resolver)
+
+      "not detect extra fields in the input" in {
+        val json = Json.parse("""{ "extra":123 , "field1" : "field one", "field2" : "field two" }""")
+
+        resolver(json) shouldBe Valid(Foo("field one", "field two"))
+      }
+    }
+  }
+
+  "the strict resolver is used" must {
+    val resolver = ResolveJsonObject.strictResolver[Foo]
+
+    behave like jsonObjectResolver(resolver)
+
+    "detect extra fields in the input" in {
+      val json = Json.parse("""{ "extra":123 , "field1" : "field one", "field2" : "field two" }""")
+
+      resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/extra")))
     }
   }
 

--- a/test/shared/controllers/validators/resolvers/ResolveNonEmptyJsonObjectSpec.scala
+++ b/test/shared/controllers/validators/resolvers/ResolveNonEmptyJsonObjectSpec.scala
@@ -17,133 +17,116 @@
 package shared.controllers.validators.resolvers
 
 import cats.data.Validated.{Invalid, Valid}
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json._
 import shapeless.HNil
 import shared.models.errors.RuleIncorrectOrEmptyBodyError
 import shared.models.utils.JsonErrorValidators
 import shared.utils.{EmptinessChecker, UnitSpec}
 
-class ResolveNonEmptyJsonObjectSpec extends UnitSpec with JsonErrorValidators {
+class ResolveNonEmptyJsonObjectSpec extends UnitSpec with ResolverSupport with JsonErrorValidators {
 
-  case class TestDataObject(field1: String, field2: String, oneOf1: Option[String] = None, oneOf2: Option[String] = None)
-  case class TestDataWrapper(arrayField: Seq[TestDataObject])
-
-  implicit val testDataObjectFormat: OFormat[TestDataObject]   = Json.format[TestDataObject]
-  implicit val testDataWrapperFormat: OFormat[TestDataWrapper] = Json.format[TestDataWrapper]
+  case class Bar(field1: String, field2: String)
+  case class Baz(field1: Option[String], field2: Option[String])
+  case class Qux(mandatory: String, oneOf1: Option[String] = None, oneOf2: Option[String] = None)
 
   // at least one of oneOf1 and oneOf2 must be included:
-  implicit val emptinessChecker: EmptinessChecker[TestDataObject] = EmptinessChecker.use { o =>
+  implicit val emptinessChecker: EmptinessChecker[Qux] = EmptinessChecker.use { o =>
     "oneOf1" -> o.oneOf1 :: "oneOf2" -> o.oneOf2 :: HNil
   }
 
-  private val resolveTestDataObject = new ResolveNonEmptyJsonObject[TestDataObject]()
+  case class Foo(bar: Bar, bars: Option[Seq[Bar]] = None, baz: Option[Baz] = None, qux: Option[Qux] = None)
 
-  private val resolveTestDataWrapper = new ResolveNonEmptyJsonObject[TestDataWrapper]()
+  implicit val barFormat: Reads[Bar] = Json.reads
+  implicit val bazFormat: Reads[Baz] = Json.reads
+  implicit val quxFormat: Reads[Qux] = Json.reads
+  implicit val fooReads: Reads[Foo]  = Json.reads
 
-  "ResolveNonEmptyJsonObject" should {
-    "return the object" when {
+  private def jsonObjectResolver(resolver: Resolver[JsValue, Foo]): Unit = {
+    "return the parsed object" when {
       "given a valid JSON object" in {
-        withClue("Uses the implicit emptinessChecker from above, which requires oneOf1 and oneOf2") {
-          val json   = Json.parse("""{ "field1" : "Something", "field2" : "SomethingElse", "oneOf1": "another1", "oneOf2": "another2" }""")
-          val result = resolveTestDataObject(json)
-          result shouldBe Valid(TestDataObject("Something", "SomethingElse", Some("another1"), Some("another2")))
-        }
+        val json = Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two" }}""")
+
+        resolver(json) shouldBe Valid(Foo(bar = Bar("field one", "field two")))
       }
     }
 
-    "return an error" when {
-      "given a JSON object with a missing required field" in {
-        val json = Json.parse("""{ "field1" : "Something" }""")
+    "return the expected error " when {
+      "a required field is missing" in {
+        val json = Json.parse("""{ "bar": {"field1" : "field one" } }""")
 
-        val result = resolveTestDataObject(json)
-        result shouldBe Invalid(
-          List(
-            RuleIncorrectOrEmptyBodyError.withPath("/field2")
-          ))
+        resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/bar/field2")))
+      }
+    }
+  }
+
+  private def jsonObjectResolverWithEmptinessChecking(resolver: Resolver[JsValue, Foo]): Unit = {
+
+    "given an empty JSON object at the top level" in {
+      resolver(JsObject.empty) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError))
+    }
+
+    "detect empty objects" in {
+      val json = Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two" }, "baz": {} }""")
+
+      resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/baz")))
+    }
+
+    "detect empty arrays" in {
+      val json = Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two" }, "bars": [] }""")
+
+      resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/bars")))
+    }
+
+    "allow custom emptiness checker requiring at least one of a number of optional fields" when {
+      "one of the optional fields is present" must {
+        "return the object" in {
+          val json = Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two" }, "qux": { "mandatory": "m", "oneOf1": "a1" } }""")
+
+          resolver(json) shouldBe Valid(Foo(bar = Bar("field one", "field two"), qux = Some(Qux("m", oneOf1 = Some("a1")))))
+        }
       }
 
-      "given a JSON object with a missing required field in an array object" in {
-        val json = Json.parse("""{ "arrayField" : [{ "field1" : "Something" }]}""")
+      "none of the required optional fields is present" must {
+        "detect this" in {
+          val json = Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two" }, "qux": { "mandatory": "m" } }""")
 
-        val result = resolveTestDataWrapper(json)
-        result shouldBe Invalid(
-          List(
-            RuleIncorrectOrEmptyBodyError.withPath("/arrayField/0/field2")
-          ))
+          resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/qux")))
+        }
+      }
+    }
+  }
+
+  "ResolveNonEmptyJsonObject" when {
+
+    "the default resolver is used" must {
+      val resolver = ResolveNonEmptyJsonObject.resolver[Foo]
+
+      behave like jsonObjectResolver(resolver)
+      behave like jsonObjectResolverWithEmptinessChecking(resolver)
+
+      "not detect extra fields in the input" in {
+        val json = Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two", "extra": "x" }}""")
+
+        resolver(json) shouldBe Valid(Foo(bar = Bar("field one", "field two")))
+      }
+    }
+
+    "the strict resolver is used" must {
+      val resolver = ResolveNonEmptyJsonObject.strictResolver[Foo]
+
+      behave like jsonObjectResolver(resolver)
+      behave like jsonObjectResolverWithEmptinessChecking(resolver)
+
+      "detect extra fields in the input" in {
+        val json = Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two", "extra": "x" }}""")
+
+        resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/bar/extra")))
       }
 
-      "given a JSON object with a missing required field in multiple array objects" in {
-        val json = Json.parse("""
-          |{
-          |  "arrayField" : [
-          |    { "field1" : "Something" },
-          |    { "field1" : "Something" }
-          |  ]
-          |}
-          |""".stripMargin)
+      "detect extra fields first (when object would otherwise be detected as empty)" in {
+        val json = Json.parse("""{ "bar": {"field1" : "field one", "field2" : "field two" }, "baz": { "extra": "x" } }""")
 
-        val result = resolveTestDataWrapper(json)
-        result shouldBe Invalid(
-          List(
-            RuleIncorrectOrEmptyBodyError.withPaths(
-              List(
-                "/arrayField/0/field2",
-                "/arrayField/1/field2"
-              ))
-          ))
-      }
-
-      "given an empty JSON object" in {
-        val json = Json.parse("""{}""")
-
-        val result = resolveTestDataObject(json)
-        result shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError))
-      }
-
-      "given a non-empty JSON object without any expected fields" in {
-        val json = Json.parse("""{"field": "value"}""")
-
-        val result = resolveTestDataObject(json)
-        result shouldBe Invalid(
-          List(
-            RuleIncorrectOrEmptyBodyError.withPaths(List("/field1", "/field2"))
-          ))
-      }
-
-      "given a field with the wrong data type" in {
-        val json = Json.parse("""{"field1": true, "field2": "value"}""")
-
-        val result = resolveTestDataObject(json)
-        result shouldBe Invalid(
-          List(
-            RuleIncorrectOrEmptyBodyError.withPath("/field1")
-          ))
-      }
-
-      "detect empty objects" in {
-        val json = Json.parse("""{ "field1" : "Something", "field2" : "SomethingElse" }""")
-
-        val result = resolveTestDataObject(json)
-        result shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError))
-      }
-
-      "detect empty arrays" in {
-        val json   = Json.parse("""{ "arrayField": [] }""")
-        val result = resolveTestDataWrapper(json)
-
-        result shouldBe Invalid(
-          List(
-            RuleIncorrectOrEmptyBodyError.withPath("/arrayField")
-          ))
-      }
-
-      "return no error when all objects are non-empty" in {
-        val json = Json.parse("""{ "field1" : "Something", "field2" : "SomethingElse", "oneOf1": "another1" }""")
-
-        val result = resolveTestDataObject(json)
-        result shouldBe Valid(
-          TestDataObject("Something", "SomethingElse", Some("another1"))
-        )
+        resolver(json) shouldBe Invalid(List(RuleIncorrectOrEmptyBodyError.withPath("/baz/extra")))
       }
     }
   }

--- a/test/shared/controllers/validators/resolvers/UnexpectedJsonFieldsValidatorSpec.scala
+++ b/test/shared/controllers/validators/resolvers/UnexpectedJsonFieldsValidatorSpec.scala
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shared.controllers.validators.resolvers
+
+import play.api.libs.json.{JsObject, Json}
+import shared.controllers.validators.resolvers.UnexpectedJsonFieldsValidator.SchemaStructureSource
+import shared.models.errors.RuleIncorrectOrEmptyBodyError
+import shared.utils.UnitSpec
+
+class UnexpectedJsonFieldsValidatorSpec extends UnitSpec {
+
+  sealed trait SomeEnum
+
+  object SumEnum {
+    object X extends SomeEnum
+    object Y extends SomeEnum
+  }
+
+  case class Bar(a: Option[String] = None, b: Option[String] = None, e: Option[SomeEnum] = None)
+
+  case class Foo(bar: Bar, bars: Option[Seq[Bar]] = None, bar2: Option[Bar] = None)
+
+  implicit val someEnumChecker: SchemaStructureSource[SomeEnum] = SchemaStructureSource.leaf
+
+  val validator = new UnexpectedJsonFieldsValidator[Foo]
+
+  private def errorWithPaths(paths: String*) = Some(Seq(RuleIncorrectOrEmptyBodyError.withPaths(paths)))
+
+  "UnexpectedJsonFieldsValidator" when {
+    "there are no extra fields" must {
+      "validate successfully" in {
+        val json = Json.parse("""{ "bar": {"a" : "v1", "b" : "v2" }, "bars": []}""").as[JsObject]
+        val data = Foo(bar = Bar(Some("v1"), Some("v2")), Some(Nil))
+
+        validator.validator((json, data)) shouldBe None
+      }
+
+      "validate successfully when object fields are in a different order" in {
+        val json = Json.parse("""{ "bars": [], "bar2": {"b" : "v2" }, "bar": {"a" : "v1" }}""").as[JsObject]
+        val data = Foo(bar = Bar(Some("v1"), None), Some(Nil), bar2 = Some(Bar(None, Some("v2"))))
+
+        validator.validator((json, data)) shouldBe None
+      }
+    }
+
+    "optional fields are missing" must {
+      "validate successfully" in {
+        val json = Json.parse("""{ "bar": {"a" : "v1", "b" : "v2" }}""").as[JsObject]
+        val data = Foo(bar = Bar(Some("v1"), Some("v2")))
+
+        validator.validator((json, data)) shouldBe None
+      }
+    }
+
+    "an additional field is present" when {
+      "a top level extra field is present" when {
+        def bazWithValue(bazValue: String) =
+          Json
+            .parse(s"""{ "baz": $bazValue, "bar": {"a" : "v1",  "b" : "v2" }}""".stripMargin)
+            .as[JsObject]
+
+        val data = Foo(bar = Bar(Some("v1"), Some("v2")), bars = None)
+
+        "the field is a string" must {
+          "return an error with path to the extra field" in {
+            validator.validator((bazWithValue(""""extra""""), data)) shouldBe errorWithPaths("/baz")
+          }
+        }
+
+        "the field is a number" must {
+          "return an error with path to the extra field" in {
+            validator.validator((bazWithValue("123"), data)) shouldBe errorWithPaths("/baz")
+          }
+        }
+
+        "the field is a boolean" must {
+          "return an error with path to the extra field" in {
+            validator.validator((bazWithValue("true"), data)) shouldBe errorWithPaths("/baz")
+          }
+        }
+
+        "the field is a object" must {
+          "return an error with path to the extra field" in {
+            validator.validator((bazWithValue("""{"bazField": "value"}"""), data)) shouldBe errorWithPaths("/baz")
+          }
+        }
+
+        "the field is a array" must {
+          "return an error with path to the extra field" in {
+            validator.validator((bazWithValue("""["value"]"""), data)) shouldBe errorWithPaths("/baz")
+          }
+        }
+      }
+
+      "locate extra fields when object fields are in a different order" in {
+        val json = Json.parse("""{ "bar2": {"b" : "v2", "baz": 123 }, "bar": {"a" : "v1" }}""").as[JsObject]
+        val data = Foo(bar = Bar(Some("v1"), None), bar2 = Some(Bar(None, Some("v2"))))
+
+        validator.validator((json, data)) shouldBe errorWithPaths("/bar2/baz")
+      }
+
+      "a nested extra field is present" when {
+        val data = Foo(bar = Bar(Some("v1"), Some("v2")), bars = Some(Seq(Bar(Some("v1"), Some("v2")), Bar(Some("v1"), Some("v2")))))
+
+        "the field is nested in an object" must {
+          "return an error with path to the extra field" in {
+            val json = Json
+              .parse("""{ "bar": {"a" : "v1", "baz": "extra", "b" : "v2" }, 
+                   |  "bars": [
+                   |    {"a" : "v1",  "b" : "v2" }, 
+                   |    {"a" : "v1", "b" : "v2" }
+                   |  ]
+                   |}""".stripMargin)
+              .as[JsObject]
+
+            validator.validator((json, data)) shouldBe errorWithPaths("/bar/baz")
+          }
+        }
+
+        "the field is nested in an object in an array" must {
+          "return an error with path to the extra field" in {
+            val json = Json
+              .parse("""{
+                   |  "bar": {"a" : "v1", "b" : "v2" },
+                   |  "bars": [
+                   |    {"a" : "v1",  "b" : "v2" }, 
+                   |    {"a" : "v1", "baz": "extra", "b" : "v2" }
+                   |  ]
+                   |}""".stripMargin)
+              .as[JsObject]
+
+            validator.validator((json, data)) shouldBe errorWithPaths("/bars/1/baz")
+          }
+        }
+
+        "multiple additional fields are present" must {
+          "return an error with paths to the extra fields" in {
+            val json = Json
+              .parse("""{
+                 |  "bar": {"a" : "v1", "b" : "v2" , "baz": "extra"},
+                 |  "baz": "extra",
+                 |  "bars": [
+                 |    {"a" : "v1", "baz": "extra0", "b" : "v2" }, 
+                 |    {"a" : "v1", "baz": "extra1", "b" : "v2" }
+                 |  ]
+                 |}""".stripMargin)
+              .as[JsObject]
+
+            validator.validator((json, data)) shouldBe errorWithPaths("/baz", "/bar/baz", "/bars/0/baz", "/bars/1/baz")
+          }
+        }
+
+        // A robustness check that the implementation does not rely on the fields that _should_ be present or their values:
+        "mandatory values in the input JSON are missing or have different values from the data" must {
+          "ignore these and only flag up extra fields" in {
+            val json = Json
+              .parse("""{
+                       |  "bar": {"a" : "wrongValueIgnored", "baz": "extra"},
+                       |  "baz": "extra",
+                       |  "bars": [
+                       |    { "baz": "extra0" },
+                       |    { "baz": "extra1" }
+                       |  ]
+                       |}""".stripMargin)
+              .as[JsObject]
+
+            validator.validator((json, data)) shouldBe errorWithPaths("/baz", "/bar/baz", "/bars/0/baz", "/bars/1/baz")
+          }
+        }
+
+        // In case we need to use a sealed trait to represent 'one of' options for a field
+        "must be able to work with co-product types (field of type A is actually A1 or A2 etc)" when {
+          sealed trait A
+          case class A1(a1: Int) extends A
+          case class A2(a2: Int) extends A
+          case class Foo2(a: A)
+
+          val dataA1 = Foo2(A1(1))
+
+          val extraPathCheckerA1 = SchemaStructureSource[A1]
+          val extraPathCheckerA2 = SchemaStructureSource[A2]
+
+          implicit val extraPathCheckerA: SchemaStructureSource[A] = SchemaStructureSource.instance {
+            case a1: A1 => extraPathCheckerA1.schemaStructureOf(a1)
+            case a2: A2 => extraPathCheckerA2.schemaStructureOf(a2)
+          }
+
+          val validator = new UnexpectedJsonFieldsValidator[Foo2]
+
+          "correct fields are present" in {
+            val json = Json.parse("""{ "a": { "a1": 1} }""").as[JsObject]
+
+            validator.validator((json, dataA1)) shouldBe None
+          }
+
+          "extra fields are present" in {
+            val json = Json.parse("""{ "a": { "a1": 1, "extra": 123 } }""").as[JsObject]
+
+            validator.validator((json, dataA1)) shouldBe errorWithPaths("/a/extra")
+          }
+
+          // (This is likely to be a coding error in the JSON Reads)
+          "the other type's fields are present" in {
+            val json = Json.parse("""{ "a": { "a2": 2} }""").as[JsObject]
+
+            validator.validator((json, dataA1)) shouldBe errorWithPaths("/a/a2")
+          }
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
- create ResolveJsonObjectInternal based on ResolveJsonObject and beef up tests
- create UnexpectedJsonFieldsValidator tests
- create UnexpectedJsonFieldsValidator implementation using Option B (Shapeless auto-generated custom type class to represent the schema structure)
- add logging similar to existing logging to emptiness check and unexpected fields validations.
- update ResolveJsonObjectSpec and ResolveNonEmptyJsonObjectSpec
- incorporate the validation in a `strictResolver` factory methods (with or without emptiness checking).