### PR TITLE
MTDSA-25661 - remove default schemas (v6)

### DIFF
--- a/app/shared/controllers/validators/AlwaysErrorsValidator.scala
+++ b/app/shared/controllers/validators/AlwaysErrorsValidator.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shared.controllers.validators
+
+import cats.data.Validated
+import cats.data.Validated.Invalid
+import shared.models.errors.MtdError
+
+case class AlwaysErrorsValidator(errors: Seq[MtdError]) extends Validator[Nothing] {
+  override def validate: Validated[Seq[MtdError], Nothing] = Invalid(errors)
+}

--- a/app/shared/controllers/validators/Validator.scala
+++ b/app/shared/controllers/validators/Validator.scala
@@ -22,7 +22,7 @@ import cats.data.Validated.{Invalid, Valid}
 import shared.utils.Logging
 import cats.implicits._
 
-trait Validator[PARSED] extends Logging {
+trait Validator[+PARSED] extends Logging {
 
   def validate: Validated[Seq[MtdError], PARSED]
 
@@ -69,5 +69,10 @@ trait Validator[PARSED] extends Logging {
       .toList
       .sortBy(_.code)
   }
+
+}
+
+object Validator {
+  def returningErrors(errors: Seq[MtdError]): Validator[Nothing] = AlwaysErrorsValidator(errors)
 
 }

--- a/app/v6/bsas/list/ListBsasSchema.scala
+++ b/app/v6/bsas/list/ListBsasSchema.scala
@@ -16,14 +16,18 @@
 
 package v6.bsas.list
 
+import cats.data.Validated
+import cats.data.Validated.Valid
 import play.api.libs.json.Reads
 import shared.controllers.validators.resolvers.ResolveTaxYear
 import shared.models.domain.TaxYear
+import shared.models.errors.MtdError
 import shared.schema.DownstreamReadable
 import v6.bsas.list.def1.model.response.Def1_ListBsasResponse
 import v6.bsas.list.def2.model.response.Def2_ListBsasResponse
 import v6.bsas.list.model.response.ListBsasResponse
 
+import java.time.Clock
 import scala.math.Ordered.orderingToOrdered
 
 sealed trait ListBsasSchema extends DownstreamReadable[ListBsasResponse]
@@ -40,15 +44,14 @@ object ListBsasSchema {
     val connectorReads: Reads[DownstreamResp] = Def2_ListBsasResponse.reads
   }
 
-  def schemaFor(maybeTaxYear: Option[String]): ListBsasSchema = {
-    maybeTaxYear
-      .map(ResolveTaxYear.resolver)
-      .flatMap(_.toOption.map(schemaFor))
-      .getOrElse(schemaFor(TaxYear.currentTaxYear))
-  }
+  def schemaFor(maybeTaxYear: Option[String])(implicit clock: Clock = Clock.systemUTC): Validated[Seq[MtdError], ListBsasSchema] =
+    maybeTaxYear match {
+      case Some(taxYearString) => ResolveTaxYear(taxYearString).map(schemaFor)
+      case None                => Valid(schemaFor(TaxYear.currentTaxYear))
+    }
 
   def schemaFor(taxYear: TaxYear): ListBsasSchema = {
-    if (taxYear < TaxYear.fromMtd("2025-26")) {
+    if (taxYear <= TaxYear.fromMtd("2024-25")) {
       Def1
     } else {
       Def2

--- a/app/v6/bsas/list/ListBsasValidatorFactory.scala
+++ b/app/v6/bsas/list/ListBsasValidatorFactory.scala
@@ -16,10 +16,12 @@
 
 package v6.bsas.list
 
+import cats.data.Validated.{Invalid, Valid}
 import shared.controllers.validators.Validator
 import v6.bsas.list.def1.Def1_ListBsasValidator
 import v6.bsas.list.def2.Def2_ListBsasValidator
 import v6.bsas.list.model.request.ListBsasRequestData
+import ListBsasSchema._
 
 import javax.inject.Singleton
 
@@ -33,11 +35,10 @@ class ListBsasValidatorFactory {
       businessId: Option[String]
   ): Validator[ListBsasRequestData] = {
 
-    val schema = ListBsasSchema.schemaFor(taxYear)
-
-    schema match {
-      case ListBsasSchema.Def1 => new Def1_ListBsasValidator(nino, taxYear, typeOfBusiness, businessId)
-      case ListBsasSchema.Def2 => new Def2_ListBsasValidator(nino, taxYear, typeOfBusiness, businessId)
+    ListBsasSchema.schemaFor(taxYear) match {
+      case Valid(Def1)     => new Def1_ListBsasValidator(nino, taxYear, typeOfBusiness, businessId)
+      case Valid(Def2)     => new Def2_ListBsasValidator(nino, taxYear, typeOfBusiness, businessId)
+      case Invalid(errors) => Validator.returningErrors(errors)
     }
   }
 

--- a/app/v6/bsas/trigger/TriggerBsasValidatorFactory.scala
+++ b/app/v6/bsas/trigger/TriggerBsasValidatorFactory.scala
@@ -16,6 +16,7 @@
 
 package v6.bsas.trigger
 
+import cats.data.Validated.{Invalid, Valid}
 import config.BsasConfig
 import play.api.libs.json.JsValue
 import shared.controllers.validators.Validator
@@ -31,11 +32,10 @@ class TriggerBsasValidatorFactory @Inject() (implicit bsasConfig: BsasConfig) {
 
   def validator(nino: String, body: JsValue): Validator[TriggerBsasRequestData] = {
 
-    val schema = TriggerSchema.schemaFor(body)
-
-    schema match {
-      case Def1 => new Def1_TriggerBsasValidator(nino, body)
-      case Def2 => new Def2_TriggerBsasValidator(nino, body)
+    TriggerSchema.schemaFor(body) match {
+      case Valid(Def1)     => new Def1_TriggerBsasValidator(nino, body)
+      case Valid(Def2)     => new Def2_TriggerBsasValidator(nino, body)
+      case Invalid(errors) => Validator.returningErrors(errors)
     }
   }
 

--- a/app/v6/bsas/trigger/TriggerSchema.scala
+++ b/app/v6/bsas/trigger/TriggerSchema.scala
@@ -16,14 +16,17 @@
 
 package v6.bsas.trigger
 
+import cats.data.Validated
+import cats.data.Validated.Invalid
 import play.api.libs.json.{JsValue, Reads}
+import shared.controllers.validators.resolvers.ResolveIsoDate
 import shared.models.domain.TaxYear
+import shared.models.errors.{EndDateFormatError, MtdError, RuleIncorrectOrEmptyBodyError}
 import shared.schema.DownstreamReadable
 import v6.bsas.trigger.def1.model.response.Def1_TriggerBsasResponse
 import v6.bsas.trigger.def2.model.response.Def2_TriggerBsasResponse
 import v6.bsas.trigger.model.TriggerBsasResponse
 
-import java.time.LocalDate
 import scala.math.Ordered.orderingToOrdered
 
 sealed trait TriggerSchema extends DownstreamReadable[TriggerBsasResponse]
@@ -40,14 +43,14 @@ object TriggerSchema {
     val connectorReads: Reads[DownstreamResp] = Def2_TriggerBsasResponse.reads
   }
 
-  private val defaultSchema = Def1
+  def schemaFor(request: JsValue): Validated[Seq[MtdError], TriggerSchema] = {
+    val maybeDateString = (request \ "accountingPeriod" \ "endDate").asOpt[String]
 
-  def schemaFor(request: JsValue): TriggerSchema =
-    (request \ "accountingPeriod" \ "endDate")
-      .asOpt[LocalDate]
-      .map(TaxYear.containing)
-      .map(schemaFor)
-      .getOrElse(defaultSchema)
+    maybeDateString match {
+      case None             => Invalid(Seq(RuleIncorrectOrEmptyBodyError.withPath("/accountingPeriod/endDate")))
+      case Some(dateString) => ResolveIsoDate(EndDateFormatError)(dateString).map(date => schemaFor(TaxYear.containing(date)))
+    }
+  }
 
   def schemaFor(taxYear: TaxYear): TriggerSchema = {
     if (taxYear <= TaxYear.starting(2024)) Def1

--- a/app/v6/foreignPropertyBsas/retrieve/RetrieveForeignPropertyBsasValidatorFactory.scala
+++ b/app/v6/foreignPropertyBsas/retrieve/RetrieveForeignPropertyBsasValidatorFactory.scala
@@ -16,6 +16,7 @@
 
 package v6.foreignPropertyBsas.retrieve
 
+import cats.data.Validated.{Invalid, Valid}
 import shared.controllers.validators.Validator
 import v6.foreignPropertyBsas.retrieve.RetrieveForeignPropertyBsasSchema._
 import v6.foreignPropertyBsas.retrieve.def1.Def1_RetrieveForeignPropertyBsasValidator
@@ -33,11 +34,10 @@ class RetrieveForeignPropertyBsasValidatorFactory {
       taxYear: Option[String]
   ): Validator[RetrieveForeignPropertyBsasRequestData] = {
 
-    val schema = RetrieveForeignPropertyBsasSchema.schemaFor(taxYear)
-
-    schema match {
-      case Def1 => new Def1_RetrieveForeignPropertyBsasValidator(nino, calculationId, taxYear)
-      case Def2 => new Def2_RetrieveForeignPropertyBsasValidator(nino, calculationId, taxYear)
+    RetrieveForeignPropertyBsasSchema.schemaFor(taxYear) match {
+      case Valid(Def1)     => new Def1_RetrieveForeignPropertyBsasValidator(nino, calculationId, taxYear)
+      case Valid(Def2)     => new Def2_RetrieveForeignPropertyBsasValidator(nino, calculationId, taxYear)
+      case Invalid(errors) => Validator.returningErrors(errors)
     }
   }
 

--- a/app/v6/foreignPropertyBsas/submit/SubmitForeignPropertyBsasSchema.scala
+++ b/app/v6/foreignPropertyBsas/submit/SubmitForeignPropertyBsasSchema.scala
@@ -16,8 +16,11 @@
 
 package v6.foreignPropertyBsas.submit
 
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
 import shared.controllers.validators.resolvers.ResolveTaxYear
 import shared.models.domain.TaxYear
+import shared.models.errors.{InvalidTaxYearParameterError, MtdError}
 
 import scala.math.Ordered.orderingToOrdered
 
@@ -29,19 +32,19 @@ object SubmitForeignPropertyBsasSchema {
   case object Def2 extends SubmitForeignPropertyBsasSchema
   case object Def3 extends SubmitForeignPropertyBsasSchema
 
-  private val defaultSchema = Def1
+  private val preTysSchema = Def1
 
-  def schemaFor(maybeTaxYear: Option[String]): SubmitForeignPropertyBsasSchema = {
-    maybeTaxYear
-      .map(ResolveTaxYear.resolver)
-      .flatMap(_.toOption.map(schemaFor))
-      .getOrElse(defaultSchema)
-  }
+  def schemaFor(maybeTaxYear: Option[String]): Validated[Seq[MtdError], SubmitForeignPropertyBsasSchema] =
+    maybeTaxYear match {
+      case Some(taxYearString) => ResolveTaxYear(taxYearString) andThen schemaFor
+      case None                => Valid(preTysSchema)
+    }
 
-  def schemaFor(taxYear: TaxYear): SubmitForeignPropertyBsasSchema = {
-    if (taxYear <= TaxYear.starting(2023)) Def1
-    else if (taxYear == TaxYear.starting(2024)) Def2
-    else Def3
+  def schemaFor(taxYear: TaxYear): Validated[Seq[MtdError], SubmitForeignPropertyBsasSchema] = {
+    if (taxYear < TaxYear.tysTaxYear) Invalid(Seq(InvalidTaxYearParameterError))
+    else if (taxYear == TaxYear.starting(2023)) Valid(Def1)
+    else if (taxYear == TaxYear.starting(2024)) Valid(Def2)
+    else Valid(Def3)
   }
 
 }

--- a/app/v6/foreignPropertyBsas/submit/SubmitForeignPropertyBsasValidatorFactory.scala
+++ b/app/v6/foreignPropertyBsas/submit/SubmitForeignPropertyBsasValidatorFactory.scala
@@ -16,6 +16,7 @@
 
 package v6.foreignPropertyBsas.submit
 
+import cats.data.Validated.{Invalid, Valid}
 import play.api.libs.json.JsValue
 import shared.controllers.validators.Validator
 import v6.foreignPropertyBsas.submit.SubmitForeignPropertyBsasSchema._
@@ -36,12 +37,11 @@ class SubmitForeignPropertyBsasValidatorFactory {
       body: JsValue
   ): Validator[SubmitForeignPropertyBsasRequestData] = {
 
-    val schema = SubmitForeignPropertyBsasSchema.schemaFor(taxYear)
-
-    schema match {
-      case Def1 => new Def1_SubmitForeignPropertyBsasValidator(nino, calculationId, taxYear, body)
-      case Def2 => new Def2_SubmitForeignPropertyBsasValidator(nino, calculationId, taxYear, body)
-      case Def3 => new Def3_SubmitForeignPropertyBsasValidator(nino, calculationId, taxYear, body)
+    SubmitForeignPropertyBsasSchema.schemaFor(taxYear) match {
+      case Valid(Def1)     => new Def1_SubmitForeignPropertyBsasValidator(nino, calculationId, taxYear, body)
+      case Valid(Def2)     => new Def2_SubmitForeignPropertyBsasValidator(nino, calculationId, taxYear, body)
+      case Valid(Def3)     => new Def3_SubmitForeignPropertyBsasValidator(nino, calculationId, taxYear, body)
+      case Invalid(errors) => Validator.returningErrors(errors)
     }
 
   }

--- a/app/v6/ukPropertyBsas/retrieve/RetrieveUkPropertyBsasValidatorFactory.scala
+++ b/app/v6/ukPropertyBsas/retrieve/RetrieveUkPropertyBsasValidatorFactory.scala
@@ -16,6 +16,7 @@
 
 package v6.ukPropertyBsas.retrieve
 
+import cats.data.Validated.{Invalid, Valid}
 import shared.controllers.validators.Validator
 import v6.ukPropertyBsas.retrieve.RetrieveUkPropertyBsasSchema.{Def1, Def2}
 import v6.ukPropertyBsas.retrieve.def1.Def1_RetrieveUkPropertyBsasValidator
@@ -33,11 +34,10 @@ class RetrieveUkPropertyBsasValidatorFactory {
       taxYear: Option[String]
   ): Validator[RetrieveUkPropertyBsasRequestData] = {
 
-    val schema = RetrieveUkPropertyBsasSchema.schemaFor(taxYear)
-
-    schema match {
-      case Def1 => new Def1_RetrieveUkPropertyBsasValidator(nino, calculationId, taxYear)
-      case Def2 => new Def2_RetrieveUkPropertyBsasValidator(nino, calculationId, taxYear)
+    RetrieveUkPropertyBsasSchema.schemaFor(taxYear) match {
+      case Valid(Def1)     => new Def1_RetrieveUkPropertyBsasValidator(nino, calculationId, taxYear)
+      case Valid(Def2)     => new Def2_RetrieveUkPropertyBsasValidator(nino, calculationId, taxYear)
+      case Invalid(errors) => Validator.returningErrors(errors)
     }
   }
 

--- a/app/v6/ukPropertyBsas/submit/SubmitUkPropertyBsasValidatorFactory.scala
+++ b/app/v6/ukPropertyBsas/submit/SubmitUkPropertyBsasValidatorFactory.scala
@@ -16,6 +16,7 @@
 
 package v6.ukPropertyBsas.submit
 
+import cats.data.Validated.{Invalid, Valid}
 import play.api.libs.json.JsValue
 import shared.controllers.validators.Validator
 import v6.ukPropertyBsas.submit.SubmitUkPropertyBsasSchema._
@@ -36,14 +37,13 @@ class SubmitUkPropertyBsasValidatorFactory {
       body: JsValue
   ): Validator[SubmitUkPropertyBsasRequestData] = {
 
-    val schema = SubmitUkPropertyBsasSchema.schemaFor(taxYear)
-
-    schema match {
-      case Def1 => new Def1_SubmitUkPropertyBsasValidator(nino, calculationId, taxYear, body)
-      case Def2 => new Def2_SubmitUkPropertyBsasValidator(nino, calculationId, taxYear, body)
-      case Def3 => new Def3_SubmitUkPropertyBsasValidator(nino, calculationId, taxYear, body)
-
+    SubmitUkPropertyBsasSchema.schemaFor(taxYear) match {
+      case Valid(Def1)     => new Def1_SubmitUkPropertyBsasValidator(nino, calculationId, taxYear, body)
+      case Valid(Def2)     => new Def2_SubmitUkPropertyBsasValidator(nino, calculationId, taxYear, body)
+      case Valid(Def3)     => new Def3_SubmitUkPropertyBsasValidator(nino, calculationId, taxYear, body)
+      case Invalid(errors) => Validator.returningErrors(errors)
     }
+
   }
 
 }

--- a/it/v6/bsas/trigger/def1/Def1_TriggerBsasISpec.scala
+++ b/it/v6/bsas/trigger/def1/Def1_TriggerBsasISpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v6.bsas.trigger.def2
+package v6.bsas.trigger.def1
 
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import common.errors._
@@ -26,18 +26,36 @@ import play.api.test.Helpers.AUTHORIZATION
 import shared.models.errors._
 import shared.services.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
 import support.IntegrationBaseSpec
-import v6.bsas.trigger.def2.model.Def2_TriggerBsasFixtures._
+import v6.bsas.trigger.def1.model.Def1_TriggerBsasFixtures._
 
-class Def2_TriggerBsasISpec extends IntegrationBaseSpec {
+class Def1_TriggerBsasISpec extends IntegrationBaseSpec {
 
   "Calling the triggerBsas" should {
     "return a 200 status code" when {
 
       List(
         "self-employment",
-        "uk-property",
+        "uk-property-fhl",
+        "uk-property-non-fhl",
+        "foreign-property-fhl-eea",
         "foreign-property"
       ).foreach { typeOfBusiness =>
+        s"any valid request is made with typeOfBusiness: $typeOfBusiness" in new NonTysTest {
+
+          override def setupStubs(): StubMapping = {
+            AuditStub.audit()
+            AuthStub.authorised()
+            MtdIdLookupStub.ninoFound(nino)
+
+            DownstreamStub.onSuccess(DownstreamStub.POST, downstreamUri, OK, Json.parse(downstreamResponse))
+          }
+
+          val result: WSResponse = await(request().post(requestBody(typeOfBusiness)))
+          result.status shouldBe OK
+          result.json shouldBe Json.parse(responseBody)
+          result.header("Content-Type") shouldBe Some("application/json")
+        }
+
         s"any valid request is made with typeOfBusiness: $typeOfBusiness (TYS)" in new TysIfsTest {
 
           override def setupStubs(): StubMapping = {
@@ -58,7 +76,7 @@ class Def2_TriggerBsasISpec extends IntegrationBaseSpec {
     "return error according to spec" when {
       "validation error" when {
         def validationErrorTest(requestNino: String, json: JsObject, expectedStatus: Int, expectedBody: MtdError): Unit = {
-          s"validation fails with ${expectedBody.code} error" in new TysIfsTest {
+          s"validation fails with ${expectedBody.code} error" in new NonTysTest {
 
             override val nino: String = requestNino
 
@@ -74,7 +92,7 @@ class Def2_TriggerBsasISpec extends IntegrationBaseSpec {
           }
         }
 
-        import RequestBodyHelper._
+        import NonTysRequestBodyHelper._
 
         val input = List(
           ("AA1123A", requestBody(), BAD_REQUEST, NinoFormatError),
@@ -92,14 +110,16 @@ class Def2_TriggerBsasISpec extends IntegrationBaseSpec {
           ("AA123456A", requestBody(endDate = "20190506"), BAD_REQUEST, EndDateFormatError),
           ("AA123456A", requestBody(typeOfBusiness = "badTypeOfBusiness"), BAD_REQUEST, TypeOfBusinessFormatError),
           ("AA123456A", requestBody(businessId = "badBusinessId"), BAD_REQUEST, BusinessIdFormatError),
-          ("AA123456A", requestBody(startDate = "2080-02-02", endDate = defaultEndDate), BAD_REQUEST, RuleEndBeforeStartDateError)
+          ("AA123456A", requestBody(startDate = "2080-02-02", endDate = defaultEndDate), BAD_REQUEST, RuleEndBeforeStartDateError),
+          ("AA123456A", requestBody(startDate = "2018-02-02", endDate = "2018-05-06"), BAD_REQUEST, RuleAccountingPeriodNotSupportedError)
         )
+
         input.foreach(args => (validationErrorTest _).tupled(args))
       }
 
       "downstream service error" when {
         def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new TysIfsTest {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
 
             override def setupStubs(): StubMapping = {
               AuditStub.audit()
@@ -143,9 +163,9 @@ class Def2_TriggerBsasISpec extends IntegrationBaseSpec {
 
     val defaultBusinessId = "XAIS12345678901"
 
-    val defaultStartDate = "2025-04-06"
+    val defaultStartDate: String
 
-    val defaultEndDate = "2026-04-05"
+    val defaultEndDate: String
 
     def requestBody(typeOfBusiness: String = defaultTypeOfBusiness,
                     startDate: String = defaultStartDate,
@@ -160,7 +180,20 @@ class Def2_TriggerBsasISpec extends IntegrationBaseSpec {
 
   }
 
-  object RequestBodyHelper extends RequestBodyHelper
+  trait NonTysRequestBodyHelper extends RequestBodyHelper {
+    val defaultStartDate = "2021-04-06"
+
+    val defaultEndDate = "2022-04-05"
+  }
+
+  object NonTysRequestBodyHelper extends NonTysRequestBodyHelper
+
+  trait TysRequestBodyHelper extends RequestBodyHelper {
+
+    val defaultStartDate = "2023-04-06"
+
+    val defaultEndDate = "2024-04-05"
+  }
 
   private trait Test {
     self: RequestBodyHelper =>
@@ -199,9 +232,15 @@ class Def2_TriggerBsasISpec extends IntegrationBaseSpec {
 
   }
 
-  private trait TysIfsTest extends Test with RequestBodyHelper {
+  private trait NonTysTest extends Test with NonTysRequestBodyHelper {
 
-    override def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/25-26/$nino"
+    override def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/$nino"
+
+  }
+
+  private trait TysIfsTest extends Test with TysRequestBodyHelper {
+
+    override def downstreamUri: String = s"/income-tax/adjustable-summary-calculation/23-24/$nino"
 
   }
 

--- a/it/v6/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasISpec.scala
+++ b/it/v6/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasISpec.scala
@@ -87,6 +87,27 @@ class Def3_SubmitForeignPropertyBsasISpec extends IntegrationBaseSpec with JsonE
         val input = List(
           ("Walrus", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", None, mtdRequestForeignPropertyValid, BAD_REQUEST, NinoFormatError),
           ("AA123456A", "BAD_CALC_ID", Some("2025-26"), mtdRequestForeignPropertyValid, BAD_REQUEST, CalculationIdFormatError),
+          (
+            "AA123456A",
+            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
+            Some("2022-23"),
+            mtdRequestForeignPropertyValid,
+            BAD_REQUEST,
+            InvalidTaxYearParameterError),
+          (
+            "AA123456A",
+            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
+            Some("BAD_TAX_YEAR"),
+            mtdRequestForeignPropertyValid,
+            BAD_REQUEST,
+            TaxYearFormatError),
+          (
+            "AA123456A",
+            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
+            Some("2022-24"),
+            mtdRequestForeignPropertyValid,
+            BAD_REQUEST,
+            RuleTaxYearRangeInvalidError),
           ("AA123456A", "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c", None, JsObject.empty, BAD_REQUEST, RuleIncorrectOrEmptyBodyError),
           (
             "AA123456A",

--- a/test/shared/controllers/validators/AlwaysErrorsValidatorSpec.scala
+++ b/test/shared/controllers/validators/AlwaysErrorsValidatorSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shared.controllers.validators
+
+import cats.data.Validated.Invalid
+import play.api.http.Status
+import shared.models.errors.MtdError
+import shared.utils.UnitSpec
+
+class AlwaysErrorsValidatorSpec extends UnitSpec {
+
+  "AlwaysErrorsValidator" must {
+    "always return the errors that it is constructed with" in {
+      val errors = Seq(MtdError("E1", "", Status.BAD_REQUEST), MtdError("E2", "", Status.BAD_REQUEST))
+
+      AlwaysErrorsValidator(errors).validate shouldBe Invalid(errors)
+    }
+  }
+
+}

--- a/test/shared/models/domain/TaxYearTestSupport.scala
+++ b/test/shared/models/domain/TaxYearTestSupport.scala
@@ -1,6 +1,17 @@
 /*
  * Copyright 2024 HM Revenue & Customs
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package shared.models.domain

--- a/test/shared/models/domain/TaxYearTestSupport.scala
+++ b/test/shared/models/domain/TaxYearTestSupport.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ */
+
+package shared.models.domain
+
+import java.time.{Clock, ZoneOffset}
+
+trait TaxYearTestSupport {
+
+  def clockAtTimeInTaxYear(taxYear: TaxYear): Clock =
+    Clock.fixed(taxYear.endDate.atStartOfDay().toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
+
+}

--- a/test/v6/foreignPropertyBsas/retrieve/RetrieveForeignPropertyBsasSchemaSpec.scala
+++ b/test/v6/foreignPropertyBsas/retrieve/RetrieveForeignPropertyBsasSchemaSpec.scala
@@ -16,36 +16,55 @@
 
 package v6.foreignPropertyBsas.retrieve
 
+import cats.data.Validated.{Invalid, Valid}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+import shared.models.errors.{InvalidTaxYearParameterError, RuleTaxYearRangeInvalidError, TaxYearFormatError}
 import shared.utils.UnitSpec
 
 class RetrieveForeignPropertyBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
 
   "schema lookup" when {
     "a tax year is present" must {
-      "use Def2 for tax years from 2025-26" in {
-        forTaxYearsFrom(TaxYear.fromMtd("2025-26")) { taxYear =>
-          RetrieveForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveForeignPropertyBsasSchema.Def2
-        }
-      }
-
-      "use Def1 for pre-TYS tax years" in {
+      "disallow a tax year parameter for pre-TYS tax years and return InvalidTaxYearParameterError" in {
         forPreTysTaxYears { taxYear =>
-          RetrieveForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveForeignPropertyBsasSchema.Def1
+          RetrieveForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Invalid(Seq(InvalidTaxYearParameterError))
         }
       }
-    }
 
-    "the tax year is present but not valid" must {
-      "use a default of Def1" in {
-        RetrieveForeignPropertyBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe RetrieveForeignPropertyBsasSchema.Def1
+      "use Def1 for tax year 2023-24" in {
+        val taxYear = TaxYear.fromMtd("2023-24")
+        RetrieveForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Valid(RetrieveForeignPropertyBsasSchema.Def1)
+      }
+
+      "use Def1 for tax year 2024-25" in {
+        val taxYear = TaxYear.fromMtd("2024-25")
+        RetrieveForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Valid(RetrieveForeignPropertyBsasSchema.Def1)
+      }
+
+      "use Def2 for tax years 2025-26 onwards" in {
+        val taxYear = TaxYear.fromMtd("2025-26")
+        RetrieveForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Valid(RetrieveForeignPropertyBsasSchema.Def2)
       }
     }
 
-    "no tax year is present" must {
-      "use a default of Def1" in {
-        RetrieveForeignPropertyBsasSchema.schemaFor(None) shouldBe RetrieveForeignPropertyBsasSchema.Def1
+    "no tax year is present (pre-TYS case)" must {
+      "use Def1" in {
+        RetrieveForeignPropertyBsasSchema.schemaFor(None) shouldBe Valid(RetrieveForeignPropertyBsasSchema.Def1)
+      }
+    }
+
+    "the tax year is present but not valid" when {
+      "the tax year format is invalid" must {
+        "return a TaxYearFormatError" in {
+          RetrieveForeignPropertyBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe Invalid(Seq(TaxYearFormatError))
+        }
+      }
+
+      "the tax year range is invalid" must {
+        "return a RuleTaxYearRangeInvalidError" in {
+          RetrieveForeignPropertyBsasSchema.schemaFor(Some("2020-99")) shouldBe Invalid(Seq(RuleTaxYearRangeInvalidError))
+        }
       }
     }
   }

--- a/test/v6/foreignPropertyBsas/submit/SubmitForeignPropertyBsasSchemaSpec.scala
+++ b/test/v6/foreignPropertyBsas/submit/SubmitForeignPropertyBsasSchemaSpec.scala
@@ -16,44 +16,55 @@
 
 package v6.foreignPropertyBsas.submit
 
+import cats.data.Validated.{Invalid, Valid}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+import shared.models.errors.{InvalidTaxYearParameterError, RuleTaxYearRangeInvalidError, TaxYearFormatError}
 import shared.utils.UnitSpec
 
 class SubmitForeignPropertyBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
 
   "schema lookup" when {
     "a tax year is present" must {
-      "use Def1 for tax years before 2023-24" in {
-        forTaxYearsBefore(TaxYear.fromMtd("2023-24")) { taxYear =>
-          SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitForeignPropertyBsasSchema.Def1
-        }
-      }
-      "use Def1 for pre-TYS tax years" in {
+      "disallow a tax year parameter for pre-TYS tax years and return InvalidTaxYearParameterError" in {
         forPreTysTaxYears { taxYear =>
-          SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitForeignPropertyBsasSchema.Def1
+          SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Invalid(Seq(InvalidTaxYearParameterError))
         }
       }
 
-      "use Def2 for tax years from 2024-25" in {
+      "use Def1 for tax year 2023-24" in {
+        val taxYear = TaxYear.fromMtd("2023-24")
+        SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Valid(SubmitForeignPropertyBsasSchema.Def1)
+      }
+
+      "use Def2 for tax year 2024-25" in {
         val taxYear = TaxYear.fromMtd("2024-25")
-        SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitForeignPropertyBsasSchema.Def2
+        SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Valid(SubmitForeignPropertyBsasSchema.Def2)
       }
-      "use Def3 for tax years from 2025-26" in {
+
+      "use Def3 for tax years 2025-26 onwards" in {
         val taxYear = TaxYear.fromMtd("2025-26")
-        SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe SubmitForeignPropertyBsasSchema.Def3
+        SubmitForeignPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Valid(SubmitForeignPropertyBsasSchema.Def3)
       }
     }
 
-    "the tax year is present but not valid" must {
-      "use a default of Def1" in {
-        SubmitForeignPropertyBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe SubmitForeignPropertyBsasSchema.Def1
+    "no tax year is present (pre-TYS case)" must {
+      "use Def1" in {
+        SubmitForeignPropertyBsasSchema.schemaFor(None) shouldBe Valid(SubmitForeignPropertyBsasSchema.Def1)
       }
     }
 
-    "no tax year is present" must {
-      "use a default of Def1" in {
-        SubmitForeignPropertyBsasSchema.schemaFor(None) shouldBe SubmitForeignPropertyBsasSchema.Def1
+    "the tax year is present but not valid" when {
+      "the tax year format is invalid" must {
+        "return a TaxYearFormatError" in {
+          SubmitForeignPropertyBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe Invalid(Seq(TaxYearFormatError))
+        }
+      }
+
+      "the tax year range is invalid" must {
+        "return a RuleTaxYearRangeInvalidError" in {
+          SubmitForeignPropertyBsasSchema.schemaFor(Some("2020-99")) shouldBe Invalid(Seq(RuleTaxYearRangeInvalidError))
+        }
       }
     }
   }

--- a/test/v6/ukPropertyBsas/retrieve/RetrieveUkPropertyBsasSchemaSpec.scala
+++ b/test/v6/ukPropertyBsas/retrieve/RetrieveUkPropertyBsasSchemaSpec.scala
@@ -16,36 +16,55 @@
 
 package v6.ukPropertyBsas.retrieve
 
+import cats.data.Validated.{Invalid, Valid}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+import shared.models.errors.{InvalidTaxYearParameterError, RuleTaxYearRangeInvalidError, TaxYearFormatError}
 import shared.utils.UnitSpec
 
 class RetrieveUkPropertyBsasSchemaSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
 
   "schema lookup" when {
     "a tax year is present" must {
-      "use Def2 for tax years from 2025-26" in {
-        forTaxYearsFrom(TaxYear.fromMtd("2025-26")) { taxYear =>
-          RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveUkPropertyBsasSchema.Def2
-        }
-      }
-
-      "use Def1 for pre-TYS tax years" in {
+      "disallow a tax year parameter for pre-TYS tax years and return InvalidTaxYearParameterError" in {
         forPreTysTaxYears { taxYear =>
-          RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe RetrieveUkPropertyBsasSchema.Def1
+          RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Invalid(Seq(InvalidTaxYearParameterError))
         }
       }
-    }
 
-    "the tax year is present but not valid" must {
-      "use a default of Def1" in {
-        RetrieveUkPropertyBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe RetrieveUkPropertyBsasSchema.Def1
+      "use Def1 for tax year 2023-24" in {
+        val taxYear = TaxYear.fromMtd("2023-24")
+        RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Valid(RetrieveUkPropertyBsasSchema.Def1)
+      }
+
+      "use Def1 for tax year 2024-25" in {
+        val taxYear = TaxYear.fromMtd("2024-25")
+        RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Valid(RetrieveUkPropertyBsasSchema.Def1)
+      }
+
+      "use Def2 for tax years 2025-26 onwards" in {
+        val taxYear = TaxYear.fromMtd("2025-26")
+        RetrieveUkPropertyBsasSchema.schemaFor(Some(taxYear.asMtd)) shouldBe Valid(RetrieveUkPropertyBsasSchema.Def2)
       }
     }
 
-    "no tax year is present" must {
-      "use a default of Def1" in {
-        RetrieveUkPropertyBsasSchema.schemaFor(None) shouldBe RetrieveUkPropertyBsasSchema.Def1
+    "no tax year is present (pre-TYS case)" must {
+      "use Def1" in {
+        RetrieveUkPropertyBsasSchema.schemaFor(None) shouldBe Valid(RetrieveUkPropertyBsasSchema.Def1)
+      }
+    }
+
+    "the tax year is present but not valid" when {
+      "the tax year format is invalid" must {
+        "return a TaxYearFormatError" in {
+          RetrieveUkPropertyBsasSchema.schemaFor(Some("NotATaxYear")) shouldBe Invalid(Seq(TaxYearFormatError))
+        }
+      }
+
+      "the tax year range is invalid" must {
+        "return a RuleTaxYearRangeInvalidError" in {
+          RetrieveUkPropertyBsasSchema.schemaFor(Some("2020-99")) shouldBe Invalid(Seq(RuleTaxYearRangeInvalidError))
+        }
       }
     }
   }


### PR DESCRIPTION
- replace default schemas with the necessary validation inside 'schemaFor' methods
- re-instate separated out tax year validation ITs (i.e. remove workaround)
- Submit Foreign property v6
- Submit UK property v6
- Retrieve UK property v6
- Retrieve Foreign property v6
- List bsas v6
- Trigger BSAS v6
  - fix trigger ISpecs to use right tax year (endDate)