### PR TITLE
MTDSA-30951: CL456 - API#1876 Adjust Def3 OAS schema (V7)

### DIFF
--- a/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_consolidated_expenses.json
+++ b/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_consolidated_expenses.json
@@ -79,6 +79,8 @@
     },
     "netProfit": 0.12,
     "totalAdditions": 0,
+    "adjustedProfit": 0.12,
+    "outstandingBusinessIncome": 0.12,
     "totalDeductions": 0.12,
     "deductions": {
       "annualInvestmentAllowance": 0.12,

--- a/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_full_expenses.json
+++ b/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_full_expenses.json
@@ -48,6 +48,8 @@
     },
     "netProfit": 0.12,
     "totalAdditions": 0.12,
+    "adjustedProfit": 0.12,
+    "outstandingBusinessIncome": 0.12,
     "additions": {
       "costOfGoodsDisallowable": 0.12,
       "paymentsToSubcontractorsDisallowable": -0.12,
@@ -159,6 +161,8 @@
     },
     "netProfit": 0.12,
     "totalAdditions": 0.12,
+    "adjustedProfit": 0.12,
+    "outstandingBusinessIncome": 0.12,
     "additions": {
       "costOfGoodsDisallowable": 0.12,
       "paymentsToSubcontractorsDisallowable": 0.12,
@@ -175,7 +179,6 @@
       "otherExpensesDisallowable": 0.12,
       "advertisingCostsDisallowable": 0.12,
       "businessEntertainmentCostsDisallowable": 0.12,
-      "outstandingBusinessIncome": 0.12,
       "balancingChargeOther": 0.12,
       "balancingChargeBpra": 0.12,
       "goodsAndServicesOwnUse": 0.12

--- a/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_trading_allowance.json
+++ b/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_trading_allowance.json
@@ -48,6 +48,8 @@
     },
     "netProfit": 0.12,
     "totalAdditions": 0.12,
+    "adjustedProfit": 0.12,
+    "outstandingBusinessIncome": 0.12,
     "additions": {
       "costOfGoodsDisallowable": -0.12,
       "paymentsToSubcontractorsDisallowable": -0.12,
@@ -64,7 +66,6 @@
       "otherExpensesDisallowable": 0.12,
       "advertisingCostsDisallowable": 0.12,
       "businessEntertainmentCostsDisallowable": 0.12,
-      "outstandingBusinessIncome": 0.12,
       "balancingChargeOther": 0.12,
       "balancingChargeBpra": 0.12,
       "goodsAndServicesOwnUse": 0.12
@@ -148,6 +149,8 @@
     },
     "netProfit": 0.12,
     "totalAdditions": 0.12,
+    "adjustedProfit": 0.12,
+    "outstandingBusinessIncome": 0.12,
     "additions": {
       "costOfGoodsDisallowable": 0.12,
       "paymentsToSubcontractorsDisallowable": 0.12,
@@ -164,7 +167,6 @@
       "otherExpensesDisallowable": 0.12,
       "advertisingCostsDisallowable": 0.12,
       "businessEntertainmentCostsDisallowable": 0.12,
-      "outstandingBusinessIncome": 0.12,
       "balancingChargeOther": 0.12,
       "balancingChargeBpra": 0.12,
       "goodsAndServicesOwnUse": 0.12

--- a/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_zero_adjustments.json
+++ b/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_zero_adjustments.json
@@ -48,6 +48,8 @@
     },
     "netProfit": 0.12,
     "totalAdditions": 0.12,
+    "adjustedProfit": 0.12,
+    "outstandingBusinessIncome": 0.12,
     "additions": {
       "costOfGoodsDisallowable": 0.12,
       "paymentsToSubcontractorsDisallowable": -0.12,
@@ -64,7 +66,6 @@
       "otherExpensesDisallowable": 0.12,
       "advertisingCostsDisallowable": 0.12,
       "businessEntertainmentCostsDisallowable": 0.12,
-      "outstandingBusinessIncome": 0.12,
       "balancingChargeOther": 0.12,
       "balancingChargeBpra": 0.12,
       "goodsAndServicesOwnUse": 0.12
@@ -122,6 +123,8 @@
     },
     "netProfit": 0.12,
     "totalAdditions": 0.12,
+    "adjustedProfit": 0.12,
+    "outstandingBusinessIncome": 0.12,
     "additions": {
       "costOfGoodsDisallowable": 0.12,
       "paymentsToSubcontractorsDisallowable": -0.12,
@@ -138,7 +141,6 @@
       "otherExpensesDisallowable": 0.12,
       "advertisingCostsDisallowable": 0.12,
       "businessEntertainmentCostsDisallowable": 0.12,
-      "outstandingBusinessIncome": 0.12,
       "balancingChargeOther": 0.12,
       "balancingChargeBpra": 0.12,
       "goodsAndServicesOwnUse": 0.12

--- a/resources/public/api/conf/7.0/schemas/retrieve_self_employment/def3/response.json
+++ b/resources/public/api/conf/7.0/schemas/retrieve_self_employment/def3/response.json
@@ -299,21 +299,35 @@
           "type": "number",
           "minimum": 0,
           "maximum": 99999999999.99,
-          "example": " 1000.45"
+          "example": "1000.45"
         },
         "netLoss": {
           "description": "The net loss of income source. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
           "type": "number",
           "minimum": 0,
           "maximum": 99999999999.99,
-          "example": " 1000.45"
+          "example": "1000.45"
         },
         "totalAdditions": {
           "description": "The total additions to net profit (or deduction to net loss). The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places.",
           "type": "number",
           "minimum": -99999999999.99,
           "maximum": 99999999999.99,
-          "example": " 1000.45"
+          "example": "1000.45"
+        },
+        "outstandingBusinessIncome": {
+          "description": "Any other business income not included in other fields. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 99999999999.99,
+          "example": "1000.45"
+        },
+        "adjustedProfit": {
+          "description": "Profit including disallowable expenses and deducting non‑taxable income, before claiming capital allowances or making any further tax adjustments. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 99999999999.99,
+          "example": "1000.45"
         },
         "additions": {
           "type": "object",
@@ -421,13 +435,6 @@
               "description": "Business entertainment costs. Any expense or partial expense that cannot be claimed for tax purposes. The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places.",
               "type": "number",
               "minimum": -99999999999.99,
-              "maximum": 99999999999.99,
-              "example": "1000.45"
-            },
-            "outstandingBusinessIncome": {
-              "description": "Any other business income not included in other fields. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
-              "type": "number",
-              "minimum": 0,
               "maximum": 99999999999.99,
               "example": "1000.45"
             },
@@ -1062,6 +1069,20 @@
           "maximum": 99999999999.99,
           "example": "1000.45"
         },
+        "outstandingBusinessIncome": {
+          "description": "Any other business income not included in other fields. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 99999999999.99,
+          "example": "1000.45"
+        },
+        "adjustedProfit": {
+          "description": "Profit including disallowable expenses and deducting non‑taxable income, before claiming capital allowances or making any further tax adjustments. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 99999999999.99,
+          "example": "1000.45"
+        },
         "additions": {
           "type": "object",
           "description": "Object containing the breakdown of the adjustable additions for the accounting period.",
@@ -1166,13 +1187,6 @@
             },
             "businessEntertainmentCostsDisallowable": {
               "description": "Business entertainment costs. Any expense or partial expense that cannot be claimed for tax purposes. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
-              "type": "number",
-              "minimum": 0,
-              "maximum": 99999999999.99,
-              "example": "1000.45"
-            },
-            "outstandingBusinessIncome": {
-              "description": "Any other business income not included in other fields. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
               "type": "number",
               "minimum": 0,
               "maximum": 99999999999.99,


### PR DESCRIPTION
- Remove optional `outstandingBusinessIncome` from `adjustableSummaryCalculation.additions` & `adjustedSummaryCalculation.additions` for tax years 2025-26 onwards in OAS documentation (V7)
- Add optional `outstandingBusinessIncome` & `adjustedProfit` to `adjustableSummaryCalculation` & `adjustedSummaryCalculation` for tax years 2025-26 onwards in OAS documentation (V7)