### PR TITLE
MTDSA-31476: Fix validation for submission endpoints

### DIFF
--- a/app/v5/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasRulesValidator.scala
+++ b/app/v5/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasRulesValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,9 +61,6 @@ object Def2_SubmitForeignPropertyBsasRulesValidator extends RulesValidator[Def2_
       validatedDuplicateCountryCode
     ).onSuccess(parsed)
   }
-
-  private def resolveNonNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
-    ResolveParsedNumber(disallowZero = true)(value, path)
 
   private def resolveMaybeNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
     ResolveParsedNumber(min = -99999999999.99, disallowZero = true)(value, path)
@@ -136,7 +133,7 @@ object Def2_SubmitForeignPropertyBsasRulesValidator extends RulesValidator[Def2_
       resolveMaybeNegativeNumber(path("expenses/professionalFees"), foreignProperty.expenses.flatMap(_.professionalFees)),
       resolveMaybeNegativeNumber(path("expenses/travelCosts"), foreignProperty.expenses.flatMap(_.travelCosts)),
       resolveMaybeNegativeNumber(path("expenses/costOfServices"), foreignProperty.expenses.flatMap(_.costOfServices)),
-      resolveNonNegativeNumber(path("expenses/residentialFinancialCost"), foreignProperty.expenses.flatMap(_.residentialFinancialCost)),
+      resolveMaybeNegativeNumber(path("expenses/residentialFinancialCost"), foreignProperty.expenses.flatMap(_.residentialFinancialCost)),
       resolveMaybeNegativeNumber(path("expenses/other"), foreignProperty.expenses.flatMap(_.other)),
       resolveMaybeNegativeNumber(path("expenses/consolidatedExpenses"), foreignProperty.expenses.flatMap(_.consolidatedExpenses))
     )

--- a/app/v5/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasRulesValidator.scala
+++ b/app/v5/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasRulesValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,9 +57,6 @@ object Def2_SubmitUkPropertyBsasRulesValidator extends RulesValidator[Def2_Submi
     ).onSuccess(parsed)
   }
 
-  private def resolveNonNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
-    ResolveParsedNumber(disallowZero = true)(value, path)
-
   private def resolveMaybeNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
     ResolveParsedNumber(min = -99999999999.99, disallowZero = true)(value, path)
 
@@ -89,7 +86,7 @@ object Def2_SubmitUkPropertyBsasRulesValidator extends RulesValidator[Def2_Submi
       resolveMaybeNegativeNumber("/nonFurnishedHolidayLet/expenses/professionalFees", nonFhl.expenses.flatMap(_.professionalFees)),
       resolveMaybeNegativeNumber("/nonFurnishedHolidayLet/expenses/travelCosts", nonFhl.expenses.flatMap(_.travelCosts)),
       resolveMaybeNegativeNumber("/nonFurnishedHolidayLet/expenses/costOfServices", nonFhl.expenses.flatMap(_.costOfServices)),
-      resolveNonNegativeNumber("/nonFurnishedHolidayLet/expenses/residentialFinancialCost", nonFhl.expenses.flatMap(_.residentialFinancialCost)),
+      resolveMaybeNegativeNumber("/nonFurnishedHolidayLet/expenses/residentialFinancialCost", nonFhl.expenses.flatMap(_.residentialFinancialCost)),
       resolveMaybeNegativeNumber("/nonFurnishedHolidayLet/expenses/other", nonFhl.expenses.flatMap(_.other)),
       resolveMaybeNegativeNumber("/nonFurnishedHolidayLet/expenses/consolidatedExpenses", nonFhl.expenses.flatMap(_.consolidatedExpenses))
     )

--- a/app/v6/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasRulesValidator.scala
+++ b/app/v6/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasRulesValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,9 +61,6 @@ object Def2_SubmitForeignPropertyBsasRulesValidator extends RulesValidator[Def2_
       validatedDuplicateCountryCode
     ).onSuccess(parsed)
   }
-
-  private def resolveNonNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
-    ResolveParsedNumber(disallowZero = true)(value, path)
 
   private def resolveMaybeNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
     ResolveParsedNumber(min = -99999999999.99, disallowZero = true)(value, path)
@@ -136,7 +133,7 @@ object Def2_SubmitForeignPropertyBsasRulesValidator extends RulesValidator[Def2_
       resolveMaybeNegativeNumber(path("expenses/professionalFees"), foreignProperty.expenses.flatMap(_.professionalFees)),
       resolveMaybeNegativeNumber(path("expenses/travelCosts"), foreignProperty.expenses.flatMap(_.travelCosts)),
       resolveMaybeNegativeNumber(path("expenses/costOfServices"), foreignProperty.expenses.flatMap(_.costOfServices)),
-      resolveNonNegativeNumber(path("expenses/residentialFinancialCost"), foreignProperty.expenses.flatMap(_.residentialFinancialCost)),
+      resolveMaybeNegativeNumber(path("expenses/residentialFinancialCost"), foreignProperty.expenses.flatMap(_.residentialFinancialCost)),
       resolveMaybeNegativeNumber(path("expenses/other"), foreignProperty.expenses.flatMap(_.other)),
       resolveMaybeNegativeNumber(path("expenses/consolidatedExpenses"), foreignProperty.expenses.flatMap(_.consolidatedExpenses))
     )

--- a/app/v6/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasRulesValidator.scala
+++ b/app/v6/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasRulesValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,9 +49,6 @@ object Def3_SubmitForeignPropertyBsasRulesValidator extends RulesValidator[Def3_
     ).onSuccess(parsed)
   }
 
-  private def resolveNonNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
-    ResolveParsedNumber(disallowZero = true)(value, path)
-
   private def resolveMaybeNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
     ResolveParsedNumber(min = -99999999999.99, disallowZero = true)(value, path)
 
@@ -96,7 +93,7 @@ object Def3_SubmitForeignPropertyBsasRulesValidator extends RulesValidator[Def3_
       resolveMaybeNegativeNumber(path("expenses/professionalFees"), foreignProperty.expenses.flatMap(_.professionalFees)),
       resolveMaybeNegativeNumber(path("expenses/travelCosts"), foreignProperty.expenses.flatMap(_.travelCosts)),
       resolveMaybeNegativeNumber(path("expenses/costOfServices"), foreignProperty.expenses.flatMap(_.costOfServices)),
-      resolveNonNegativeNumber(path("expenses/residentialFinancialCost"), foreignProperty.expenses.flatMap(_.residentialFinancialCost)),
+      resolveMaybeNegativeNumber(path("expenses/residentialFinancialCost"), foreignProperty.expenses.flatMap(_.residentialFinancialCost)),
       resolveMaybeNegativeNumber(path("expenses/other"), foreignProperty.expenses.flatMap(_.other)),
       resolveMaybeNegativeNumber(path("expenses/consolidatedExpenses"), foreignProperty.expenses.flatMap(_.consolidatedExpenses))
     )

--- a/app/v6/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasRulesValidator.scala
+++ b/app/v6/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasRulesValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,9 +57,6 @@ object Def2_SubmitUkPropertyBsasRulesValidator extends RulesValidator[Def2_Submi
     ).onSuccess(parsed)
   }
 
-  private def resolveNonNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
-    ResolveParsedNumber(disallowZero = true)(value, path)
-
   private def resolveMaybeNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
     ResolveParsedNumber(min = -99999999999.99, disallowZero = true)(value, path)
 
@@ -89,7 +86,7 @@ object Def2_SubmitUkPropertyBsasRulesValidator extends RulesValidator[Def2_Submi
       resolveMaybeNegativeNumber("/ukProperty/expenses/professionalFees", ukProperty.expenses.flatMap(_.professionalFees)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/travelCosts", ukProperty.expenses.flatMap(_.travelCosts)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/costOfServices", ukProperty.expenses.flatMap(_.costOfServices)),
-      resolveNonNegativeNumber("/ukProperty/expenses/residentialFinancialCost", ukProperty.expenses.flatMap(_.residentialFinancialCost)),
+      resolveMaybeNegativeNumber("/ukProperty/expenses/residentialFinancialCost", ukProperty.expenses.flatMap(_.residentialFinancialCost)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/other", ukProperty.expenses.flatMap(_.other)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/consolidatedExpenses", ukProperty.expenses.flatMap(_.consolidatedExpenses))
     )

--- a/app/v6/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasRulesValidator.scala
+++ b/app/v6/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasRulesValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,10 +64,8 @@ object Def3_SubmitUkPropertyBsasRulesValidator extends RulesValidator[Def3_Submi
       resolveMaybeNegativeNumber("/ukProperty/expenses/travelCosts", ukProperty.expenses.flatMap(_.travelCosts)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/consolidatedExpenses", ukProperty.expenses.flatMap(_.consolidatedExpenses)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/costOfServices", ukProperty.expenses.flatMap(_.costOfServices)),
-      ResolveParsedNumber(disallowZero = true)(
-        ukProperty.expenses.flatMap(_.residentialFinancialCost),
-        "/ukProperty/expenses/residentialFinancialCost"),
-      ResolveParsedNumber(disallowZero = true)(ukProperty.expenses.flatMap(_.other), "/ukProperty/expenses/other")
+      resolveMaybeNegativeNumber("/ukProperty/expenses/residentialFinancialCost", ukProperty.expenses.flatMap(_.residentialFinancialCost)),
+      resolveMaybeNegativeNumber("/ukProperty/expenses/other", ukProperty.expenses.flatMap(_.other))
     )
   }
 

--- a/app/v7/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasRulesValidator.scala
+++ b/app/v7/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasRulesValidator.scala
@@ -101,9 +101,6 @@ object Def2_SubmitForeignPropertyBsasRulesValidator extends RulesValidator[Def2_
     validateZeroAdjustments(zeroAdjustments, hasAdjustableFields, "/foreignProperty")
   }
 
-  private def resolveNonNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
-    ResolveParsedNumber(disallowZero = true)(value, path)
-
   private def resolveMaybeNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
     ResolveParsedNumber(min = -99999999999.99, disallowZero = true)(value, path)
 
@@ -170,7 +167,7 @@ object Def2_SubmitForeignPropertyBsasRulesValidator extends RulesValidator[Def2_
       resolveMaybeNegativeNumber(path("expenses/professionalFees"), countryLevelDetail.expenses.flatMap(_.professionalFees)),
       resolveMaybeNegativeNumber(path("expenses/travelCosts"), countryLevelDetail.expenses.flatMap(_.travelCosts)),
       resolveMaybeNegativeNumber(path("expenses/costOfServices"), countryLevelDetail.expenses.flatMap(_.costOfServices)),
-      resolveNonNegativeNumber(path("expenses/residentialFinancialCost"), countryLevelDetail.expenses.flatMap(_.residentialFinancialCost)),
+      resolveMaybeNegativeNumber(path("expenses/residentialFinancialCost"), countryLevelDetail.expenses.flatMap(_.residentialFinancialCost)),
       resolveMaybeNegativeNumber(path("expenses/other"), countryLevelDetail.expenses.flatMap(_.other)),
       resolveMaybeNegativeNumber(path("expenses/consolidatedExpenses"), countryLevelDetail.expenses.flatMap(_.consolidatedExpenses))
     )

--- a/app/v7/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasRulesValidator.scala
+++ b/app/v7/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasRulesValidator.scala
@@ -75,9 +75,6 @@ object Def3_SubmitForeignPropertyBsasRulesValidator extends RulesValidator[Def3_
     }
   }
 
-  private def resolveNonNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
-    ResolveParsedNumber(disallowZero = true)(value, path)
-
   private def resolveMaybeNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
     ResolveParsedNumber(min = -99999999999.99, disallowZero = true)(value, path)
 
@@ -118,7 +115,7 @@ object Def3_SubmitForeignPropertyBsasRulesValidator extends RulesValidator[Def3_
       resolveMaybeNegativeNumber(path("expenses/professionalFees"), countryLevelDetail.expenses.flatMap(_.professionalFees)),
       resolveMaybeNegativeNumber(path("expenses/travelCosts"), countryLevelDetail.expenses.flatMap(_.travelCosts)),
       resolveMaybeNegativeNumber(path("expenses/costOfServices"), countryLevelDetail.expenses.flatMap(_.costOfServices)),
-      resolveNonNegativeNumber(path("expenses/residentialFinancialCost"), countryLevelDetail.expenses.flatMap(_.residentialFinancialCost)),
+      resolveMaybeNegativeNumber(path("expenses/residentialFinancialCost"), countryLevelDetail.expenses.flatMap(_.residentialFinancialCost)),
       resolveMaybeNegativeNumber(path("expenses/other"), countryLevelDetail.expenses.flatMap(_.other)),
       resolveMaybeNegativeNumber(path("expenses/consolidatedExpenses"), countryLevelDetail.expenses.flatMap(_.consolidatedExpenses))
     )

--- a/app/v7/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasRulesValidator.scala
+++ b/app/v7/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasRulesValidator.scala
@@ -92,9 +92,6 @@ object Def2_SubmitUkPropertyBsasRulesValidator extends RulesValidator[Def2_Submi
     }
   }
 
-  private def resolveNonNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
-    ResolveParsedNumber(disallowZero = true)(value, path)
-
   private def resolveMaybeNegativeNumber(path: String, value: Option[BigDecimal]): Validated[Seq[MtdError], Option[BigDecimal]] =
     ResolveParsedNumber(min = -99999999999.99, disallowZero = true)(value, path)
 
@@ -124,7 +121,7 @@ object Def2_SubmitUkPropertyBsasRulesValidator extends RulesValidator[Def2_Submi
       resolveMaybeNegativeNumber("/ukProperty/expenses/professionalFees", ukProperty.expenses.flatMap(_.professionalFees)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/travelCosts", ukProperty.expenses.flatMap(_.travelCosts)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/costOfServices", ukProperty.expenses.flatMap(_.costOfServices)),
-      resolveNonNegativeNumber("/ukProperty/expenses/residentialFinancialCost", ukProperty.expenses.flatMap(_.residentialFinancialCost)),
+      resolveMaybeNegativeNumber("/ukProperty/expenses/residentialFinancialCost", ukProperty.expenses.flatMap(_.residentialFinancialCost)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/other", ukProperty.expenses.flatMap(_.other)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/consolidatedExpenses", ukProperty.expenses.flatMap(_.consolidatedExpenses))
     )

--- a/app/v7/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasRulesValidator.scala
+++ b/app/v7/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasRulesValidator.scala
@@ -89,10 +89,8 @@ object Def3_SubmitUkPropertyBsasRulesValidator extends RulesValidator[Def3_Submi
       resolveMaybeNegativeNumber("/ukProperty/expenses/travelCosts", ukProperty.expenses.flatMap(_.travelCosts)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/consolidatedExpenses", ukProperty.expenses.flatMap(_.consolidatedExpenses)),
       resolveMaybeNegativeNumber("/ukProperty/expenses/costOfServices", ukProperty.expenses.flatMap(_.costOfServices)),
-      ResolveParsedNumber(disallowZero = true)(
-        ukProperty.expenses.flatMap(_.residentialFinancialCost),
-        "/ukProperty/expenses/residentialFinancialCost"),
-      ResolveParsedNumber(disallowZero = true)(ukProperty.expenses.flatMap(_.other), "/ukProperty/expenses/other")
+      resolveMaybeNegativeNumber("/ukProperty/expenses/residentialFinancialCost", ukProperty.expenses.flatMap(_.residentialFinancialCost)),
+      resolveMaybeNegativeNumber("/ukProperty/expenses/other", ukProperty.expenses.flatMap(_.other))
     )
   }
 

--- a/it/test/v5/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasHipISpec.scala
+++ b/it/test/v5/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasHipISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import shared.support.IntegrationBaseSpec
 import v5.foreignPropertyBsas.submit.def2.model.request.SubmitForeignPropertyBsasFixtures.{
   downstreamRequestValid,
   mtdRequestNonFhlFull,
-  mtdRequestNonFhlValid,
   mtdRequestValid
 }
 
@@ -112,17 +111,7 @@ class Def2_SubmitForeignPropertyBsasHipISpec extends IntegrationBaseSpec with Js
             None,
             requestBodyWithCountryCode("FRANCE"),
             BAD_REQUEST,
-            CountryCodeFormatError.copy(paths = Some(List("/nonFurnishedHolidayLet/0/countryCode")))),
-          (
-            "AA123456A",
-            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
-            Some("2024-25"),
-            mtdRequestNonFhlValid,
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/nonFurnishedHolidayLet/0/expenses/residentialFinancialCost"))
-            ))
+            CountryCodeFormatError.copy(paths = Some(List("/nonFurnishedHolidayLet/0/countryCode"))))
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v5/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasIfISpec.scala
+++ b/it/test/v5/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasIfISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import shared.support.IntegrationBaseSpec
 import v5.foreignPropertyBsas.submit.def2.model.request.SubmitForeignPropertyBsasFixtures.{
   downstreamRequestValid,
   mtdRequestNonFhlFull,
-  mtdRequestNonFhlValid,
   mtdRequestValid
 }
 
@@ -124,17 +123,7 @@ class Def2_SubmitForeignPropertyBsasIfISpec extends IntegrationBaseSpec with Jso
             None,
             requestBodyWithCountryCode("FRANCE"),
             BAD_REQUEST,
-            CountryCodeFormatError.copy(paths = Some(List("/nonFurnishedHolidayLet/0/countryCode")))),
-          (
-            "AA123456A",
-            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
-            Some("2024-25"),
-            mtdRequestNonFhlValid,
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/nonFurnishedHolidayLet/0/expenses/residentialFinancialCost"))
-            ))
+            CountryCodeFormatError.copy(paths = Some(List("/nonFurnishedHolidayLet/0/countryCode"))))
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v5/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasHipISpec.scala
+++ b/it/test/v5/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasHipISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,7 @@ import v5.ukPropertyBsas.submit.def1.model.request.SubmitUKPropertyBsasRequestBo
 
 class Def2_SubmitUkPropertyBsasHipISpec extends IntegrationBaseSpec with JsonErrorValidators {
 
-  val requestBodyJson: JsValue       = validfhlInputJson
-  val nonFHLRequestBodyJson: JsValue = validNonFHLInputJson
+  val requestBodyJson: JsValue = validfhlInputJson
 
   "Calling the Submit UK Property Accounting Adjustments endpoint" should {
     "return a 200 status code" when {
@@ -93,17 +92,7 @@ class Def2_SubmitUkPropertyBsasHipISpec extends IntegrationBaseSpec with JsonErr
             None,
             requestBodyJson.update("/nonFurnishedHolidayLet/income/totalRentsReceived", JsNumber(2.25)),
             BAD_REQUEST,
-            RuleBothPropertiesSuppliedError),
-          (
-            "AA123456A",
-            "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
-            Some("2024-25"),
-            nonFHLRequestBodyJson.update("/nonFurnishedHolidayLet/expenses/residentialFinancialCost", JsNumber(-1.523)),
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/nonFurnishedHolidayLet/expenses/residentialFinancialCost"))
-            ))
+            RuleBothPropertiesSuppliedError)
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v5/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasIfISpec.scala
+++ b/it/test/v5/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasIfISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,7 @@ class Def2_SubmitUkPropertyBsasIfISpec extends IntegrationBaseSpec with JsonErro
   override def servicesConfig: Map[String, Any] =
     Map("feature-switch.ifs_hip_migration_1874.enabled" -> false) ++ super.servicesConfig
 
-  val requestBodyJson: JsValue       = validfhlInputJson
-  val nonFHLRequestBodyJson: JsValue = validNonFHLInputJson
+  val requestBodyJson: JsValue = validfhlInputJson
 
   "Calling the Submit UK Property Accounting Adjustments endpoint" should {
     "return a 200 status code" when {
@@ -107,17 +106,7 @@ class Def2_SubmitUkPropertyBsasIfISpec extends IntegrationBaseSpec with JsonErro
             None,
             requestBodyJson.update("/nonFurnishedHolidayLet/income/totalRentsReceived", JsNumber(2.25)),
             BAD_REQUEST,
-            RuleBothPropertiesSuppliedError),
-          (
-            "AA123456A",
-            "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
-            Some("2024-25"),
-            nonFHLRequestBodyJson.update("/nonFurnishedHolidayLet/expenses/residentialFinancialCost", JsNumber(-1.523)),
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/nonFurnishedHolidayLet/expenses/residentialFinancialCost"))
-            ))
+            RuleBothPropertiesSuppliedError)
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v6/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasHipISpec.scala
+++ b/it/test/v6/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasHipISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,12 +27,7 @@ import shared.models.errors.*
 import shared.models.utils.JsonErrorValidators
 import shared.services.*
 import shared.support.IntegrationBaseSpec
-import v6.foreignPropertyBsas.submit.def2.model.request.SubmitForeignPropertyBsasFixtures.{
-  downstreamRequestValid,
-  mtdRequestForeignPropertyValid,
-  mtdRequestFull,
-  mtdRequestValid
-}
+import v6.foreignPropertyBsas.submit.def2.model.request.SubmitForeignPropertyBsasFixtures.{downstreamRequestValid, mtdRequestFull, mtdRequestValid}
 
 class Def2_SubmitForeignPropertyBsasHipISpec extends IntegrationBaseSpec with JsonErrorValidators {
 
@@ -110,17 +105,7 @@ class Def2_SubmitForeignPropertyBsasHipISpec extends IntegrationBaseSpec with Js
             "2024-25",
             requestBodyWithCountryCode("FRANCE"),
             BAD_REQUEST,
-            CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/0/countryCode")))),
-          (
-            "AA123456A",
-            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
-            "2024-25",
-            mtdRequestForeignPropertyValid,
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/foreignProperty/0/expenses/residentialFinancialCost"))
-            ))
+            CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/0/countryCode"))))
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v6/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasIfISpec.scala
+++ b/it/test/v6/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasIfISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,12 +27,7 @@ import shared.models.errors.*
 import shared.models.utils.JsonErrorValidators
 import shared.services.*
 import shared.support.IntegrationBaseSpec
-import v6.foreignPropertyBsas.submit.def2.model.request.SubmitForeignPropertyBsasFixtures.{
-  downstreamRequestValid,
-  mtdRequestForeignPropertyValid,
-  mtdRequestFull,
-  mtdRequestValid
-}
+import v6.foreignPropertyBsas.submit.def2.model.request.SubmitForeignPropertyBsasFixtures.{downstreamRequestValid, mtdRequestFull, mtdRequestValid}
 
 class Def2_SubmitForeignPropertyBsasIfISpec extends IntegrationBaseSpec with JsonErrorValidators {
 
@@ -113,17 +108,7 @@ class Def2_SubmitForeignPropertyBsasIfISpec extends IntegrationBaseSpec with Jso
             "2024-25",
             requestBodyWithCountryCode("FRANCE"),
             BAD_REQUEST,
-            CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/0/countryCode")))),
-          (
-            "AA123456A",
-            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
-            "2024-25",
-            mtdRequestForeignPropertyValid,
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/foreignProperty/0/expenses/residentialFinancialCost"))
-            ))
+            CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/0/countryCode"))))
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v6/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasHipISpec.scala
+++ b/it/test/v6/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasHipISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import shared.support.IntegrationBaseSpec
 import v6.foreignPropertyBsas.submit.def3.model.request.SubmitForeignPropertyBsasFixtures.{
   downstreamRequestValid,
   mtdRequestForeignPropertyFull,
-  mtdRequestForeignPropertyInvalidResidentialCost,
   mtdRequestForeignPropertyValid
 }
 
@@ -111,17 +110,7 @@ class Def3_SubmitForeignPropertyBsasHipISpec extends IntegrationBaseSpec with Js
             "2025-26",
             requestBodyWithCountryCode("FRANCE"),
             BAD_REQUEST,
-            CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/0/countryCode")))),
-          (
-            "AA123456A",
-            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
-            "2025-26",
-            mtdRequestForeignPropertyInvalidResidentialCost,
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/foreignProperty/0/expenses/residentialFinancialCost"))
-            ))
+            CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/0/countryCode"))))
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v6/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasIfISpec.scala
+++ b/it/test/v6/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasIfISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import shared.support.IntegrationBaseSpec
 import v6.foreignPropertyBsas.submit.def3.model.request.SubmitForeignPropertyBsasFixtures.{
   downstreamRequestValid,
   mtdRequestForeignPropertyFull,
-  mtdRequestForeignPropertyInvalidResidentialCost,
   mtdRequestForeignPropertyValid
 }
 
@@ -114,17 +113,7 @@ class Def3_SubmitForeignPropertyBsasIfISpec extends IntegrationBaseSpec with Jso
             "2025-26",
             requestBodyWithCountryCode("FRANCE"),
             BAD_REQUEST,
-            CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/0/countryCode")))),
-          (
-            "AA123456A",
-            "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
-            "2025-26",
-            mtdRequestForeignPropertyInvalidResidentialCost,
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/foreignProperty/0/expenses/residentialFinancialCost"))
-            ))
+            CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/0/countryCode"))))
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v6/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasHipISpec.scala
+++ b/it/test/v6/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasHipISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,7 @@ import v6.ukPropertyBsas.submit.def2.model.request.SubmitUKPropertyBsasRequestBo
 
 class Def2_SubmitUkPropertyBsasHipISpec extends IntegrationBaseSpec with JsonErrorValidators {
 
-  val requestBodyJson: JsValue           = validfhlInputJson
-  val ukPropertyRequestBodyJson: JsValue = validUkPropertyInputJson
+  val requestBodyJson: JsValue = validfhlInputJson
 
   "Calling the Submit UK Property Accounting Adjustments endpoint" should {
     "return a 200 status code" when {
@@ -93,17 +92,7 @@ class Def2_SubmitUkPropertyBsasHipISpec extends IntegrationBaseSpec with JsonErr
             "2023-24",
             requestBodyJson.update("/ukProperty/income/totalRentsReceived", JsNumber(2.25)),
             BAD_REQUEST,
-            RuleBothPropertiesSuppliedError),
-          (
-            "AA123456A",
-            "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
-            "2024-25",
-            ukPropertyRequestBodyJson.update("/ukProperty/expenses/residentialFinancialCost", JsNumber(-1.523)),
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/ukProperty/expenses/residentialFinancialCost"))
-            ))
+            RuleBothPropertiesSuppliedError)
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v6/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasIfISpec.scala
+++ b/it/test/v6/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasIfISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,7 @@ class Def2_SubmitUkPropertyBsasIfISpec extends IntegrationBaseSpec with JsonErro
   override def servicesConfig: Map[String, Any] =
     Map("feature-switch.ifs_hip_migration_1874.enabled" -> false) ++ super.servicesConfig
 
-  val requestBodyJson: JsValue           = validfhlInputJson
-  val ukPropertyRequestBodyJson: JsValue = validUkPropertyInputJson
+  val requestBodyJson: JsValue = validfhlInputJson
 
   "Calling the Submit UK Property Accounting Adjustments endpoint" should {
     "return a 200 status code" when {
@@ -96,17 +95,7 @@ class Def2_SubmitUkPropertyBsasIfISpec extends IntegrationBaseSpec with JsonErro
             "2023-24",
             requestBodyJson.update("/ukProperty/income/totalRentsReceived", JsNumber(2.25)),
             BAD_REQUEST,
-            RuleBothPropertiesSuppliedError),
-          (
-            "AA123456A",
-            "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
-            "2024-25",
-            ukPropertyRequestBodyJson.update("/ukProperty/expenses/residentialFinancialCost", JsNumber(-1.523)),
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/ukProperty/expenses/residentialFinancialCost"))
-            ))
+            RuleBothPropertiesSuppliedError)
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v6/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasHipISpec.scala
+++ b/it/test/v6/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasHipISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,17 +85,7 @@ class Def3_SubmitUkPropertyBsasHipISpec extends IntegrationBaseSpec with JsonErr
             fullRequestJson.update("/ukProperty/expenses/consolidatedExpenses", JsNumber(1.23)),
             BAD_REQUEST,
             RuleBothExpensesError.copy(paths = Some(List("/ukProperty/expenses")))
-          ),
-          (
-            "AA123456A",
-            "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
-            "2025-26",
-            fullRequestJson.update("/ukProperty/expenses/residentialFinancialCost", JsNumber(-1.523)),
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/ukProperty/expenses/residentialFinancialCost"))
-            ))
+          )
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v6/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasIfISpec.scala
+++ b/it/test/v6/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasIfISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,17 +88,7 @@ class Def3_SubmitUkPropertyBsasIfISpec extends IntegrationBaseSpec with JsonErro
             fullRequestJson.update("/ukProperty/expenses/consolidatedExpenses", JsNumber(1.23)),
             BAD_REQUEST,
             RuleBothExpensesError.copy(paths = Some(List("/ukProperty/expenses")))
-          ),
-          (
-            "AA123456A",
-            "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
-            "2025-26",
-            fullRequestJson.update("/ukProperty/expenses/residentialFinancialCost", JsNumber(-1.523)),
-            BAD_REQUEST,
-            ValueFormatError.copy(
-              message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-              paths = Some(List("/ukProperty/expenses/residentialFinancialCost"))
-            ))
+          )
         )
         input.foreach(validationErrorTest.tupled)
       }

--- a/it/test/v7/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasHipISpec.scala
+++ b/it/test/v7/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasHipISpec.scala
@@ -227,19 +227,6 @@ class Def2_SubmitForeignPropertyBsasHipISpec extends IntegrationBaseSpec with Js
           CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/countryLevelDetail/0/countryCode"))),
           None,
           None
-        ),
-        (
-          "AA123456A",
-          "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
-          "2024-25",
-          mtdRequestForeignPropertyInvalid,
-          BAD_REQUEST,
-          ValueFormatError.copy(
-            message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-            paths = Some(List("/foreignProperty/countryLevelDetail/0/expenses/residentialFinancialCost"))
-          ),
-          None,
-          None
         )
       )
 

--- a/it/test/v7/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasIfISpec.scala
+++ b/it/test/v7/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasIfISpec.scala
@@ -230,19 +230,6 @@ class Def2_SubmitForeignPropertyBsasIfISpec extends IntegrationBaseSpec with Jso
           CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/countryLevelDetail/0/countryCode"))),
           None,
           None
-        ),
-        (
-          "AA123456A",
-          "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
-          "2024-25",
-          mtdRequestForeignPropertyInvalid,
-          BAD_REQUEST,
-          ValueFormatError.copy(
-            message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-            paths = Some(List("/foreignProperty/countryLevelDetail/0/expenses/residentialFinancialCost"))
-          ),
-          None,
-          None
         )
       )
 

--- a/it/test/v7/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasHipISpec.scala
+++ b/it/test/v7/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasHipISpec.scala
@@ -167,18 +167,6 @@ class Def3_SubmitForeignPropertyBsasHipISpec extends IntegrationBaseSpec with Js
           BAD_REQUEST,
           CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/countryLevelDetail/0/countryCode"))),
           None
-        ),
-        (
-          "AA123456A",
-          "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
-          "2025-26",
-          mtdRequestForeignPropertyInvalidResidentialCost,
-          BAD_REQUEST,
-          ValueFormatError.copy(
-            message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-            paths = Some(List("/foreignProperty/countryLevelDetail/0/expenses/residentialFinancialCost"))
-          ),
-          None
         )
       )
 

--- a/it/test/v7/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasIfISpec.scala
+++ b/it/test/v7/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasIfISpec.scala
@@ -170,18 +170,6 @@ class Def3_SubmitForeignPropertyBsasIfISpec extends IntegrationBaseSpec with Jso
           BAD_REQUEST,
           CountryCodeFormatError.copy(paths = Some(List("/foreignProperty/countryLevelDetail/0/countryCode"))),
           None
-        ),
-        (
-          "AA123456A",
-          "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
-          "2025-26",
-          mtdRequestForeignPropertyInvalidResidentialCost,
-          BAD_REQUEST,
-          ValueFormatError.copy(
-            message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-            paths = Some(List("/foreignProperty/countryLevelDetail/0/expenses/residentialFinancialCost"))
-          ),
-          None
         )
       )
 

--- a/it/test/v7/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasHipISpec.scala
+++ b/it/test/v7/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasHipISpec.scala
@@ -207,19 +207,6 @@ class Def2_SubmitUkPropertyBsasHipISpec extends IntegrationBaseSpec with JsonErr
           RuleBothPropertiesSuppliedError,
           None,
           None
-        ),
-        (
-          "AA123456A",
-          "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
-          "2024-25",
-          ukPropertyRequestBodyJson.update("/ukProperty/expenses/residentialFinancialCost", JsNumber(-1.523)),
-          BAD_REQUEST,
-          ValueFormatError.copy(
-            message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-            paths = Some(List("/ukProperty/expenses/residentialFinancialCost"))
-          ),
-          None,
-          None
         )
       )
 

--- a/it/test/v7/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasIfISpec.scala
+++ b/it/test/v7/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasIfISpec.scala
@@ -210,19 +210,6 @@ class Def2_SubmitUkPropertyBsasIfISpec extends IntegrationBaseSpec with JsonErro
           RuleBothPropertiesSuppliedError,
           None,
           None
-        ),
-        (
-          "AA123456A",
-          "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
-          "2024-25",
-          ukPropertyRequestBodyJson.update("/ukProperty/expenses/residentialFinancialCost", JsNumber(-1.523)),
-          BAD_REQUEST,
-          ValueFormatError.copy(
-            message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-            paths = Some(List("/ukProperty/expenses/residentialFinancialCost"))
-          ),
-          None,
-          None
         )
       )
 

--- a/it/test/v7/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasHipISpec.scala
+++ b/it/test/v7/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasHipISpec.scala
@@ -134,18 +134,6 @@ class Def3_SubmitUkPropertyBsasHipISpec extends IntegrationBaseSpec with JsonErr
           BAD_REQUEST,
           RuleBothExpensesError.copy(paths = Some(List("/ukProperty/expenses"))),
           None
-        ),
-        (
-          "AA123456A",
-          "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
-          "2025-26",
-          fullRequestJson.update("/ukProperty/expenses/residentialFinancialCost", JsNumber(-1.523)),
-          BAD_REQUEST,
-          ValueFormatError.copy(
-            message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-            paths = Some(List("/ukProperty/expenses/residentialFinancialCost"))
-          ),
-          None
         )
       )
 

--- a/it/test/v7/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasIfISpec.scala
+++ b/it/test/v7/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasIfISpec.scala
@@ -137,18 +137,6 @@ class Def3_SubmitUkPropertyBsasIfISpec extends IntegrationBaseSpec with JsonErro
           BAD_REQUEST,
           RuleBothExpensesError.copy(paths = Some(List("/ukProperty/expenses"))),
           None
-        ),
-        (
-          "AA123456A",
-          "041f7e4d-87b9-4d4a-a296-3cfbdf92f7e2",
-          "2025-26",
-          fullRequestJson.update("/ukProperty/expenses/residentialFinancialCost", JsNumber(-1.523)),
-          BAD_REQUEST,
-          ValueFormatError.copy(
-            message = "The value must be between 0 and 99999999999.99 (but cannot be 0 or 0.00)",
-            paths = Some(List("/ukProperty/expenses/residentialFinancialCost"))
-          ),
-          None
         )
       )
 

--- a/resources/public/api/conf/5.0/schemas/submit_foreign_property_accounting_adjustments/def2/request.json
+++ b/resources/public/api/conf/5.0/schemas/submit_foreign_property_accounting_adjustments/def2/request.json
@@ -90,9 +90,9 @@
                 "example": "1000.45"
               },
               "residentialFinancialCost": {
-                "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between 0 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
+                "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
                 "type": "number",
-                "minimum": 0,
+                "minimum": -99999999999.99,
                 "maximum": 99999999999.99,
                 "example": "1000.45"
               },

--- a/resources/public/api/conf/5.0/schemas/submit_uk_property_accounting_adjustments/def2/request.json
+++ b/resources/public/api/conf/5.0/schemas/submit_uk_property_accounting_adjustments/def2/request.json
@@ -100,10 +100,10 @@
               "example": "1000.45"
             },
             "residentialFinancialCost": {
-              "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between 0 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
+              "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
               "type": "number",
               "multipleOf": 0.01,
-              "minimum": 0,
+              "minimum": -99999999999.99,
               "maximum": 99999999999.99,
               "example": "1000.45"
             },

--- a/resources/public/api/conf/6.0/schemas/submit_foreign_property_accounting_adjustments/def2/request.json
+++ b/resources/public/api/conf/6.0/schemas/submit_foreign_property_accounting_adjustments/def2/request.json
@@ -90,9 +90,9 @@
                 "example": "1000.45"
               },
               "residentialFinancialCost": {
-                "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between 0 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
+                "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
                 "type": "number",
-                "minimum": 0,
+                "minimum": -99999999999.99,
                 "maximum": 99999999999.99,
                 "example": "1000.45"
               },

--- a/resources/public/api/conf/6.0/schemas/submit_foreign_property_accounting_adjustments/def3/request.json
+++ b/resources/public/api/conf/6.0/schemas/submit_foreign_property_accounting_adjustments/def3/request.json
@@ -90,9 +90,9 @@
                 "example": "1000.45"
               },
               "residentialFinancialCost": {
-                "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between 0 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
+                "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
                 "type": "number",
-                "minimum": 0,
+                "minimum": -99999999999.99,
                 "maximum": 99999999999.99,
                 "example": "1000.45"
               },

--- a/resources/public/api/conf/6.0/schemas/submit_uk_property_accounting_adjustments/def2/request.json
+++ b/resources/public/api/conf/6.0/schemas/submit_uk_property_accounting_adjustments/def2/request.json
@@ -100,10 +100,10 @@
               "example": "1000.45"
             },
             "residentialFinancialCost": {
-              "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between 0 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
+              "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
               "type": "number",
               "multipleOf": 0.01,
-              "minimum": 0,
+              "minimum": -99999999999.99,
               "maximum": 99999999999.99,
               "example": "1000.45"
             },

--- a/resources/public/api/conf/6.0/schemas/submit_uk_property_accounting_adjustments/def3/request.json
+++ b/resources/public/api/conf/6.0/schemas/submit_uk_property_accounting_adjustments/def3/request.json
@@ -100,10 +100,10 @@
               "example": "1000.45"
             },
             "residentialFinancialCost": {
-              "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between 0 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
+              "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
               "type": "number",
               "multipleOf": 0.01,
-              "minimum": 0,
+              "minimum": -99999999999.99,
               "maximum": 99999999999.99,
               "example": "1000.45"
             },

--- a/resources/public/api/conf/7.0/schemas/submit_foreign_property_accounting_adjustments/def2/request.json
+++ b/resources/public/api/conf/7.0/schemas/submit_foreign_property_accounting_adjustments/def2/request.json
@@ -94,9 +94,9 @@
                   "example": "1000.45"
                 },
                 "residentialFinancialCost": {
-                  "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between 0 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
+                  "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
                   "type": "number",
-                  "minimum": 0,
+                  "minimum": -99999999999.99,
                   "maximum": 99999999999.99,
                   "example": "1000.45"
                 },

--- a/resources/public/api/conf/7.0/schemas/submit_foreign_property_accounting_adjustments/def3/request.json
+++ b/resources/public/api/conf/7.0/schemas/submit_foreign_property_accounting_adjustments/def3/request.json
@@ -94,9 +94,9 @@
                     "example": "1000.45"
                   },
                   "residentialFinancialCost": {
-                    "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between 0 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
+                    "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
                     "type": "number",
-                    "minimum": 0,
+                    "minimum": -99999999999.99,
                     "maximum": 99999999999.99,
                     "example": "1000.45"
                   },

--- a/resources/public/api/conf/7.0/schemas/submit_uk_property_accounting_adjustments/def2/request.json
+++ b/resources/public/api/conf/7.0/schemas/submit_uk_property_accounting_adjustments/def2/request.json
@@ -100,10 +100,10 @@
               "example": "1000.45"
             },
             "residentialFinancialCost": {
-              "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between 0 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
+              "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
               "type": "number",
               "multipleOf": 0.01,
-              "minimum": 0,
+              "minimum": -99999999999.99,
               "maximum": 99999999999.99,
               "example": "1000.45"
             },

--- a/resources/public/api/conf/7.0/schemas/submit_uk_property_accounting_adjustments/def3/request.json
+++ b/resources/public/api/conf/7.0/schemas/submit_uk_property_accounting_adjustments/def3/request.json
@@ -100,10 +100,10 @@
               "example": "1000.45"
             },
             "residentialFinancialCost": {
-              "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between 0 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
+              "description": "The adjustment to the residential financial cost that can be deductible from rental income (tax relief). The value must be between -99999999999.99 and 99999999999.99 up to 2 decimal places (excluding 0 or 0.00).",
               "type": "number",
               "multipleOf": 0.01,
-              "minimum": 0,
+              "minimum": -99999999999.99,
               "maximum": 99999999999.99,
               "example": "1000.45"
             },

--- a/test/v5/foreignPropertyBsas/submit/def1/Def1_SubmitForeignPropertyBsasValidatorSpec.scala
+++ b/test/v5/foreignPropertyBsas/submit/def1/Def1_SubmitForeignPropertyBsasValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,16 +382,13 @@ class Def1_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
             ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/financialCosts", v)), "/nonFurnishedHolidayLet/0/expenses/financialCosts"),
             ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/professionalFees", v)), "/nonFurnishedHolidayLet/0/expenses/professionalFees"),
             ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/costOfServices", v)), "/nonFurnishedHolidayLet/0/expenses/costOfServices"),
+            (
+              (v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/residentialFinancialCost", v)),
+              "/nonFurnishedHolidayLet/0/expenses/residentialFinancialCost"),
             ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/other", v)), "/nonFurnishedHolidayLet/0/expenses/other"),
             ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/travelCosts", v)), "/nonFurnishedHolidayLet/0/expenses/travelCosts")
           ).foreach { case (body, path) => testWith(body, path) }
 
-          List(
-            (
-              (v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/residentialFinancialCost", v)),
-              "/nonFurnishedHolidayLet/0/expenses/residentialFinancialCost")).foreach { case (body, path) =>
-            testWith(body, path, min = "-99999999999.99")
-          }
         }
 
         "consolidated expenses is invalid" when {
@@ -428,7 +425,7 @@ class Def1_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
           )
         }
 
-        def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+        def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
           s"for $expectedPath" when {
             def doTest(value: JsNumber) = {
               val result = validator(validNino, validCalculationId, None, body(value)).validateAndWrapResult()
@@ -436,7 +433,7 @@ class Def1_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
               result shouldBe Left(
                 ErrorWrapper(
                   correlationId,
-                  ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                  ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
                 )
               )
             }

--- a/test/v5/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasValidatorSpec.scala
+++ b/test/v5/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -383,13 +383,11 @@ class Def2_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
             ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/professionalFees", v)), "/nonFurnishedHolidayLet/0/expenses/professionalFees"),
             ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/costOfServices", v)), "/nonFurnishedHolidayLet/0/expenses/costOfServices"),
             ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/other", v)), "/nonFurnishedHolidayLet/0/expenses/other"),
-            ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/travelCosts", v)), "/nonFurnishedHolidayLet/0/expenses/travelCosts")
-          ).foreach { case (body, path) => testWith(body, path) }
-
-          List(
+            ((v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/travelCosts", v)), "/nonFurnishedHolidayLet/0/expenses/travelCosts"),
             (
               (v: JsNumber) => nonFhlBodyWith(entry.update("/expenses/residentialFinancialCost", v)),
-              "/nonFurnishedHolidayLet/0/expenses/residentialFinancialCost")).foreach { case (body, path) => testWith(body, path, min = "0") }
+              "/nonFurnishedHolidayLet/0/expenses/residentialFinancialCost")
+          ).foreach { case (body, path) => testWith(body, path) }
         }
 
         "consolidated expenses is invalid" when {
@@ -426,7 +424,7 @@ class Def2_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
           )
         }
 
-        def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+        def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
           s"for $expectedPath" when {
             def doTest(value: JsNumber) = {
               val result = validator(validNino, validCalculationId, None, body(value)).validateAndWrapResult()
@@ -434,7 +432,7 @@ class Def2_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
               result shouldBe Left(
                 ErrorWrapper(
                   correlationId,
-                  ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                  ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
                 )
               )
             }

--- a/test/v5/foreignPropertyBsas/submit/def2/model/request/SubmitForeignPropertyBsasFixtures.scala
+++ b/test/v5/foreignPropertyBsas/submit/def2/model/request/SubmitForeignPropertyBsasFixtures.scala
@@ -46,31 +46,6 @@ object SubmitForeignPropertyBsasFixtures {
       |}
       |""".stripMargin)
 
-  val mtdRequestNonFhlValid: JsValue = Json.parse("""
-      |{
-      |   "nonFurnishedHolidayLet":  [
-      |       {
-      |          "countryCode": "FRA",
-      |          "income": {
-      |              "totalRentsReceived": 1.12,
-      |              "premiumsOfLeaseGrant": 2.12,
-      |              "otherPropertyIncome": 3.12
-      |          },
-      |          "expenses": {
-      |              "premisesRunningCosts": 5.12,
-      |              "repairsAndMaintenance": 6.12,
-      |              "financialCosts": 7.12,
-      |              "professionalFees": 8.12,
-      |              "costOfServices": 9.12,
-      |              "residentialFinancialCost": -3000.93,
-      |              "other": 11.12,
-      |              "travelCosts": 12.12
-      |          }
-      |       }
-      |    ]
-      |}
-      |""".stripMargin)
-
   val downstreamRequestNonFhlFull: JsValue = Json.parse("""
       |{
       |   "incomeSourceType": "15",

--- a/test/v5/ukPropertyBsas/submit/def1/Def1_SubmitUkPropertyBsasValidatorSpec.scala
+++ b/test/v5/ukPropertyBsas/submit/def1/Def1_SubmitUkPropertyBsasValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -337,13 +337,11 @@ class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
           "/nonFurnishedHolidayLet/expenses/financialCosts",
           "/nonFurnishedHolidayLet/expenses/professionalFees",
           "/nonFurnishedHolidayLet/expenses/costOfServices",
+          "/nonFurnishedHolidayLet/expenses/residentialFinancialCost",
           "/nonFurnishedHolidayLet/expenses/other",
           "/nonFurnishedHolidayLet/expenses/travelCosts"
         ).foreach(path => testWith(nonFhlBodyJson.update(path, _), path))
 
-        List(
-          "/nonFurnishedHolidayLet/expenses/residentialFinancialCost"
-        ).foreach(path => testWith(nonFhlBodyJson.update(path, _), path, min = "-99999999999.99"))
       }
 
       "consolidated expenses is invalid" when {
@@ -376,7 +374,7 @@ class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
         )
       }
 
-      def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
         s"for $expectedPath" when {
           def doTest(value: JsNumber): Assertion = {
             val result = validator(validNino, validCalculationId, None, body(value)).validateAndWrapResult()
@@ -384,12 +382,12 @@ class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
             result shouldBe Left(
               ErrorWrapper(
                 correlationId,
-                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
               )
             )
           }
 
-          "value is out of range" in doTest(JsNumber(BigDecimal(max) + 0.01))
+          "value is out of range" in doTest(JsNumber(BigDecimal(99999999999.99) + 0.01))
 
           "value is zero" in doTest(JsNumber(0))
         }

--- a/test/v5/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasValidatorSpec.scala
+++ b/test/v5/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -337,13 +337,11 @@ class Def2_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
           "/nonFurnishedHolidayLet/expenses/financialCosts",
           "/nonFurnishedHolidayLet/expenses/professionalFees",
           "/nonFurnishedHolidayLet/expenses/costOfServices",
+          "/nonFurnishedHolidayLet/expenses/residentialFinancialCost",
           "/nonFurnishedHolidayLet/expenses/other",
           "/nonFurnishedHolidayLet/expenses/travelCosts"
         ).foreach(path => testWith(nonFhlBodyJson.update(path, _), path))
 
-        List(
-          "/nonFurnishedHolidayLet/expenses/residentialFinancialCost"
-        ).foreach(path => testWith(nonFhlBodyJson.update(path, _), path, min = "0"))
       }
 
       "consolidated expenses is invalid" when {
@@ -376,7 +374,7 @@ class Def2_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
         )
       }
 
-      def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
         s"for $expectedPath" when {
           def doTest(value: JsNumber): Assertion = {
             val result = validator(validNino, validCalculationId, None, body(value)).validateAndWrapResult()
@@ -384,12 +382,12 @@ class Def2_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
             result shouldBe Left(
               ErrorWrapper(
                 correlationId,
-                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
               )
             )
           }
 
-          "value is out of range" in doTest(JsNumber(BigDecimal(max) + 0.01))
+          "value is out of range" in doTest(JsNumber(BigDecimal(99999999999.99) + 0.01))
 
           "value is zero" in doTest(JsNumber(0))
         }

--- a/test/v6/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasValidatorSpec.scala
+++ b/test/v6/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -359,13 +359,10 @@ class Def2_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
             ((v: JsNumber) => BodyWith(entry.update("/expenses/professionalFees", v)), "/foreignProperty/0/expenses/professionalFees"),
             ((v: JsNumber) => BodyWith(entry.update("/expenses/costOfServices", v)), "/foreignProperty/0/expenses/costOfServices"),
             ((v: JsNumber) => BodyWith(entry.update("/expenses/other", v)), "/foreignProperty/0/expenses/other"),
-            ((v: JsNumber) => BodyWith(entry.update("/expenses/travelCosts", v)), "/foreignProperty/0/expenses/travelCosts")
+            ((v: JsNumber) => BodyWith(entry.update("/expenses/travelCosts", v)), "/foreignProperty/0/expenses/travelCosts"),
+            ((v: JsNumber) => BodyWith(entry.update("/expenses/residentialFinancialCost", v)), "/foreignProperty/0/expenses/residentialFinancialCost")
           ).foreach { case (body, path) => testWith(body, path) }
 
-          List(
-            (
-              (v: JsNumber) => BodyWith(entry.update("/expenses/residentialFinancialCost", v)),
-              "/foreignProperty/0/expenses/residentialFinancialCost")).foreach { case (body, path) => testWith(body, path, min = "0") }
         }
 
         "consolidated expenses is invalid" when {
@@ -402,7 +399,7 @@ class Def2_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
           )
         }
 
-        def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+        def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
           s"for $expectedPath" when {
             def doTest(value: JsNumber) = {
               val result = validator(validNino, validCalculationId, validTaxYear, body(value)).validateAndWrapResult()
@@ -410,7 +407,7 @@ class Def2_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
               result shouldBe Left(
                 ErrorWrapper(
                   correlationId,
-                  ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                  ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
                 )
               )
             }

--- a/test/v6/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasValidatorSpec.scala
+++ b/test/v6/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,13 +211,12 @@ class Def3_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
             ((v: JsNumber) => foreignPropertyBodyWith(entry.update("/expenses/professionalFees", v)), "/foreignProperty/0/expenses/professionalFees"),
             ((v: JsNumber) => foreignPropertyBodyWith(entry.update("/expenses/costOfServices", v)), "/foreignProperty/0/expenses/costOfServices"),
             ((v: JsNumber) => foreignPropertyBodyWith(entry.update("/expenses/other", v)), "/foreignProperty/0/expenses/other"),
-            ((v: JsNumber) => foreignPropertyBodyWith(entry.update("/expenses/travelCosts", v)), "/foreignProperty/0/expenses/travelCosts")
-          ).foreach { case (body, path) => testWith(body, path) }
-
-          List(
+            ((v: JsNumber) => foreignPropertyBodyWith(entry.update("/expenses/travelCosts", v)), "/foreignProperty/0/expenses/travelCosts"),
             (
               (v: JsNumber) => foreignPropertyBodyWith(entry.update("/expenses/residentialFinancialCost", v)),
-              "/foreignProperty/0/expenses/residentialFinancialCost")).foreach { case (body, path) => testWith(body, path, min = "0") }
+              "/foreignProperty/0/expenses/residentialFinancialCost")
+          ).foreach { case (body, path) => testWith(body, path) }
+
         }
 
         "consolidated expenses is invalid" when {
@@ -250,7 +249,7 @@ class Def3_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
           )
         }
 
-        def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+        def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
           s"for $expectedPath" when {
             def doTest(value: JsNumber) = {
               val result = validator(validNino, validCalculationId, validTaxYear, body(value)).validateAndWrapResult()
@@ -258,7 +257,7 @@ class Def3_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
               result shouldBe Left(
                 ErrorWrapper(
                   correlationId,
-                  ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                  ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
                 )
               )
             }

--- a/test/v6/foreignPropertyBsas/submit/def3/model/request/SubmitForeignPropertyBsasFixtures.scala
+++ b/test/v6/foreignPropertyBsas/submit/def3/model/request/SubmitForeignPropertyBsasFixtures.scala
@@ -71,31 +71,6 @@ object SubmitForeignPropertyBsasFixtures {
       |}
       |""".stripMargin)
 
-  val mtdRequestForeignPropertyInvalidResidentialCost: JsValue = Json.parse("""
-      |{
-      |   "foreignProperty":  [
-      |       {
-      |          "countryCode": "FRA",
-      |          "income": {
-      |              "totalRentsReceived": 1.12,
-      |              "premiumsOfLeaseGrant": 2.12,
-      |              "otherPropertyIncome": 3.12
-      |          },
-      |          "expenses": {
-      |              "premisesRunningCosts": 5.12,
-      |              "repairsAndMaintenance": 6.12,
-      |              "financialCosts": 7.12,
-      |              "professionalFees": 8.12,
-      |              "costOfServices": 9.12,
-      |              "residentialFinancialCost": -10.12,
-      |              "other": 11.12,
-      |              "travelCosts": 12.12
-      |          }
-      |       }
-      |    ]
-      |}
-      |""".stripMargin)
-
   val downstreamRequestForeignPropertyFull: JsValue = Json.parse("""
       |{
       |   "incomeSourceType": "15",

--- a/test/v6/ukPropertyBsas/submit/def1/Def1_SubmitUkPropertyBsasValidatorSpec.scala
+++ b/test/v6/ukPropertyBsas/submit/def1/Def1_SubmitUkPropertyBsasValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -338,12 +338,9 @@ class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
           "/ukProperty/expenses/professionalFees",
           "/ukProperty/expenses/costOfServices",
           "/ukProperty/expenses/other",
-          "/ukProperty/expenses/travelCosts"
-        ).foreach(path => testWith(ukPropertyBodyJson.update(path, _), path))
-
-        List(
+          "/ukProperty/expenses/travelCosts",
           "/ukProperty/expenses/residentialFinancialCost"
-        ).foreach(path => testWith(ukPropertyBodyJson.update(path, _), path, min = "-99999999999.99"))
+        ).foreach(path => testWith(ukPropertyBodyJson.update(path, _), path))
       }
 
       "consolidated expenses is invalid" when {
@@ -376,7 +373,7 @@ class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
         )
       }
 
-      def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
         s"for $expectedPath" when {
           def doTest(value: JsNumber): Assertion = {
             val result = validator(validNino, validCalculationId, validTaxYear, body(value)).validateAndWrapResult()
@@ -384,12 +381,12 @@ class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
             result shouldBe Left(
               ErrorWrapper(
                 correlationId,
-                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
               )
             )
           }
 
-          "value is out of range" in doTest(JsNumber(BigDecimal(max) + 0.01))
+          "value is out of range" in doTest(JsNumber(BigDecimal(99999999999.99) + 0.01))
 
           "value is zero" in doTest(JsNumber(0))
         }

--- a/test/v6/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasValidatorSpec.scala
+++ b/test/v6/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -338,12 +338,10 @@ class Def2_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
           "/ukProperty/expenses/professionalFees",
           "/ukProperty/expenses/costOfServices",
           "/ukProperty/expenses/other",
-          "/ukProperty/expenses/travelCosts"
+          "/ukProperty/expenses/travelCosts",
+          "/ukProperty/expenses/residentialFinancialCost"
         ).foreach(path => testWith(ukPropertyBodyJson.update(path, _), path))
 
-        List(
-          "/ukProperty/expenses/residentialFinancialCost"
-        ).foreach(path => testWith(ukPropertyBodyJson.update(path, _), path, min = "0"))
       }
 
       "consolidated expenses is invalid" when {
@@ -376,7 +374,7 @@ class Def2_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
         )
       }
 
-      def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
         s"for $expectedPath" when {
           def doTest(value: JsNumber): Assertion = {
             val result = validator(validNino, validCalculationId, validTaxYear, body(value)).validateAndWrapResult()
@@ -384,12 +382,12 @@ class Def2_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
             result shouldBe Left(
               ErrorWrapper(
                 correlationId,
-                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
               )
             )
           }
 
-          "value is out of range" in doTest(JsNumber(BigDecimal(max) + 0.01))
+          "value is out of range" in doTest(JsNumber(BigDecimal(99999999999.99) + 0.01))
 
           "value is zero" in doTest(JsNumber(0))
         }

--- a/test/v6/ukPropertyBsas/submit/def2/model/request/SubmitUKPropertyBsasRequestBodyFixtures.scala
+++ b/test/v6/ukPropertyBsas/submit/def2/model/request/SubmitUKPropertyBsasRequestBodyFixtures.scala
@@ -44,29 +44,6 @@ object SubmitUKPropertyBsasRequestBodyFixtures {
       |}
       |""".stripMargin)
 
-  val validUkPropertyInputJson: JsValue = Json.parse("""
-      |{
-      |  "ukProperty": {
-      |    "income": {
-      |      "totalRentsReceived": 1.45,
-      |      "premiumsOfLeaseGrant": 2.45,
-      |      "reversePremiums": 3.45,
-      |      "otherPropertyIncome": 4.45
-      |    },
-      |    "expenses": {
-      |      "premisesRunningCosts": 6.45,
-      |      "repairsAndMaintenance": 7.45,
-      |      "financialCosts": 8.45,
-      |      "professionalFees": 9.45,
-      |      "costOfServices": 10.45,
-      |      "residentialFinancialCost": 11.45,
-      |      "other": 12.45,
-      |      "travelCosts": 13.45
-      |    }
-      |  }
-      |}
-      |""".stripMargin)
-
   val requestUkPropertyFull: Def2_SubmitUkPropertyBsasRequestBody = Def2_SubmitUkPropertyBsasRequestBody(
     ukProperty = Some(
       UkProperty(

--- a/test/v6/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasValidatorSpec.scala
+++ b/test/v6/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,7 +211,9 @@ class Def3_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
           "/ukProperty/expenses/financialCosts",
           "/ukProperty/expenses/professionalFees",
           "/ukProperty/expenses/costOfServices",
-          "/ukProperty/expenses/travelCosts"
+          "/ukProperty/expenses/travelCosts",
+          "/ukProperty/expenses/residentialFinancialCost",
+          "/ukProperty/expenses/other"
         ).foreach(path => testWith(fullRequestJson.update(path, _), path))
       }
 
@@ -219,13 +221,6 @@ class Def3_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
         List(
           "/ukProperty/expenses/consolidatedExpenses"
         ).foreach(path => testWith(consolidatedBodyJson.update(path, _), path))
-      }
-
-      "non negative fields have negative values" when {
-        List(
-          "/ukProperty/expenses/residentialFinancialCost",
-          "/ukProperty/expenses/other"
-        ).foreach(path => testWith(fullRequestJson.update(path, _), path, min = "0"))
       }
 
       "multiple fields are invalid" in {
@@ -248,7 +243,7 @@ class Def3_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
         )
       }
 
-      def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
         s"for $expectedPath" when {
           def doTest(value: JsNumber): Assertion = {
             val result = validator(validNino, validCalculationId, validTaxYear, body(value)).validateAndWrapResult()
@@ -256,12 +251,12 @@ class Def3_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
             result shouldBe Left(
               ErrorWrapper(
                 correlationId,
-                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
               )
             )
           }
 
-          "value is out of range" in doTest(JsNumber(BigDecimal(max) + 0.01))
+          "value is out of range" in doTest(JsNumber(BigDecimal(99999999999.99) + 0.01))
 
           "value is zero" in doTest(JsNumber(0))
         }

--- a/test/v7/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasValidatorSpec.scala
+++ b/test/v7/foreignPropertyBsas/submit/def2/Def2_SubmitForeignPropertyBsasValidatorSpec.scala
@@ -410,14 +410,12 @@ class Def2_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
             "/foreignProperty/countryLevelDetail/0/expenses/professionalFees"),
           ((v: JsNumber) => bodyWith(entry.update("/expenses/costOfServices", v)), "/foreignProperty/countryLevelDetail/0/expenses/costOfServices"),
           ((v: JsNumber) => bodyWith(entry.update("/expenses/other", v)), "/foreignProperty/countryLevelDetail/0/expenses/other"),
-          ((v: JsNumber) => bodyWith(entry.update("/expenses/travelCosts", v)), "/foreignProperty/countryLevelDetail/0/expenses/travelCosts")
-        ).foreach { case (body, path) => testWith(body, path) }
-
-        List(
+          ((v: JsNumber) => bodyWith(entry.update("/expenses/travelCosts", v)), "/foreignProperty/countryLevelDetail/0/expenses/travelCosts"),
           (
             (v: JsNumber) => bodyWith(entry.update("/expenses/residentialFinancialCost", v)),
             "/foreignProperty/countryLevelDetail/0/expenses/residentialFinancialCost")
-        ).foreach { case (body, path) => testWith(body, path, min = "0") }
+        ).foreach { case (body, path) => testWith(body, path) }
+
       }
 
       "consolidated expenses is invalid" when {
@@ -454,7 +452,7 @@ class Def2_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
         )
       }
 
-      def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
         s"for $expectedPath" when {
           def doTest(value: JsNumber) = {
             val result = validator(validNino, validCalculationId, validTaxYear, body(value)).validateAndWrapResult()
@@ -462,7 +460,7 @@ class Def2_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
             result shouldBe Left(
               ErrorWrapper(
                 correlationId,
-                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
               )
             )
           }

--- a/test/v7/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasValidatorSpec.scala
+++ b/test/v7/foreignPropertyBsas/submit/def3/Def3_SubmitForeignPropertyBsasValidatorSpec.scala
@@ -248,14 +248,12 @@ class Def3_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
           ((v: JsNumber) => foreignPropertyBodyWith(entry.update("/expenses/other", v)), "/foreignProperty/countryLevelDetail/0/expenses/other"),
           (
             (v: JsNumber) => foreignPropertyBodyWith(entry.update("/expenses/travelCosts", v)),
-            "/foreignProperty/countryLevelDetail/0/expenses/travelCosts")
-        ).foreach { case (body, path) => testWith(body, path) }
-
-        List(
+            "/foreignProperty/countryLevelDetail/0/expenses/travelCosts"),
           (
             (v: JsNumber) => foreignPropertyBodyWith(entry.update("/expenses/residentialFinancialCost", v)),
             "/foreignProperty/countryLevelDetail/0/expenses/residentialFinancialCost")
-        ).foreach { case (body, path) => testWith(body, path, min = "0") }
+        ).foreach { case (body, path) => testWith(body, path) }
+
       }
 
       "consolidated expenses is invalid" when {
@@ -288,7 +286,7 @@ class Def3_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
         )
       }
 
-      def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
         s"for $expectedPath" when {
           def doTest(value: JsNumber) = {
             val result = validator(validNino, validCalculationId, validTaxYear, body(value)).validateAndWrapResult()
@@ -296,7 +294,7 @@ class Def3_SubmitForeignPropertyBsasValidatorSpec extends UnitSpec with JsonErro
             result shouldBe Left(
               ErrorWrapper(
                 correlationId,
-                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
               )
             )
           }

--- a/test/v7/foreignPropertyBsas/submit/def3/model/request/SubmitForeignPropertyBsasFixtures.scala
+++ b/test/v7/foreignPropertyBsas/submit/def3/model/request/SubmitForeignPropertyBsasFixtures.scala
@@ -79,35 +79,6 @@ object SubmitForeignPropertyBsasFixtures {
     """.stripMargin
   )
 
-  val mtdRequestForeignPropertyInvalidResidentialCost: JsValue = Json.parse(
-    """
-      |{
-      |    "foreignProperty": {
-      |        "countryLevelDetail": [
-      |            {
-      |                "countryCode": "FRA",
-      |                "income": {
-      |                    "totalRentsReceived": 1.12,
-      |                    "premiumsOfLeaseGrant": 2.12,
-      |                    "otherPropertyIncome": 3.12
-      |                },
-      |                "expenses": {
-      |                    "premisesRunningCosts": 5.12,
-      |                    "repairsAndMaintenance": 6.12,
-      |                    "financialCosts": 7.12,
-      |                    "professionalFees": 8.12,
-      |                    "costOfServices": 9.12,
-      |                    "residentialFinancialCost": -10.12,
-      |                    "other": 11.12,
-      |                    "travelCosts": 12.12
-      |                }
-      |            }
-      |        ]
-      |    }
-      |}
-    """.stripMargin
-  )
-
   val downstreamRequestForeignPropertyFull: JsValue = Json.parse(
     """
       |{

--- a/test/v7/ukPropertyBsas/submit/def1/Def1_SubmitUkPropertyBsasValidatorSpec.scala
+++ b/test/v7/ukPropertyBsas/submit/def1/Def1_SubmitUkPropertyBsasValidatorSpec.scala
@@ -338,12 +338,9 @@ class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
           "/ukProperty/expenses/professionalFees",
           "/ukProperty/expenses/costOfServices",
           "/ukProperty/expenses/other",
-          "/ukProperty/expenses/travelCosts"
-        ).foreach(path => testWith(ukPropertyBodyJson.update(path, _), path))
-
-        List(
+          "/ukProperty/expenses/travelCosts",
           "/ukProperty/expenses/residentialFinancialCost"
-        ).foreach(path => testWith(ukPropertyBodyJson.update(path, _), path, min = "-99999999999.99"))
+        ).foreach(path => testWith(ukPropertyBodyJson.update(path, _), path))
       }
 
       "consolidated expenses is invalid" when {
@@ -376,7 +373,7 @@ class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
         )
       }
 
-      def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
         s"for $expectedPath" when {
           def doTest(value: JsNumber): Assertion = {
             val result = validator(validNino, validCalculationId, validTaxYear, body(value)).validateAndWrapResult()
@@ -384,12 +381,12 @@ class Def1_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
             result shouldBe Left(
               ErrorWrapper(
                 correlationId,
-                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
               )
             )
           }
 
-          "value is out of range" in doTest(JsNumber(BigDecimal(max) + 0.01))
+          "value is out of range" in doTest(JsNumber(BigDecimal(99999999999.99) + 0.01))
 
           "value is zero" in doTest(JsNumber(0))
         }

--- a/test/v7/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasValidatorSpec.scala
+++ b/test/v7/ukPropertyBsas/submit/def2/Def2_SubmitUkPropertyBsasValidatorSpec.scala
@@ -377,13 +377,11 @@ class Def2_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
           "/ukProperty/expenses/financialCosts",
           "/ukProperty/expenses/professionalFees",
           "/ukProperty/expenses/costOfServices",
+          "/ukProperty/expenses/residentialFinancialCost",
           "/ukProperty/expenses/other",
           "/ukProperty/expenses/travelCosts"
         ).foreach(path => testWith(ukPropertyBodyJson.update(path, _), path))
 
-        List(
-          "/ukProperty/expenses/residentialFinancialCost"
-        ).foreach(path => testWith(ukPropertyBodyJson.update(path, _), path, min = "0"))
       }
 
       "consolidated expenses is invalid" when {
@@ -416,7 +414,7 @@ class Def2_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
         )
       }
 
-      def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
         s"for $expectedPath" when {
           def doTest(value: JsNumber): Assertion = {
             val result = validator(validNino, validCalculationId, validTaxYear, body(value)).validateAndWrapResult()
@@ -424,12 +422,12 @@ class Def2_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
             result shouldBe Left(
               ErrorWrapper(
                 correlationId,
-                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
               )
             )
           }
 
-          "value is out of range" in doTest(JsNumber(BigDecimal(max) + 0.01))
+          "value is out of range" in doTest(JsNumber(BigDecimal(99999999999.99) + 0.01))
 
           "value is zero" in doTest(JsNumber(0))
         }

--- a/test/v7/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasValidatorSpec.scala
+++ b/test/v7/ukPropertyBsas/submit/def3/Def3_SubmitUkPropertyBsasValidatorSpec.scala
@@ -241,7 +241,9 @@ class Def3_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
           "/ukProperty/expenses/financialCosts",
           "/ukProperty/expenses/professionalFees",
           "/ukProperty/expenses/costOfServices",
-          "/ukProperty/expenses/travelCosts"
+          "/ukProperty/expenses/travelCosts",
+          "/ukProperty/expenses/residentialFinancialCost",
+          "/ukProperty/expenses/other"
         ).foreach(path => testWith(fullRequestJson.update(path, _), path))
       }
 
@@ -249,13 +251,6 @@ class Def3_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
         List(
           "/ukProperty/expenses/consolidatedExpenses"
         ).foreach(path => testWith(consolidatedBodyJson.update(path, _), path))
-      }
-
-      "non negative fields have negative values" when {
-        List(
-          "/ukProperty/expenses/residentialFinancialCost",
-          "/ukProperty/expenses/other"
-        ).foreach(path => testWith(fullRequestJson.update(path, _), path, min = "0"))
       }
 
       "multiple fields are invalid" in {
@@ -278,7 +273,7 @@ class Def3_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
         )
       }
 
-      def testWith(body: JsNumber => JsValue, expectedPath: String, min: String = "-99999999999.99", max: String = "99999999999.99"): Unit =
+      def testWith(body: JsNumber => JsValue, expectedPath: String): Unit =
         s"for $expectedPath" when {
           def doTest(value: JsNumber): Assertion = {
             val result = validator(validNino, validCalculationId, validTaxYear, body(value)).validateAndWrapResult()
@@ -286,12 +281,12 @@ class Def3_SubmitUkPropertyBsasValidatorSpec extends UnitSpec with JsonErrorVali
             result shouldBe Left(
               ErrorWrapper(
                 correlationId,
-                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, min, max)
+                ValueFormatError.forPathAndRangeExcludeZero(expectedPath, "-99999999999.99", "99999999999.99")
               )
             )
           }
 
-          "value is out of range" in doTest(JsNumber(BigDecimal(max) + 0.01))
+          "value is out of range" in doTest(JsNumber(BigDecimal(99999999999.99) + 0.01))
 
           "value is zero" in doTest(JsNumber(0))
         }


### PR DESCRIPTION
- Change validation for `ukproperty.expenses.residentialFinancialCost` in **Submit UK Property Accounting Adjustments** to allow negative values for all tax years (V5,V6,V7)
- Change validation for `foreignProperty[].expenses.residentialFinancialCost` in **Submit Foreign Property Accounting Adjustments** to allow negative values for all tax years (V5,V6,V7)