### PR TITLE
[MTDSA-35028]: Remove deprecated field outstandingBusinessIncome(TY25-26 onwards)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Requirements
 
-- Scala 3.5.2
-- Java 11
-- sbt 1.10.10
+- Scala 3.x.x
+- Java 21
+- sbt 1.10.x
 - [Service Manager](https://github.com/hmrc/sm2)
 
 # To run locally

--- a/app/v7/selfEmploymentBsas/retrieve/def2/model/response/SummaryCalculationAdditions.scala
+++ b/app/v7/selfEmploymentBsas/retrieve/def2/model/response/SummaryCalculationAdditions.scala
@@ -35,7 +35,6 @@ case class SummaryCalculationAdditions(
     otherExpensesDisallowable: Option[BigDecimal],
     advertisingCostsDisallowable: Option[BigDecimal],
     businessEntertainmentCostsDisallowable: Option[BigDecimal],
-    outstandingBusinessIncome: Option[BigDecimal],
     balancingChargeOther: Option[BigDecimal],
     balancingChargeBpra: Option[BigDecimal],
     goodsAndServicesOwnUse: Option[BigDecimal]
@@ -59,7 +58,6 @@ object SummaryCalculationAdditions {
       (JsPath \ "otherExpensesDisallowable").readNullable[BigDecimal] and
       (JsPath \ "advertisingCostsDisallowable").readNullable[BigDecimal] and
       (JsPath \ "businessEntertainmentCostsDisallowable").readNullable[BigDecimal] and
-      (JsPath \ "outstandingBusinessIncome").readNullable[BigDecimal] and
       (JsPath \ "balancingChargeOther").readNullable[BigDecimal] and
       (JsPath \ "balancingChargeBpra").readNullable[BigDecimal] and
       (JsPath \ "goodAndServicesOwnUse").readNullable[BigDecimal]

--- a/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_full_expenses.json
+++ b/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_full_expenses.json
@@ -66,7 +66,6 @@
       "otherExpensesDisallowable": 0.12,
       "advertisingCostsDisallowable": 0.12,
       "businessEntertainmentCostsDisallowable": 0.12,
-      "outstandingBusinessIncome": 0.12,
       "balancingChargeOther": 0.12,
       "balancingChargeBpra": 0.12,
       "goodsAndServicesOwnUse": 0.12
@@ -177,7 +176,6 @@
       "otherExpensesDisallowable": 0.12,
       "advertisingCostsDisallowable": 0.12,
       "businessEntertainmentCostsDisallowable": 0.12,
-      "outstandingBusinessIncome": 0.12,
       "balancingChargeOther": 0.12,
       "balancingChargeBpra": 0.12,
       "goodsAndServicesOwnUse": 0.12

--- a/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_trading_allowance.json
+++ b/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_trading_allowance.json
@@ -66,7 +66,6 @@
       "otherExpensesDisallowable": 0.12,
       "advertisingCostsDisallowable": 0.12,
       "businessEntertainmentCostsDisallowable": 0.12,
-      "outstandingBusinessIncome": 0.12,
       "balancingChargeOther": 0.12,
       "balancingChargeBpra": 0.12,
       "goodsAndServicesOwnUse": 0.12
@@ -166,7 +165,6 @@
       "otherExpensesDisallowable": 0.12,
       "advertisingCostsDisallowable": 0.12,
       "businessEntertainmentCostsDisallowable": 0.12,
-      "outstandingBusinessIncome": 0.12,
       "balancingChargeOther": 0.12,
       "balancingChargeBpra": 0.12,
       "goodsAndServicesOwnUse": 0.12

--- a/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_zero_adjustments.json
+++ b/resources/public/api/conf/7.0/examples/retrieve_self_employment/def3/retrieve_self_employment_zero_adjustments.json
@@ -66,7 +66,6 @@
       "otherExpensesDisallowable": 0.12,
       "advertisingCostsDisallowable": 0.12,
       "businessEntertainmentCostsDisallowable": 0.12,
-      "outstandingBusinessIncome": 0.12,
       "balancingChargeOther": 0.12,
       "balancingChargeBpra": 0.12,
       "goodsAndServicesOwnUse": 0.12
@@ -140,7 +139,6 @@
       "otherExpensesDisallowable": 0.12,
       "advertisingCostsDisallowable": 0.12,
       "businessEntertainmentCostsDisallowable": 0.12,
-      "outstandingBusinessIncome": 0.12,
       "balancingChargeOther": 0.12,
       "balancingChargeBpra": 0.12,
       "goodsAndServicesOwnUse": 0.12

--- a/resources/public/api/conf/7.0/schemas/retrieve_self_employment/def3/response.json
+++ b/resources/public/api/conf/7.0/schemas/retrieve_self_employment/def3/response.json
@@ -491,15 +491,6 @@
               "maximum": 99999999999.99,
               "example": 1000.45
             },
-            "outstandingBusinessIncome": {
-              "description": "Any other business income not included in other fields. The value must be between 0 and 99999999999.99 up to 2 decimal places. This field is deprecated and will be removed in a future release. Use `outstandingBusinessIncome` in `adjustableSummaryCalculation` or `adjustedSummaryCalculation` instead.",
-              "type": "number",
-              "multipleOf": 0.01,
-              "minimum": 0,
-              "maximum": 99999999999.99,
-              "example": 1000.45,
-              "deprecated": true
-            },
             "balancingChargeOther": {
               "description": "Balancing charge on sale or cessation of business use (where you have disposed of assets for more than their tax value). The value must be between 0 and 99999999999.99 up to 2 decimal places.",
               "type": "number",
@@ -1350,15 +1341,6 @@
               "minimum": 0,
               "maximum": 99999999999.99,
               "example": 1000.45
-            },
-            "outstandingBusinessIncome": {
-              "description": "Any other business income not included in other fields. The value must be between 0 and 99999999999.99 up to 2 decimal places. This field is deprecated and will be removed in a future release. Use `outstandingBusinessIncome` in `adjustableSummaryCalculation` or `adjustedSummaryCalculation` instead.",
-              "type": "number",
-              "multipleOf": 0.01,
-              "minimum": 0,
-              "maximum": 99999999999.99,
-              "example": 1000.45,
-              "deprecated": true
             },
             "balancingChargeOther": {
               "description": "Balancing charge on sale or cessation of business use (where you have disposed of assets for more than their tax value). The value must be between 0 and 99999999999.99 up to 2 decimal places.",

--- a/test/v7/selfEmploymentBsas/retrieve/def2/model/Def2_RetrieveSelfEmploymentBsasFixtures.scala
+++ b/test/v7/selfEmploymentBsas/retrieve/def2/model/Def2_RetrieveSelfEmploymentBsasFixtures.scala
@@ -375,7 +375,6 @@ object Def2_RetrieveSelfEmploymentBsasFixtures {
       |  "otherExpensesDisallowable": 5.13,
       |  "advertisingCostsDisallowable": 5.14,
       |  "businessEntertainmentCostsDisallowable": 5.15,
-      |  "outstandingBusinessIncome": 11,
       |  "balancingChargeOther": 5.17,
       |  "balancingChargeBpra": 5.18,
       |  "goodsAndServicesOwnUse": 5.19
@@ -585,7 +584,6 @@ object Def2_RetrieveSelfEmploymentBsasFixtures {
     otherExpensesDisallowable = Some(5.13),
     advertisingCostsDisallowable = Some(5.14),
     businessEntertainmentCostsDisallowable = Some(5.15),
-    outstandingBusinessIncome = Some(11),
     balancingChargeOther = Some(5.17),
     balancingChargeBpra = Some(5.18),
     goodsAndServicesOwnUse = Some(5.19)


### PR DESCRIPTION
**AdjustedSummaryCalculation Additions**
---
<img width="678" height="1067" alt="adjustedSummaryCalculation" src="https://github.com/user-attachments/assets/724e2386-ffdb-4d04-a2a9-71d3a9c1425c" />



**AdjustableSummaryCalculation Additions**
---
<img width="666" height="1074" alt="adjustableSummaryCalculation" src="https://github.com/user-attachments/assets/4491c71d-850d-4cd6-abae-28b7bee2a4f8" />
